### PR TITLE
[Linkedin/Helix] -- Provide JDK 1.8 (backward) compatibility for meta-client

### DIFF
--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -219,7 +219,6 @@
             <phase>package</phase>
             <goals>
               <goal>jar</goal>
-              <goal>test-jar</goal>
             </goals>
             <configuration>
               <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>

--- a/meta-client/pom.xml
+++ b/meta-client/pom.xml
@@ -91,6 +91,24 @@ under the License.
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>default-package-jdk11</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>
+              <classifier>jdk8</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:
Fixes Issue: We have some consumers which are still running their (open-source) systems on JRE-8, hence they are not able to run helix libraries compiled with JDK11+. 

### Description
We would like to provide a backward compatible support to our consumers where they also have an option to use JDK-8 compiled helix-core jar, if they have such a requirement. By default we will generate JDK-11 jars and JDK-8 jars using a classifier. 
```
<major.minor.patch> will use JDK11 (default)
<major.minor.patch> classifier say jdk8 , will use JDK8
```
### For JDK-11 usecase
```
      <dependency>
          <groupId>org.apache</groupId>
          <artifactId>meta-client</artifactId>
          <version>1.3.4</version>
      </dependency>
```
### For JDK-8 usecase
```
      <dependency>
          <groupId>org.apache</groupId>
          <artifactId>meta-client</artifactId>
          <version>1.3.4</version>
          <classifier>jdk8</classifier>
      </dependency>
```

### Tests

- [x] The following tests are written for this issue:
N/A

<img width="444" alt="Screenshot 2024-05-07 at 12 20 22 PM" src="https://github.com/apache/helix/assets/2539436/a2b3d542-739c-44fc-8053-bca9e919285a">

```
---------------------------------------------------------------------------------------------------
mvn clean install -Dmaven.test.skip.exec=true
---------------------------------------------------------------------------------------------------
[INFO] 
[INFO] --- compiler:3.12.1:compile (JDK 8) @ helix-core ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 579 source files with javac [forked debug release 8] to target/classes_jdk8
[WARNING] [options] source value 8 is obsolete and will be removed in a future release
[WARNING] [options] target value 8 is obsolete and will be removed in a future release
[WARNING] [options] To suppress warnings about obsolete options, use -Xlint:-options.
[WARNING] Overwriting artifact's file from /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/classes to /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/classes_jdk8
[INFO] 
[INFO] --- compiler:3.12.1:compile (JDK 11) @ helix-core ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 579 source files with javac [forked debug release 11] to target/classes
[WARNING]   on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
/Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/src/main/java/org/apache/helix/api/listeners/ConfigChangeListener.java:[30,7] [dep-ann] deprecated item is not annotated with @Deprecated
[WARNING] Overwriting artifact's file from /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/classes_jdk8 to /Users/hkandwal/Documents/workspaces/projects/helix_os_hk/helix-core/target/classes
[INFO] 

```

- The following is the result of the "mvn test" command on the appropriate module:
N/A

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
