### PR TITLE
Adding check if resources are migrated from an unhealthy evacuated instance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -139,7 +139,7 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
       // Note: if instance is not live, the mapping for that instance will not show up in
       // BestPossibleMapping (and ExternalView)
       // if instance is evacuated keep the instanceStateMap same as idealStateMap
-      if ((assignableLiveInstancesMap.containsKey(instance) || isAssignableForCustomizedResource)) {
+      if (assignableLiveInstancesMap.containsKey(instance) || isAssignableForCustomizedResource) {
         if (enabled) {
           instanceStateMap.put(instance, idealStateMap.get(instance));
         } else {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/CustomRebalancer.java
@@ -131,8 +131,6 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
 
     Map<String, LiveInstance> assignableLiveInstancesMap = cache.getAssignableLiveInstances();
     for (String instance : idealStateMap.keySet()) {
-      boolean notInErrorState = currentStateMap != null
-          && !HelixDefinedState.ERROR.toString().equals(currentStateMap.get(instance));
       boolean enabled = !disabledInstancesForPartition.contains(instance) && isResourceEnabled;
       InstanceConfig instanceConfig = cache.getInstanceConfigMap().get(instance);
       boolean hasEvacuatedOp = instanceConfig != null &&
@@ -141,7 +139,7 @@ public class CustomRebalancer extends AbstractRebalancer<ResourceControllerDataP
       // Note: if instance is not live, the mapping for that instance will not show up in
       // BestPossibleMapping (and ExternalView)
       // if instance is evacuated keep the instanceStateMap same as idealStateMap
-      if ((assignableLiveInstancesMap.containsKey(instance) || isAssignableForCustomizedResource) && notInErrorState) {
+      if ((assignableLiveInstancesMap.containsKey(instance) || isAssignableForCustomizedResource)) {
         if (enabled) {
           instanceStateMap.put(instance, idealStateMap.get(instance));
         } else {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -762,9 +762,10 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   /**
-   * Return true if instance has any resource with FULL_AUTO or CUSTOMIZED rebalance mode in current state or
-   * if instance has any pending message. Otherwise, return false if instance is offline,
-   * instance has no active session, or if instance is online but has no current state or pending message.
+   * Returns true if instance has more than one session or for online instance if it has messages or
+   * FULL_AUTO and CUSTOMIZED resources in current states, false otherwise. For offline instances,
+   * returns false if all CUSTOMIZED resources in current states are migrated to other instances
+   * in ideal state, true otherwise.
    * @param clusterName
    * @param instanceName
    * @return
@@ -782,12 +783,12 @@ public class ZKHelixAdmin implements HelixAdmin {
     // then there are > 1 session ZNodes.
     List<String> sessions = baseAccessor.getChildNames(PropertyPathBuilder.instanceCurrentState(clusterName, instanceName), 0);
     if (sessions.isEmpty()) {
-      logger.warn("Instance {} in cluster {} does not have any session.  The instance can be removed anyway.",
+      logger.info("Instance {} in cluster {} does not have any session.  The instance can be removed anyway.",
           instanceName, clusterName);
       return false;
     }
     if (sessions.size() > 1) {
-      logger.warn("Instance {} in cluster {} is carrying over from prev session.", instanceName,
+      logger.info("Instance {} in cluster {} is carrying over from prev session.", instanceName,
           clusterName);
       return true;
     }
@@ -795,7 +796,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     String sessionId = sessions.get(0);
     List<CurrentState> currentStates = accessor.getChildValues(keyBuilder.currentStates(instanceName, sessionId), true);
     if (currentStates == null || currentStates.isEmpty()) {
-      logger.warn("Instance {} in cluster {} does not have any current state.",
+      logger.info("Instance {} in cluster {} does not have any current state.",
           instanceName, clusterName);
       return false;
     }
@@ -812,7 +813,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     // see if instance has pending message.
     List<String> messages = accessor.getChildNames(keyBuilder.messages(instanceName));
     if (messages != null && !messages.isEmpty()) {
-      logger.warn("Instance {} in cluster {} has pending messages.", instanceName, clusterName);
+      logger.info("Instance {} in cluster {} has pending messages.", instanceName, clusterName);
       return true;
     }
     // Get set of FULL_AUTO and CUSTOMIZED resources

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -802,7 +802,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates(), true);
     if (liveInstance == null) {
-      return !areResourcesMigrated(currentStates, idealStates, instanceName, RebalanceMode.CUSTOMIZED);
+      return !areAllPartitionsReassigned(currentStates, idealStates, instanceName, RebalanceMode.CUSTOMIZED);
     }
 
     // see if instance has pending message.
@@ -821,15 +821,17 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   /**
-   * Return true if all the partitions of the resources which match RebalanceMode state are now assigned
-   * to a different instance in ideal state.
-   * @param currentStates
-   * @param idealStates
-   * @param instanceName
-   * @param rebalanceMode
+   * Returns true if, for all resources present in the given current states and whose
+   * RebalanceMode matches the specified {@link  RebalanceMode}, every partition is now assigned
+   * to a different instance (i.e., not instanceName) in the IdealState.
+   *
+   * @param currentStates  list of CurrentState objects representing the current assignment of resources
+   * @param idealStates    list of IdealState objects representing the desired assignment of resources
+   * @param instanceName   the instance from which resources are migrated
+   * @param rebalanceMode  the rebalance mode to match in IdealState
    * @return
    */
-  private boolean areResourcesMigrated(List<CurrentState> currentStates,
+  private boolean areAllPartitionsReassigned(List<CurrentState> currentStates,
       List<IdealState> idealStates, String instanceName, RebalanceMode rebalanceMode) {
     // Step 1: Create a map of resourceName -> CurrentState
     Map<String, CurrentState> currentStateMap = currentStates.stream()

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -825,7 +825,8 @@ public class ZKHelixAdmin implements HelixAdmin {
    * RebalanceMode matches the specified {@link  RebalanceMode}, every partition is now assigned
    * to a different instance (i.e., not instanceName) in the IdealState.
    *
-   * @param currentStates  list of CurrentState objects representing the current assignment of resources
+   * @param currentStates  list of CurrentState objects of instanceName representing the current assignment of
+   *                       resources on the instance
    * @param idealStates    list of IdealState objects representing the desired assignment of resources
    * @param instanceName   the instance from which resources are migrated
    * @param rebalanceMode  the rebalance mode to match in IdealState

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -776,11 +776,6 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     // check the instance is alive
     LiveInstance liveInstance = accessor.getProperty(keyBuilder.liveInstance(instanceName));
-//    if (liveInstance == null) {
-//      logger.warn("Instance {} in cluster {} is not alive. The instance can be removed anyway.", instanceName,
-//          clusterName);
-//      return false;
-//    }
 
     BaseDataAccessor<ZNRecord> baseAccessor = _baseDataAccessor;
     // count number of sessions under CurrentState folder. If it is carrying over from prv session,
@@ -804,7 +799,7 @@ public class ZKHelixAdmin implements HelixAdmin {
           instanceName, clusterName);
       return false;
     }
-    // Get set of FULL_AUTO and CUSTOMIZED resources
+
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates(), true);
     if (liveInstance == null) {
       return !areResourcesMigrated(currentStates, idealStates, instanceName, RebalanceMode.CUSTOMIZED);
@@ -816,6 +811,7 @@ public class ZKHelixAdmin implements HelixAdmin {
       logger.warn("Instance {} in cluster {} has pending messages.", instanceName, clusterName);
       return true;
     }
+    // Get set of FULL_AUTO and CUSTOMIZED resources
     Set<String> resources = idealStates != null ? idealStates.stream()
         .filter(idealState -> idealState.getRebalanceMode() == RebalanceMode.FULL_AUTO ||
             idealState.getRebalanceMode() == RebalanceMode.CUSTOMIZED)

--- a/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
+++ b/helix-core/src/test/java/org/apache/helix/common/ZkTestBase.java
@@ -452,6 +452,11 @@ public class ZkTestBase {
 
   protected void createResourceInCustomizedMode(ClusterSetup clusterSetup, String clusterName, String resourceName,
       Map<Integer, String> partitionInstanceMap) {
+    clusterSetup.addResourceToCluster(clusterName, resourceName, createCustomizedResourceIdealState(resourceName,
+        partitionInstanceMap));
+  }
+
+  protected IdealState createCustomizedResourceIdealState(String resourceName, Map<Integer, String> partitionInstanceMap) {
     IdealState idealState = new IdealState(resourceName);
     idealState.setNumPartitions(partitionInstanceMap.size());
     idealState.setStateModelDefRef(OnlineOfflineSMD.name);
@@ -460,7 +465,7 @@ public class ZkTestBase {
       idealState.setPartitionState(resourceName + "_" + partitionID,
           instanceName, OnlineOfflineSMD.States.ONLINE.toString());
     });
-    clusterSetup.addResourceToCluster(clusterName, resourceName, idealState);
+    return idealState;
   }
 
   protected void removeAllResourcesFromInstance(MockParticipantManager participant, Set<String> excludeResourceNames) {

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -348,6 +348,7 @@ public class TestInstanceOperation extends ZkTestBase {
     partitionInstanceMap.put(Integer.valueOf(1), _participants.get(1).getInstanceName());
     IdealState newIdealState = createCustomizedResourceIdealState(customizedDB, partitionInstanceMap);
     _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, customizedDB, newIdealState);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
     // Drop customized DBs in clusterx
     _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, customizedDB);

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -300,10 +300,55 @@ public class TestInstanceOperation extends ZkTestBase {
     // evacuated instance
     _gSetupTool.getClusterManagementTool()
         .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
     _gSetupTool.getClusterManagementTool()
         .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+    // Drop customized DBs in clusterx
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, customizedDB);
+    createTestDBs(DEFAULT_RESOURCE_DELAY_TIME);
+  }
+
+  @Test
+  public void testEvacuateWithCustomizedResourceOfflineInstance() throws Exception {
+    /*
+      Test the following scenario
+       * Customized resource partitions P0, P1 assigned to an instance A.
+       * Instance A becomes unhealthy.
+       * Cluster enters maintenance mode.
+       * Evacuate operation is set of instance A
+       * Cluster exists maintenance mode
+       * isEvacuateFinished operation on instanceA returns False
+       * new ideal state is computed, which doesn't have instance A
+       * isEvacuateFinished operation on instanceA returns true
+     */
+    System.out.println("START TestInstanceOperation.testEvacuateWithCustomizedResourceOfflineInstance() at " + new Date(System.currentTimeMillis()));
+    for( String resource : _allDBs) {
+      _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, resource);
+    }
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    String customizedDB = "CustomizedTestDB";
+    Map<Integer, String> partitionInstanceMap = new HashMap<>();
+    partitionInstanceMap.put(Integer.valueOf(0), _participants.get(0).getInstanceName());
+    partitionInstanceMap.put(Integer.valueOf(1), _participants.get(0).getInstanceName());
+    createResourceInCustomizedMode(_gSetupTool, CLUSTER_NAME, customizedDB, partitionInstanceMap);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    _participants.get(0).syncStop();
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, true, null, null);
+    // evacuated instance
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+    partitionInstanceMap.put(Integer.valueOf(0), _participants.get(1).getInstanceName());
+    partitionInstanceMap.put(Integer.valueOf(1), _participants.get(1).getInstanceName());
+    IdealState newIdealState = createCustomizedResourceIdealState(customizedDB, partitionInstanceMap);
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, customizedDB, newIdealState);
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
     // Drop customized DBs in clusterx
     _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, customizedDB);
     createTestDBs(DEFAULT_RESOURCE_DELAY_TIME);


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Currently if an instance is unhealthy and we set evacuate tag on the instance, `isEvacuateFinished` immediately returns False. For Apache pinot, this leads to deleting of the evacuated instance even when there are customized resources assigned on the evacuated instance, and a new ideal state is not generated.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

My PR adds a check in isEvacuateFinished when instance is not live. It checks if all the cutomized resources partitions are assigned to other instances in the ideal sates.
It also removes the `notInErrorState` check from CustomRebalancer. This check was previously removed in this [PR](https://github.com/apache/helix/pull/3024) but then it somehow got added back [while resolving conflicts](https://github.com/linkedin/helix/commit/a0676102731ad8cbc3caae2b9334834caf0c3764).

### Tests

 The following tests are written for this issue:
- [ ] TestInstanceOperation.testEvacuateWithCustomizedResourceOfflineInstance()

- The following is the result of the "mvn test" command on the appropriate module:

```
mvn test -o -Dtest=TestInstanceOperation -pl=helix-core

[INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 625.765 s - in org.apache.helix.integration.rebalancer.TestInstanceOperation
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.6:report (generate-code-coverage-report) @ helix-core ---
[INFO] Loading execution data file /Users/anubagar/workspace/helix-projects/apache-helix/helix/helix-core/target/jacoco.exec
[INFO] Analyzed bundle 'Apache Helix :: Core' with 819 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10:40 min
[INFO] Finished at: 2025-06-08T21:30:08+05:30
[INFO] ------------------------------------------------------------------------

```
(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
