### PR TITLE
Revert "upgrade xstream to 1.4.20 to pick up fixes for 2 CVEs (#2763)" dep is banned internally

### DIFF
--- a/helix-admin-webapp/pom.xml
+++ b/helix-admin-webapp/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.20</version>
+      <version>1.4.19</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This reverts commit 53b588982c281009085076b480a3ce58cccbe618.

This dependency is banned at li.

### Issues

This reverts commit 53b588982c281009085076b480a3ce58cccbe618.

This dependency is banned at li.

### Description

This reverts commit 53b588982c281009085076b480a3ce58cccbe618.

This dependency is banned at li.

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
