### PR TITLE
Pin xstream to 1.4.19 as 1.4.21 is banned in LI

### DIFF
--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.21</version>
+      <version>1.4.19</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
### Issues

xstream 1.4.21 is banned in LI as it has backwards incompatible changes

