### PR TITLE
Add optional relaxed disabled partition constraint for WAGED rebalancer

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ReplicaActivateConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ReplicaActivateConstraint.java
@@ -41,6 +41,16 @@ class ReplicaActivateConstraint extends HardConstraint {
         .containsKey(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY);
 
     if (allResourcesDisabled || (disabledPartitions != null && disabledPartitions.contains(replica.getPartitionName()))) {
+      // Check if relaxed disabled partition constraint is enabled
+      if (clusterContext.isRelaxedDisabledPartitionConstraintEnabled(replica.getResourceName())) {
+        // In relaxed mode, allow assignment to disabled partitions (they will remain OFFLINE)
+        if (enableLogging) {
+          LOG.info("Relaxed mode: allowing assignment of replica {} to disabled partition", replica.getPartitionName());
+        }
+        return true;
+      }
+      
+      // Default behavior: reject assignment to disabled partitions
       if (enableLogging) {
         LOG.info("Cannot assign the inactive replica: {}", replica.getPartitionName());
       }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -268,7 +268,8 @@ public class ClusterModelProvider {
     // Construct and initialize cluster context.
     ClusterContext context = new ClusterContext(
         replicaMap.values().stream().flatMap(Set::stream).collect(Collectors.toSet()),
-        assignableNodes, logicalIdIdealAssignment, logicalIdCurrentAssignment, dataProvider.getClusterConfig());
+        assignableNodes, logicalIdIdealAssignment, logicalIdCurrentAssignment, 
+        dataProvider.getClusterConfig(), dataProvider);
 
     // Initial the cluster context with the allocated assignments.
     context.setAssignmentForFaultZoneMap(mapAssignmentToFaultZone(assignableNodes));

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -167,7 +167,10 @@ public class ClusterConfig extends HelixProperty {
     // List of Preferred scoring keys used in evenness score computation
     PREFERRED_SCORING_KEYS,
     // How long offline nodes will stay in the cluster before they are automatically purged, in milliseconds
-    PARTICIPANT_DEREGISTRATION_TIMEOUT
+    PARTICIPANT_DEREGISTRATION_TIMEOUT,
+
+    // Allow disabled partitions to remain OFFLINE instead of being reassigned in WAGED rebalancer
+    RELAXED_DISABLED_PARTITION_CONSTRAINT
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -864,6 +867,27 @@ public class ClusterConfig extends HelixProperty {
    */
   public void enableP2PMessage(boolean enabled) {
     _record.setBooleanField(HelixConfigProperty.P2P_MESSAGE_ENABLED.name(), enabled);
+  }
+
+  /**
+   * Whether the relaxed disabled partition constraint is enabled for this cluster.
+   * When enabled, WAGED rebalancer will allow disabled partitions to remain OFFLINE 
+   * instead of being immediately reassigned, making behavior consistent with CrushEd.
+   * By default it is disabled if not set.
+   * @return true if relaxed disabled partition constraint is enabled, false otherwise
+   */
+  public boolean isRelaxedDisabledPartitionConstraintEnabled() {
+    return _record.getBooleanField(ClusterConfigProperty.RELAXED_DISABLED_PARTITION_CONSTRAINT.name(), false);
+  }
+
+  /**
+   * Enable/disable relaxed disabled partition constraint for this cluster.
+   * When enabled, WAGED rebalancer will allow disabled partitions to remain OFFLINE 
+   * instead of being immediately reassigned, making behavior consistent with CrushEd.
+   * @param enabled true to enable relaxed constraint, false for strict constraint (default)
+   */
+  public void setRelaxedDisabledPartitionConstraint(boolean enabled) {
+    _record.setBooleanField(ClusterConfigProperty.RELAXED_DISABLED_PARTITION_CONSTRAINT.name(), enabled);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
@@ -59,7 +59,8 @@ public class ResourceConfig extends HelixProperty {
     GROUP_ROUTING_ENABLED,
     EXTERNAL_VIEW_DISABLED,
     DELAY_REBALANCE_ENABLED,
-    PARTITION_CAPACITY_MAP
+    PARTITION_CAPACITY_MAP,
+    RELAXED_DISABLED_PARTITION_CONSTRAINT // Resource-level override for relaxed disabled partition constraint
   }
 
   public enum ResourceConfigConstants {
@@ -334,6 +335,34 @@ public class ResourceConfig extends HelixProperty {
    */
   public Boolean isExternalViewDisabled() {
     return _record.getBooleanField(ResourceConfigProperty.EXTERNAL_VIEW_DISABLED.name(), false);
+  }
+
+  /**
+   * Whether the relaxed disabled partition constraint is enabled for this resource.
+   * When enabled, WAGED rebalancer will allow disabled partitions to remain OFFLINE 
+   * instead of being immediately reassigned for this specific resource.
+   * This setting overrides the cluster-level configuration for this resource.
+   * @return true if enabled, false if disabled, null if not set (uses cluster default)
+   */
+  public Boolean isRelaxedDisabledPartitionConstraintEnabled() {
+    String value = _record.getSimpleField(ResourceConfigProperty.RELAXED_DISABLED_PARTITION_CONSTRAINT.name());
+    return value != null ? Boolean.valueOf(value) : null;
+  }
+
+  /**
+   * Enable/disable relaxed disabled partition constraint for this resource.
+   * When enabled, WAGED rebalancer will allow disabled partitions to remain OFFLINE 
+   * instead of being immediately reassigned for this specific resource.
+   * This setting overrides the cluster-level configuration for this resource.
+   * @param enabled true to enable relaxed constraint, false for strict constraint, 
+   *                null to use cluster default
+   */
+  public void setRelaxedDisabledPartitionConstraint(Boolean enabled) {
+    if (enabled == null) {
+      _record.getSimpleFields().remove(ResourceConfigProperty.RELAXED_DISABLED_PARTITION_CONSTRAINT.name());
+    } else {
+      _record.setBooleanField(ResourceConfigProperty.RELAXED_DISABLED_PARTITION_CONSTRAINT.name(), enabled);
+    }
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestReplicaActivateConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestReplicaActivateConstraint.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
@@ -65,8 +66,48 @@ public class TestReplicaActivateConstraint {
     when(_testReplica.getResourceName()).thenReturn(TEST_RESOURCE);
     when(_testReplica.getPartitionName()).thenReturn(TEST_PARTITION);
     when(_testNode.getDisabledPartitionsMap()).thenReturn(disabledReplicaMap);
+    when(_clusterContext.isRelaxedDisabledPartitionConstraintEnabled(TEST_RESOURCE)).thenReturn(false);
 
     Assert.assertFalse(_faultZoneAwareConstraint.isAssignmentValid(_testNode, _testReplica, _clusterContext));
+  }
+
+  @Test
+  public void validWhenPartitionIsDisabledButRelaxedModeEnabled() {
+    Map<String, List<String>> disabledReplicaMap = new HashMap<>();
+    disabledReplicaMap.put(TEST_RESOURCE, Collections.singletonList(TEST_PARTITION));
+
+    when(_testReplica.getResourceName()).thenReturn(TEST_RESOURCE);
+    when(_testReplica.getPartitionName()).thenReturn(TEST_PARTITION);
+    when(_testNode.getDisabledPartitionsMap()).thenReturn(disabledReplicaMap);
+    when(_clusterContext.isRelaxedDisabledPartitionConstraintEnabled(TEST_RESOURCE)).thenReturn(true);
+
+    Assert.assertTrue(_faultZoneAwareConstraint.isAssignmentValid(_testNode, _testReplica, _clusterContext));
+  }
+
+  @Test
+  public void invalidWhenAllResourcesDisabledAndRelaxedModeDisabled() {
+    Map<String, List<String>> disabledReplicaMap = new HashMap<>();
+    disabledReplicaMap.put(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY, Collections.singletonList("*"));
+
+    when(_testReplica.getResourceName()).thenReturn(TEST_RESOURCE);
+    when(_testReplica.getPartitionName()).thenReturn(TEST_PARTITION);
+    when(_testNode.getDisabledPartitionsMap()).thenReturn(disabledReplicaMap);
+    when(_clusterContext.isRelaxedDisabledPartitionConstraintEnabled(TEST_RESOURCE)).thenReturn(false);
+
+    Assert.assertFalse(_faultZoneAwareConstraint.isAssignmentValid(_testNode, _testReplica, _clusterContext));
+  }
+
+  @Test
+  public void validWhenAllResourcesDisabledButRelaxedModeEnabled() {
+    Map<String, List<String>> disabledReplicaMap = new HashMap<>();
+    disabledReplicaMap.put(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY, Collections.singletonList("*"));
+
+    when(_testReplica.getResourceName()).thenReturn(TEST_RESOURCE);
+    when(_testReplica.getPartitionName()).thenReturn(TEST_PARTITION);
+    when(_testNode.getDisabledPartitionsMap()).thenReturn(disabledReplicaMap);
+    when(_clusterContext.isRelaxedDisabledPartitionConstraintEnabled(TEST_RESOURCE)).thenReturn(true);
+
+    Assert.assertTrue(_faultZoneAwareConstraint.isAssignmentValid(_testNode, _testReplica, _clusterContext));
   }
 
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalancerDisabledScenarios.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalancerDisabledScenarios.java
@@ -1,0 +1,828 @@
+package org.apache.helix.integration.rebalancer.WagedRebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TestWagedRebalancerDisabledScenarios extends ZkTestBase {
+  private static final int NUM_NODE = 6;
+  private static final int START_PORT = 12918;
+  private static final int PARTITIONS = 20;
+  private static final int REPLICAS = 3;
+  private static final String OFFLINE = "OFFLINE";
+
+  private final String _className = getShortClassName();
+  private final String _clusterName = CLUSTER_PREFIX + "_" + _className;
+  private ClusterControllerManager _controller;
+  private MockParticipantManager[] _participants;
+  private String[] _instanceNames;
+
+  @BeforeClass
+  @Override
+  public void beforeClass() throws Exception {
+    System.out.println("START " + _className + " at " + new Date(System.currentTimeMillis()));
+    _gSetupTool.addCluster(_clusterName, true);
+    _gSetupTool.getClusterManagementTool().addStateModelDef(_clusterName, "MasterSlave",
+        BuiltInStateModelDefinitions.MasterSlave.getStateModelDefinition());
+    setupCluster();
+
+    // Enable delayed rebalance at cluster level
+    enableDelayRebalanceInCluster(_gZkClient, _clusterName, true, 5000); // Default 5 second delay
+
+    _participants = new MockParticipantManager[NUM_NODE];
+    _instanceNames = new String[NUM_NODE];
+    for (int i = 0; i < NUM_NODE; i++) {
+      String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _gSetupTool.addInstanceToCluster(_clusterName, instanceName);
+      _instanceNames[i] = instanceName;
+    }
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, _clusterName, controllerName);
+    _controller.syncStart();
+
+    // start participants
+    for (int i = 0; i < NUM_NODE; i++) {
+      _participants[i] = new MockParticipantManager(ZK_ADDR, _clusterName, _instanceNames[i]);
+      _participants[i].syncStart();
+    }
+  }
+
+  protected void setupCluster() {
+    // Empty implementation. Can be overridden by the test class.
+  }
+
+  @AfterClass
+  public void afterClass() {
+    if (_controller != null && _controller.isConnected()) {
+      _controller.syncStop();
+    }
+    for (int i = 0; i < NUM_NODE; i++) {
+      if (_participants[i] != null && _participants[i].isConnected()) {
+        _participants[i].syncStop();
+      }
+    }
+    deleteCluster(_clusterName);
+    System.out.println("END " + _className + " at " + new Date(System.currentTimeMillis()));
+  }
+
+  @BeforeMethod
+  public void beforeMethod() throws Exception {
+    // Ensure all instances are enabled before each test
+    enableAllInstances();
+
+    // Wait for cluster to be ready and all participants to be connected
+    TestHelper.verify(() -> {
+      if (!_gSetupTool.getClusterManagementTool().getClusters().contains(_clusterName)) {
+        return false;
+      }
+      // Ensure all participants are connected
+      for (MockParticipantManager participant : _participants) {
+        if (!participant.isConnected()) {
+          return false;
+        }
+      }
+      return true;
+    }, TestHelper.WAIT_DURATION);
+  }
+
+  @AfterMethod
+  public void afterMethod() {
+    // Clean up resources created during the test
+    cleanupResourcesAndResetInstances();
+  }
+
+  @Test
+  public void testInstanceDisabled() throws Exception {
+    String dbName = generateUniqueResourceName("InstanceDisabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+    // Since the instance is disabled, the replicas should be moved to other instances.
+    validateExternalView(dbName, _instanceNames[0]);
+  }
+
+  @Test
+  public void testResourceDisabled() throws Exception {
+    String dbName = generateUniqueResourceName("ResourceDisabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    _gSetupTool.getClusterManagementTool().enableResource(_clusterName, dbName, false);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+    // Since the resource is disabled, all replicas should be in OFFLINE state.
+    validateExternalViewAllOffline(dbName);
+  }
+
+  @Test
+  public void testPartitionDisabled() throws Exception {
+    String dbName = generateUniqueResourceName("PartitionDisabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    // Validate rebalance worked - wait for convergence and ensure target instance has partitions
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null || ev.getPartitionSet().size() != PARTITIONS) {
+        return false;
+      }
+      // Ensure the target instance has at least one partition
+      return findPartitionOnInstance(dbName, _instanceNames[0]) != null;
+    }, TestHelper.WAIT_DURATION);
+
+    // Find a partition that is currently assigned to the target instance
+    String partitionToDisable = findPartitionOnInstance(dbName, _instanceNames[0]);
+    Assert.assertNotNull("No partition found on instance " + _instanceNames[0], partitionToDisable);
+
+    _gSetupTool.getClusterManagementTool().enablePartition(false, _clusterName, _instanceNames[0],
+        dbName, Collections.singletonList(partitionToDisable));
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // Since the specific partition is disabled on one instance:
+    // 1. That partition should not be on the disabled instance
+    // 2. The partition should be reassigned to maintain replica count
+    validatePartitionDisabledBehavior(dbName, partitionToDisable, _instanceNames[0]);
+  }
+
+  @Test
+  public void testAllResourcesDisabled() throws Exception {
+    String dbName = generateUniqueResourceName("AllResourcesDisabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    // Disable the instance completely (ALL_RESOURCES disabled)
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+    // Since all resources are disabled on the instance, replicas should be evacuated from that instance.
+    validateExternalView(dbName, _instanceNames[0]);
+  }
+
+  // ==============================
+  // Delayed Rebalance Scenarios
+  // ==============================
+
+  @Test
+  public void testInstanceDisabledDuringDelayWindow() throws Exception {
+    String dbName = generateUniqueResourceName("InstanceDisabledDelayed");
+    createResourceWithDelayedRebalance(dbName, PARTITIONS, REPLICAS, 10000); // 10 second delay
+
+    // Wait for initial assignment to stabilize
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null) return false;
+
+      // Check that all partitions are assigned and the target instance has some replicas
+      boolean allPartitionsAssigned = ev.getPartitionSet().size() == PARTITIONS;
+      Map<String, String> assignment = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+      boolean targetInstanceHasReplicas = !assignment.isEmpty();
+
+      return allPartitionsAssigned && targetInstanceHasReplicas;
+    }, 8000);
+
+    // Record initial assignment after stabilization
+    Map<String, String> initialAssignment = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+    Assert.assertFalse(initialAssignment.isEmpty(), "Instance should have partitions initially");
+
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // During delay window: Replicas should stay on disabled instance, new assignments blocked
+    validateInstanceDisabledDuringDelayWindow(dbName, _instanceNames[0], initialAssignment);
+
+    // After delay window expires: Replicas should eventually move out of the disabled instance
+    validateInstanceDisabledAfterDelayWindow(dbName, _instanceNames[0]);
+  }
+
+  @Test
+  public void testInstanceDisabledAfterDelayWindow() throws Exception {
+    String dbName = generateUniqueResourceName("InstanceDisabledAfterDelay");
+    createResourceWithDelayedRebalance(dbName, PARTITIONS, REPLICAS, 2000); // 2 second delay
+
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // Wait for delay window to expire and validate evacuation
+    validateInstanceDisabledAfterDelayWindow(dbName, _instanceNames[0]);
+
+    // After delay window: Replicas should be evacuated from disabled instance
+    validateExternalView(dbName, _instanceNames[0]);
+  }
+
+  @Test
+  public void testAllResourcesDisabledDuringDelayWindow() throws Exception {
+    String dbName = generateUniqueResourceName("AllResourcesDisabledDelayed");
+    createResourceWithDelayedRebalance(dbName, PARTITIONS, REPLICAS, 10000); // 10 second delay
+
+    // Wait for initial assignment to stabilize
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null) return false;
+
+      // Check that all partitions are assigned and the target instance has some replicas
+      boolean allPartitionsAssigned = ev.getPartitionSet().size() == PARTITIONS;
+      Map<String, String> assignment = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+      boolean targetInstanceHasReplicas = !assignment.isEmpty();
+
+      return allPartitionsAssigned && targetInstanceHasReplicas;
+    }, 8000);
+
+    // Record initial assignment after stabilization
+    Map<String, String> initialAssignment = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+    Assert.assertFalse(initialAssignment.isEmpty(), "Instance should have partitions initially");
+
+    // Disable all resources on the instance
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // During delay window: Should behave like instance disabled - replicas stay
+    validateInstanceDisabledDuringDelayWindow(dbName, _instanceNames[0], initialAssignment);
+
+    // After delay window expires: Replicas should eventually move out of the disabled instance
+    validateInstanceDisabledAfterDelayWindow(dbName, _instanceNames[0]);
+  }
+
+  @Test
+  public void testAllResourcesDisabledAfterDelayWindow() throws Exception {
+    String dbName = generateUniqueResourceName("AllResourcesDisabledAfterDelay");
+    createResourceWithDelayedRebalance(dbName, PARTITIONS, REPLICAS, 2000); // 2 second delay
+
+    // Disable all resources on the instance
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // Wait for delay window to expire and validate evacuation
+    validateInstanceDisabledAfterDelayWindow(dbName, _instanceNames[0]);
+
+    // After delay window: Replicas should be evacuated from disabled instance
+    validateExternalView(dbName, _instanceNames[0]);
+  }
+
+  @Test
+  public void testMultipleInstancesDisabled() throws Exception {
+    String dbName = generateUniqueResourceName("MultipleInstancesDisabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+
+    // Disable multiple instances simultaneously
+    disableInstance(_instanceNames[0]);
+    disableInstance(_instanceNames[1]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // Since multiple instances are disabled, replicas should be evacuated from both instances
+    validateExternalView(dbName, _instanceNames[0]);
+    validateExternalView(dbName, _instanceNames[1]);
+
+    // Ensure proper replica distribution on remaining instances
+    validateProperReplicaDistribution(dbName, REPLICAS);
+  }
+
+  @Test
+  public void testMultipleInstancesDisabledDuringDelayWindow() throws Exception {
+    String dbName = generateUniqueResourceName("MultipleInstancesDisabledDelayed");
+    createResourceWithDelayedRebalance(dbName, PARTITIONS, REPLICAS, 10000); // 10 second delay
+
+    // Wait for initial assignment to stabilize
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null) return false;
+      return ev.getPartitionSet().size() == PARTITIONS;
+    }, 8000);
+
+    // Record initial assignments before disabling
+    Map<String, String> initialAssignment1 = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+    Map<String, String> initialAssignment2 = getPartitionAssignmentForInstance(dbName, _instanceNames[1]);
+
+    // Disable multiple instances
+    disableInstance(_instanceNames[0]);
+    disableInstance(_instanceNames[1]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // During delay window: Replicas should stay on disabled instances
+    validateInstanceDisabledDuringDelayWindow(dbName, _instanceNames[0], initialAssignment1);
+    validateInstanceDisabledDuringDelayWindow(dbName, _instanceNames[1], initialAssignment2);
+
+    // After delay window expires: Replicas should be evacuated from both instances
+    validateInstanceDisabledAfterDelayWindow(dbName, _instanceNames[0]);
+    validateInstanceDisabledAfterDelayWindow(dbName, _instanceNames[1]);
+  }
+
+  protected void createResourceWithWagedRebalance(String dbName, int partitions, int replicas) throws Exception {
+    IdealState idealState =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(_clusterName, dbName);
+    if (idealState == null) {
+      idealState = new IdealState(dbName);
+      idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+      idealState.setNumPartitions(partitions);
+      idealState.setReplicas(String.valueOf(replicas));
+      idealState.setMinActiveReplicas(2);
+      idealState.setRebalancerClassName(
+          "org.apache.helix.controller.rebalancer.waged.WagedRebalancer");
+      idealState.setRebalanceStrategy(
+          "org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy");
+      idealState.setStateModelDefRef("MasterSlave");
+      idealState.setStateModelFactoryName("DEFAULT");
+      _gSetupTool.getClusterManagementTool().addResource(_clusterName, dbName, idealState);
+    }
+    // Explicit rebalance call is still needed to trigger rebalancing
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, replicas);
+
+    // Wait for the resource to be properly assigned
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == partitions;
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  protected void createResourceWithDelayedRebalance(String dbName, int partitions, int replicas, int delay) throws Exception {
+    IdealState idealState =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(_clusterName, dbName);
+    if (idealState == null) {
+      idealState = new IdealState(dbName);
+      idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+      idealState.setNumPartitions(partitions);
+      idealState.setReplicas(String.valueOf(replicas));
+      idealState.setMinActiveReplicas(2);
+      idealState.setRebalancerClassName(
+          "org.apache.helix.controller.rebalancer.waged.WagedRebalancer");
+      idealState.setRebalanceStrategy(
+          "org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy");
+      idealState.setStateModelDefRef("MasterSlave");
+      idealState.setStateModelFactoryName("DEFAULT");
+      idealState.setRebalanceDelay(delay);
+      idealState.setDelayRebalanceEnabled(true); // Enable delayed rebalance feature
+      _gSetupTool.getClusterManagementTool().addResource(_clusterName, dbName, idealState);
+    }
+    // Explicit rebalance call is still needed to trigger rebalancing
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, replicas);
+
+    // Wait for the resource to be properly assigned
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == partitions;
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  protected void validateExternalView(String dbName, String disabledInstance) throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView externalView =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (externalView == null) {
+        return false;
+      }
+      for (String partitionName : externalView.getPartitionSet()) {
+        Map<String, String> stateMap = externalView.getStateMap(partitionName);
+        if (stateMap == null) {
+          return false;
+        }
+        if (stateMap.containsKey(disabledInstance)) {
+          return false;
+        }
+      }
+      return true;
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  protected void validatePartitionNotOnInstance(String dbName, String partitionName, String disabledInstance) throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView externalView =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (externalView == null) {
+        return false;
+      }
+      Map<String, String> stateMap = externalView.getStateMap(partitionName);
+      if (stateMap == null) {
+        return true; // If no state map, partition is not on any instance
+      }
+      // Check that the disabled instance does not have this specific partition
+      return !stateMap.containsKey(disabledInstance);
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  protected void validatePartitionDisabledBehavior(String dbName, String partitionName, String disabledInstance) throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView externalView =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (externalView == null) {
+        return false;
+      }
+      Map<String, String> stateMap = externalView.getStateMap(partitionName);
+      if (stateMap == null) {
+        return false; // Partition should still exist
+      }
+
+      // For WAGED rebalancer with FULL_AUTO mode, when a partition is disabled on an instance:
+      // 1. The disabled instance should not have this partition in active state
+      // 2. The partition should maintain some active replicas on other instances
+
+      // Check that the disabled instance does not have this partition in active states
+      boolean partitionNotActiveOnDisabledInstance = true;
+      if (stateMap.containsKey(disabledInstance)) {
+        String state = stateMap.get(disabledInstance);
+        // If the partition exists on disabled instance, it should be in OFFLINE state or DROPPED
+        if (!OFFLINE.equals(state) && !"DROPPED".equals(state)) {
+          partitionNotActiveOnDisabledInstance = false;
+        }
+      }
+
+      if (!partitionNotActiveOnDisabledInstance) {
+        return false;
+      }
+
+      // Check that the partition has some active replicas on other instances
+      long activeReplicas = stateMap.values().stream()
+          .filter(state -> !OFFLINE.equals(state) && !"DROPPED".equals(state))
+          .count();
+
+      // Should have at least 1 active replica (preferably meet min active replicas)
+      // But in some edge cases with partition disable, we might have less than ideal replica count
+      return activeReplicas >= 1;
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  protected String findPartitionOnInstance(String dbName, String instanceName) {
+    ExternalView externalView =
+        _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+    if (externalView == null) {
+      return null;
+    }
+
+    for (String partitionName : externalView.getPartitionSet()) {
+      Map<String, String> stateMap = externalView.getStateMap(partitionName);
+      if (stateMap != null && stateMap.containsKey(instanceName)) {
+        return partitionName;
+      }
+    }
+    return null;
+  }
+
+  protected void validateExternalViewAllOffline(String dbName) throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView externalView =
+          _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (externalView == null) {
+        return false;
+      }
+      for (String partitionName : externalView.getPartitionSet()) {
+        Map<String, String> stateMap = externalView.getStateMap(partitionName);
+        if (stateMap == null || stateMap.isEmpty()) {
+          return false;
+        }
+        for (String instance : stateMap.keySet()) {
+          if (!stateMap.get(instance).equals(OFFLINE)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  private void disableInstance(String instanceName) {
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(_clusterName, instanceName,
+        InstanceConstants.InstanceOperation.DISABLE);
+  }
+
+  private void validateInstanceDisabledDuringDelayWindow(String dbName, String disabledInstance, Map<String, String> originalAssignment) throws Exception {
+    // During delay window, partitions should remain on the disabled instance
+    TestHelper.verify(() -> {
+      Map<String, String> currentAssignment = getPartitionAssignmentForInstance(dbName, disabledInstance);
+      return currentAssignment.size() == originalAssignment.size();
+    }, 3000);
+  }
+
+  private void validateInstanceDisabledAfterDelayWindow(String dbName, String disabledInstance) throws Exception {
+    // After delay window, partitions should be evacuated from the disabled instance
+    // Use a longer timeout since we need to wait for the delay window to expire (10+ seconds)
+    TestHelper.verify(() -> {
+      Map<String, String> currentAssignment = getPartitionAssignmentForInstance(dbName, disabledInstance);
+      return currentAssignment.isEmpty();
+    }, 15000);
+  }
+
+  protected Map<String, String> getPartitionAssignmentForInstance(String dbName, String instanceName) {
+    ExternalView externalView =
+        _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+    if (externalView == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> assignments = new HashMap<>();
+    for (String partition : externalView.getPartitionSet()) {
+      Map<String, String> stateMap = externalView.getStateMap(partition);
+      if (stateMap != null && stateMap.containsKey(instanceName)) {
+        assignments.put(partition, stateMap.get(instanceName));
+      }
+    }
+    return assignments;
+  }
+
+  private String generateUniqueResourceName(String testName) {
+    return "TestDB_" + testName + "_" + System.currentTimeMillis();
+  }
+
+  private void enableAllInstances() {
+    for (String instanceName : _instanceNames) {
+      _gSetupTool.getClusterManagementTool().setInstanceOperation(_clusterName, instanceName,
+          InstanceConstants.InstanceOperation.ENABLE);
+
+      // Also re-enable all partitions on the instance for all resources
+      try {
+        for (String resourceName : _gSetupTool.getClusterManagementTool().getResourcesInCluster(_clusterName)) {
+          _gSetupTool.getClusterManagementTool().resetPartition(_clusterName, instanceName, resourceName, Collections.emptyList());
+        }
+      } catch (Exception e) {
+        // Ignore errors during cleanup - might not have resources yet
+      }
+    }
+  }
+
+  private void cleanupResourcesAndResetInstances() {
+    try {
+      // Remove all resources that were created during tests
+      for (String resourceName : _gSetupTool.getClusterManagementTool().getResourcesInCluster(_clusterName)) {
+        if (resourceName.startsWith("TestDB_")) {
+          _gSetupTool.getClusterManagementTool().dropResource(_clusterName, resourceName);
+        }
+      }
+
+      // Re-enable all instances to clean state
+      enableAllInstances();
+
+      // Wait for cleanup to take effect
+      TestHelper.verify(() -> {
+        long testResourceCount = _gSetupTool.getClusterManagementTool().getResourcesInCluster(_clusterName)
+            .stream().filter(name -> name.startsWith("TestDB_")).count();
+        return testResourceCount == 0;
+      }, 5000);
+
+    } catch (Exception e) {
+      System.err.println("Warning: Error during test cleanup: " + e.getMessage());
+    }
+  }
+
+  protected void validateProperReplicaDistribution(String dbName, int expectedReplicas) throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView externalView = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (externalView == null) {
+        return false;
+      }
+
+      // Check that each partition has the expected number of active replicas
+      for (String partitionName : externalView.getPartitionSet()) {
+        Map<String, String> stateMap = externalView.getStateMap(partitionName);
+        if (stateMap == null) {
+          return false;
+        }
+
+        long activeReplicas = stateMap.values().stream()
+            .filter(state -> !OFFLINE.equals(state) && !"DROPPED".equals(state))
+            .count();
+
+        if (activeReplicas != expectedReplicas) {
+          return false;
+        }
+      }
+      return true;
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  @Test
+  public void testPartitionDisabledDuringDelayWindow() throws Exception {
+    String dbName = generateUniqueResourceName("PartitionDisabledDelayed");
+    createResourceWithDelayedRebalance(dbName, PARTITIONS, REPLICAS, 10000); // 10 second delay
+
+    // Wait for initial assignment to stabilize and ensure target instance has partitions
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null || ev.getPartitionSet().size() != PARTITIONS) {
+        return false;
+      }
+      // Ensure the target instance has at least one partition
+      return findPartitionOnInstance(dbName, _instanceNames[0]) != null;
+    }, TestHelper.WAIT_DURATION);
+
+    // Find a partition that is currently assigned to the target instance
+    String partitionToDisable = findPartitionOnInstance(dbName, _instanceNames[0]);
+    Assert.assertNotNull("No partition found on instance " + _instanceNames[0], partitionToDisable);
+
+    // Disable specific partition on instance
+    _gSetupTool.getClusterManagementTool().enablePartition(false, _clusterName, _instanceNames[0],
+        dbName, Collections.singletonList(partitionToDisable));
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // During delay window: The disabled partition should remain for some time but in OFFLINE state
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null) return false;
+      Map<String, String> stateMap = ev.getStateMap(partitionToDisable);
+      if (stateMap == null) return true; // Partition has been moved
+      return !stateMap.containsKey(_instanceNames[0]) || OFFLINE.equals(stateMap.get(_instanceNames[0]));
+    }, 5000);
+
+    // Eventually: The disabled partition should be completely reassigned
+    validatePartitionDisabledBehavior(dbName, partitionToDisable, _instanceNames[0]);
+  }
+
+  @Test
+  public void testMixedResourcesWithDifferentDelaySettings() throws Exception {
+    String dbName1 = generateUniqueResourceName("MixedDelayed1");
+    String dbName2 = generateUniqueResourceName("MixedDelayed2");
+    String dbName3 = generateUniqueResourceName("MixedNoDelay");
+
+    // Create resources with different delay settings
+    createResourceWithDelayedRebalance(dbName1, PARTITIONS, REPLICAS, 10000); // 10s delay
+    createResourceWithDelayedRebalance(dbName2, PARTITIONS, REPLICAS, 2000);  // 2s delay
+    createResourceWithWagedRebalance(dbName3, PARTITIONS, REPLICAS);          // No delay
+
+    // Wait for all resources to stabilize
+    TestHelper.verify(() -> {
+      ExternalView ev1 = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName1);
+      ExternalView ev2 = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName2);
+      ExternalView ev3 = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName3);
+      return ev1 != null && ev1.getPartitionSet().size() == PARTITIONS &&
+             ev2 != null && ev2.getPartitionSet().size() == PARTITIONS &&
+             ev3 != null && ev3.getPartitionSet().size() == PARTITIONS;
+    }, 8000);
+
+    // Disable instance
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName1, REPLICAS);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName2, REPLICAS);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName3, REPLICAS);
+
+    // Resource with no delay should evacuate immediately
+    validateExternalView(dbName3, _instanceNames[0]);
+
+    // Resource with 2s delay should evacuate after short wait
+    TestHelper.verify(() -> {
+      ExternalView ev2 = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName2);
+      if (ev2 == null) return false;
+      for (String partition : ev2.getPartitionSet()) {
+        Map<String, String> stateMap = ev2.getStateMap(partition);
+        if (stateMap != null && stateMap.containsKey(_instanceNames[0])) {
+          return false;
+        }
+      }
+      return true;
+    }, 5000);
+
+    // Resource with 10s delay may still have replicas (depending on timing)
+    // but should eventually evacuate
+    validateInstanceDisabledAfterDelayWindow(dbName1, _instanceNames[0]);
+  }
+
+  @Test
+  public void testInstanceReEnableAfterDisable() throws Exception {
+    String dbName = generateUniqueResourceName("InstanceReEnabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+
+    // Wait for initial assignment to stabilize
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == PARTITIONS;
+    }, TestHelper.WAIT_DURATION);
+
+    // Record initial assignment
+    Map<String, String> initialAssignment = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+    Assert.assertTrue(!initialAssignment.isEmpty(), "Instance should have partitions initially");
+
+    // Disable instance
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // Validate evacuation
+    validateExternalView(dbName, _instanceNames[0]);
+
+    // Re-enable instance
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(_clusterName, _instanceNames[0],
+        InstanceConstants.InstanceOperation.ENABLE);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // Validate that instance can receive partitions again
+    TestHelper.verify(() -> {
+      Map<String, String> currentAssignment = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+      return !currentAssignment.isEmpty();
+    }, TestHelper.WAIT_DURATION);
+  }
+
+  @Test
+  public void testInstanceDisableWithMinActiveReplicaViolation() throws Exception {
+    String dbName = generateUniqueResourceName("MinActiveReplicaViolation");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+
+    // Disable enough instances to potentially violate minActiveReplicas (which is set to 2)
+    disableInstance(_instanceNames[0]);
+    disableInstance(_instanceNames[1]);
+    disableInstance(_instanceNames[2]);
+    disableInstance(_instanceNames[3]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // With only 2 instances left (NUM_NODE=6, disabled 4), should still maintain minActiveReplicas=2
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null) return false;
+
+      for (String partition : ev.getPartitionSet()) {
+        Map<String, String> stateMap = ev.getStateMap(partition);
+        if (stateMap == null) return false;
+
+        long activeReplicas = stateMap.values().stream()
+            .filter(state -> !OFFLINE.equals(state) && !"DROPPED".equals(state))
+            .count();
+
+        // Should maintain at least minActiveReplicas=2
+        if (activeReplicas < 2) {
+          return false;
+        }
+      }
+      return true;
+    }, TestHelper.WAIT_DURATION);
+  }
+
+  @Test
+  public void testPartialPartitionDisable() throws Exception {
+    String dbName = generateUniqueResourceName("PartialPartitionDisable");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+
+    // Wait for stabilization
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == PARTITIONS;
+    }, 8000);
+
+    // Disable multiple partitions on the same instance
+    ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+    Map<String, String> instancePartitions = new HashMap<>();
+    for (String partition : ev.getPartitionSet()) {
+      Map<String, String> stateMap = ev.getStateMap(partition);
+      if (stateMap != null && stateMap.containsKey(_instanceNames[0])) {
+        instancePartitions.put(partition, stateMap.get(_instanceNames[0]));
+      }
+    }
+
+    // Take first 2 partitions from the target instance
+    String[] partitionsToDisable = instancePartitions.keySet().stream()
+        .limit(2)
+        .toArray(String[]::new);
+
+    if (partitionsToDisable.length >= 2) {
+      _gSetupTool.getClusterManagementTool().enablePartition(false, _clusterName, _instanceNames[0],
+          dbName, java.util.Arrays.asList(partitionsToDisable));
+      _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+      // Validate that disabled partitions are not on the instance
+      for (String partition : partitionsToDisable) {
+        validatePartitionDisabledBehavior(dbName, partition, _instanceNames[0]);
+      }
+
+      // Validate that other partitions can still be on the instance
+      TestHelper.verify(() -> {
+        ExternalView extView = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+        if (extView == null) return false;
+
+        // Check if instance still has some partitions (not the disabled ones)
+        for (String partition : extView.getPartitionSet()) {
+          if (!java.util.Arrays.asList(partitionsToDisable).contains(partition)) {
+            Map<String, String> stateMap = extView.getStateMap(partition);
+            if (stateMap != null && stateMap.containsKey(_instanceNames[0])) {
+              String state = stateMap.get(_instanceNames[0]);
+              if (!OFFLINE.equals(state) && !"DROPPED".equals(state)) {
+                return true; // Found at least one active partition
+              }
+            }
+          }
+        }
+        return false;
+      }, TestHelper.WAIT_DURATION);
+    }
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalancerRelaxedDisabledPartitionConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/WagedRebalancer/TestWagedRebalancerRelaxedDisabledPartitionConstraint.java
@@ -1,0 +1,735 @@
+package org.apache.helix.integration.rebalancer.WagedRebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.ResourceConfig;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+/**
+ * Integration tests for the relaxed disabled partition constraint feature in WAGED rebalancer.
+ * This test class verifies that when the relaxed constraint is enabled, disabled partitions
+ * remain OFFLINE instead of being reassigned (CrushEd-like behavior).
+ */
+public class TestWagedRebalancerRelaxedDisabledPartitionConstraint extends ZkTestBase {
+  private static final int NUM_NODE = 6;
+  private static final int START_PORT = 12918;
+  private static final int PARTITIONS = 20;
+  private static final int REPLICAS = 3;
+  private static final String OFFLINE = "OFFLINE";
+
+  private final String _className = getShortClassName();
+  private final String _clusterName = CLUSTER_PREFIX + "_" + _className;
+  private ClusterControllerManager _controller;
+  private MockParticipantManager[] _participants;
+  private String[] _instanceNames;
+
+  @BeforeClass
+  @Override
+  public void beforeClass() throws Exception {
+    System.out.println("START " + _className + " at " + new Date(System.currentTimeMillis()));
+    _gSetupTool.addCluster(_clusterName, true);
+    _gSetupTool.getClusterManagementTool().addStateModelDef(_clusterName, "MasterSlave",
+        BuiltInStateModelDefinitions.MasterSlave.getStateModelDefinition());
+
+    // Enable delayed rebalance at cluster level
+    enableDelayRebalanceInCluster(_gZkClient, _clusterName, true, 5000); // Default 5 second delay
+
+    _participants = new MockParticipantManager[NUM_NODE];
+    _instanceNames = new String[NUM_NODE];
+    for (int i = 0; i < NUM_NODE; i++) {
+      String instanceName = PARTICIPANT_PREFIX + "_" + (START_PORT + i);
+      _gSetupTool.addInstanceToCluster(_clusterName, instanceName);
+      _instanceNames[i] = instanceName;
+    }
+
+    // start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, _clusterName, controllerName);
+    _controller.syncStart();
+
+    // start participants
+    for (int i = 0; i < NUM_NODE; i++) {
+      _participants[i] = new MockParticipantManager(ZK_ADDR, _clusterName, _instanceNames[i]);
+      _participants[i].syncStart();
+    }
+  }
+
+  @AfterClass
+  public void afterClass() {
+    if (_controller != null && _controller.isConnected()) {
+      _controller.syncStop();
+    }
+    for (int i = 0; i < NUM_NODE; i++) {
+      if (_participants[i] != null && _participants[i].isConnected()) {
+        _participants[i].syncStop();
+      }
+    }
+    deleteCluster(_clusterName);
+    System.out.println("END " + _className + " at " + new Date(System.currentTimeMillis()));
+  }
+
+  @BeforeMethod
+  public void beforeMethod() throws Exception {
+    // Ensure all instances are enabled before each test
+    enableAllInstances();
+
+    // Wait for cluster to be ready and all participants to be connected
+    TestHelper.verify(new TestHelper.Verifier() {
+      @Override
+      public boolean verify() throws Exception {
+        if (!_gSetupTool.getClusterManagementTool().getClusters().contains(_clusterName)) {
+          return false;
+        }
+        // Ensure all participants are connected
+        for (MockParticipantManager participant : _participants) {
+          if (!participant.isConnected()) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }, TestHelper.WAIT_DURATION);
+  }
+
+  @AfterMethod
+  public void afterMethod() {
+    // Clean up resources created during the test
+    cleanupResourcesAndResetInstances();
+    // Clean up any cluster/resource level configs we may have set
+    resetClusterConfigToDefault();
+  }
+
+  // ====================================
+  // Backward Compatibility Tests
+  // ====================================
+
+  @Test
+  public void testBackwardCompatibility_PartitionDisabled_RelaxedModeDisabled() throws Exception {
+    // Test that existing behavior is preserved when relaxed mode is disabled (default)
+    String dbName = generateUniqueResourceName("BackwardCompatPartitionDisabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    
+    // Wait for convergence and find a partition on target instance
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == PARTITIONS && 
+             findPartitionOnInstance(dbName, _instanceNames[0]) != null;
+    }, TestHelper.WAIT_DURATION);
+
+    String partitionToDisable = findPartitionOnInstance(dbName, _instanceNames[0]);
+    Assert.assertNotNull(partitionToDisable, "No partition found on target instance");
+
+    // Disable the partition on the instance
+    _gSetupTool.getClusterManagementTool().enablePartition(false, _clusterName, _instanceNames[0],
+        dbName, Collections.singletonList(partitionToDisable));
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // With relaxed mode disabled (default behavior), partition should be reassigned away
+    validatePartitionDisabledBehavior(dbName, partitionToDisable, _instanceNames[0]);
+  }
+
+  @Test
+  public void testBackwardCompatibility_AllResourcesDisabled_RelaxedModeDisabled() throws Exception {
+    // Test that existing behavior is preserved when relaxed mode is disabled (default)
+    String dbName = generateUniqueResourceName("BackwardCompatAllResourcesDisabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+
+    // Disable all resources on the instance (instance level disable)
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // With relaxed mode disabled (default behavior), all replicas should be evacuated
+    validateExternalView(dbName, _instanceNames[0]);
+  }
+
+  // ====================================
+  // Cluster-Level Relaxed Mode Tests
+  // ====================================
+
+  @Test
+  public void testClusterLevel_PartitionDisabled_RelaxedModeEnabled() throws Exception {
+    String dbName = generateUniqueResourceName("ClusterLevelPartitionDisabled");
+    
+    // Enable relaxed mode at cluster level
+    enableRelaxedConstraintAtClusterLevel(true);
+    
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    
+    // Wait for convergence and find a partition on target instance
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == PARTITIONS && 
+             findPartitionOnInstance(dbName, _instanceNames[0]) != null;
+    }, TestHelper.WAIT_DURATION);
+
+    String partitionToDisable = findPartitionOnInstance(dbName, _instanceNames[0]);
+    Assert.assertNotNull(partitionToDisable, "No partition found on target instance");
+    
+    // Get initial state before disabling
+    String initialState = getPartitionStateOnInstance(dbName, partitionToDisable, _instanceNames[0]);
+    Assert.assertNotNull(initialState, "Partition should have a state initially");
+
+    // Disable the partition on the instance
+    _gSetupTool.getClusterManagementTool().enablePartition(false, _clusterName, _instanceNames[0],
+        dbName, Collections.singletonList(partitionToDisable));
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // With relaxed mode enabled, partition should remain on the instance but in OFFLINE state
+    validatePartitionRemainsOfflineOnInstance(dbName, partitionToDisable, _instanceNames[0]);
+  }
+
+  @Test
+  public void testClusterLevel_AllResourcesDisabled_RelaxedModeEnabled() throws Exception {
+    String dbName = generateUniqueResourceName("ClusterLevelAllResourcesDisabled");
+    
+    // Enable relaxed mode at cluster level
+    enableRelaxedConstraintAtClusterLevel(true);
+    
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    
+    // Wait for initial assignment and record partitions on target instance
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == PARTITIONS;
+    }, TestHelper.WAIT_DURATION);
+
+    Map<String, String> initialAssignment = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+    Assert.assertFalse(initialAssignment.isEmpty(), "Instance should have partitions initially");
+
+    // Disable all resources on the instance
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // With relaxed mode enabled, partitions should remain on instance but in OFFLINE state
+    validatePartitionsRemainOfflineOnInstance(dbName, _instanceNames[0], initialAssignment.keySet());
+  }
+
+  // ====================================
+  // Resource-Level Relaxed Mode Tests
+  // ====================================
+
+  @Test
+  public void testResourceLevel_PartitionDisabled_RelaxedModeEnabled() throws Exception {
+    String dbName = generateUniqueResourceName("ResourceLevelPartitionDisabled");
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    
+    // Enable relaxed mode at resource level
+    enableRelaxedConstraintAtResourceLevel(dbName, true);
+    
+    // Wait for convergence and find a partition on target instance
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == PARTITIONS && 
+             findPartitionOnInstance(dbName, _instanceNames[0]) != null;
+    }, TestHelper.WAIT_DURATION);
+
+    String partitionToDisable = findPartitionOnInstance(dbName, _instanceNames[0]);
+    Assert.assertNotNull(partitionToDisable, "No partition found on target instance");
+
+    // Disable the partition on the instance
+    _gSetupTool.getClusterManagementTool().enablePartition(false, _clusterName, _instanceNames[0],
+        dbName, Collections.singletonList(partitionToDisable));
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // With relaxed mode enabled at resource level, partition should remain OFFLINE on instance
+    validatePartitionRemainsOfflineOnInstance(dbName, partitionToDisable, _instanceNames[0]);
+  }
+
+  @Test
+  public void testResourceLevel_OverridesClusterLevel() throws Exception {
+    String dbName1 = generateUniqueResourceName("ResourceOverrideEnabled");
+    String dbName2 = generateUniqueResourceName("ResourceOverrideDisabled");
+    
+    // Enable relaxed mode at cluster level
+    enableRelaxedConstraintAtClusterLevel(true);
+    
+    createResourceWithWagedRebalance(dbName1, PARTITIONS, REPLICAS);
+    createResourceWithWagedRebalance(dbName2, PARTITIONS, REPLICAS);
+    
+    // Override at resource level: dbName1 inherits cluster setting (enabled), dbName2 is explicitly disabled
+    enableRelaxedConstraintAtResourceLevel(dbName2, false);
+    
+    // Wait for convergence
+    TestHelper.verify(() -> {
+      ExternalView ev1 = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName1);
+      ExternalView ev2 = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName2);
+      return ev1 != null && ev1.getPartitionSet().size() == PARTITIONS &&
+             ev2 != null && ev2.getPartitionSet().size() == PARTITIONS &&
+             findPartitionOnInstance(dbName1, _instanceNames[0]) != null &&
+             findPartitionOnInstance(dbName2, _instanceNames[0]) != null;
+    }, TestHelper.WAIT_DURATION);
+
+    String partition1 = findPartitionOnInstance(dbName1, _instanceNames[0]);
+    String partition2 = findPartitionOnInstance(dbName2, _instanceNames[0]);
+    
+    // Disable partitions on both resources
+    _gSetupTool.getClusterManagementTool().enablePartition(false, _clusterName, _instanceNames[0],
+        dbName1, Collections.singletonList(partition1));
+    _gSetupTool.getClusterManagementTool().enablePartition(false, _clusterName, _instanceNames[0],
+        dbName2, Collections.singletonList(partition2));
+    
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName1, REPLICAS);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName2, REPLICAS);
+
+    // dbName1 should use cluster setting (relaxed enabled) - partition stays OFFLINE
+    validatePartitionRemainsOfflineOnInstance(dbName1, partition1, _instanceNames[0]);
+    
+    // dbName2 should use resource override (relaxed disabled) - partition gets reassigned
+    validatePartitionDisabledBehavior(dbName2, partition2, _instanceNames[0]);
+  }
+
+  // ====================================
+  // Mixed Scenarios Tests
+  // ====================================
+
+  @Test
+  public void testMixedResources_DifferentRelaxedSettings() throws Exception {
+    String dbNameRelaxed = generateUniqueResourceName("MixedRelaxedEnabled");
+    String dbNameStrict = generateUniqueResourceName("MixedRelaxedDisabled");
+    
+    createResourceWithWagedRebalance(dbNameRelaxed, PARTITIONS, REPLICAS);
+    createResourceWithWagedRebalance(dbNameStrict, PARTITIONS, REPLICAS);
+    
+    // Set different relaxed modes for different resources
+    enableRelaxedConstraintAtResourceLevel(dbNameRelaxed, true);
+    enableRelaxedConstraintAtResourceLevel(dbNameStrict, false);
+    
+    // Wait for convergence
+    TestHelper.verify(() -> {
+      ExternalView ev1 = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbNameRelaxed);
+      ExternalView ev2 = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbNameStrict);
+      return ev1 != null && ev1.getPartitionSet().size() == PARTITIONS &&
+             ev2 != null && ev2.getPartitionSet().size() == PARTITIONS;
+    }, TestHelper.WAIT_DURATION);
+
+    // Disable all resources on an instance
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbNameRelaxed, REPLICAS);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbNameStrict, REPLICAS);
+
+    // Resource with relaxed mode enabled should keep partitions OFFLINE on disabled instance
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbNameRelaxed);
+      if (ev == null) return false;
+      
+      for (String partition : ev.getPartitionSet()) {
+        Map<String, String> stateMap = ev.getStateMap(partition);
+        if (stateMap != null && stateMap.containsKey(_instanceNames[0])) {
+          String state = stateMap.get(_instanceNames[0]);
+          if (!OFFLINE.equals(state)) {
+            return false; // Should be OFFLINE
+          }
+        }
+      }
+      return true;
+    }, TestHelper.WAIT_DURATION);
+
+    // Resource with relaxed mode disabled should evacuate partitions from disabled instance
+    validateExternalView(dbNameStrict, _instanceNames[0]);
+  }
+
+  @Test
+  public void testRelaxedMode_WithDelayedRebalance() throws Exception {
+    String dbName = generateUniqueResourceName("RelaxedModeWithDelay");
+    
+    // Enable relaxed mode at cluster level
+    enableRelaxedConstraintAtClusterLevel(true);
+    
+    createResourceWithDelayedRebalance(dbName, PARTITIONS, REPLICAS, 5000); // 5 second delay
+    
+    // Wait for initial assignment
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == PARTITIONS;
+    }, TestHelper.WAIT_DURATION);
+
+    Map<String, String> initialAssignment = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+    Assert.assertFalse(initialAssignment.isEmpty(), "Instance should have partitions initially");
+
+    // Disable instance
+    disableInstance(_instanceNames[0]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // With relaxed mode + delayed rebalance: partitions should stay OFFLINE during and after delay
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null) return false;
+      
+      for (String partition : initialAssignment.keySet()) {
+        Map<String, String> stateMap = ev.getStateMap(partition);
+        if (stateMap == null || !stateMap.containsKey(_instanceNames[0])) {
+          return false; // Partition should still be on the instance
+        }
+        String state = stateMap.get(_instanceNames[0]);
+        if (!OFFLINE.equals(state)) {
+          return false; // Should be OFFLINE
+        }
+      }
+      return true;
+    }, 8000); // Wait longer than delay period
+  }
+
+  // ====================================
+  // Edge Cases and Error Scenarios
+  // ====================================
+
+  @Test
+  public void testRelaxedMode_MultipleInstancesDisabled() throws Exception {
+    String dbName = generateUniqueResourceName("RelaxedModeMultipleInstances");
+    
+    // Enable relaxed mode at cluster level
+    enableRelaxedConstraintAtClusterLevel(true);
+    
+    createResourceWithWagedRebalance(dbName, PARTITIONS, REPLICAS);
+    
+    // Wait for convergence
+    TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      return ev != null && ev.getPartitionSet().size() == PARTITIONS;
+    }, TestHelper.WAIT_DURATION);
+
+    // Record initial assignments
+    Map<String, String> assignment1 = getPartitionAssignmentForInstance(dbName, _instanceNames[0]);
+    Map<String, String> assignment2 = getPartitionAssignmentForInstance(dbName, _instanceNames[1]);
+
+    // Disable multiple instances
+    disableInstance(_instanceNames[0]);
+    disableInstance(_instanceNames[1]);
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, REPLICAS);
+
+    // With relaxed mode, partitions should stay OFFLINE on both disabled instances
+    if (!assignment1.isEmpty()) {
+      validatePartitionsRemainOfflineOnInstance(dbName, _instanceNames[0], assignment1.keySet());
+    }
+    if (!assignment2.isEmpty()) {
+      validatePartitionsRemainOfflineOnInstance(dbName, _instanceNames[1], assignment2.keySet());
+    }
+  }
+
+  // ====================================
+  // Helper Methods
+  // ====================================
+
+  private void enableRelaxedConstraintAtClusterLevel(boolean enabled) {
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(_clusterName);
+    clusterConfig.setRelaxedDisabledPartitionConstraint(enabled);
+    configAccessor.setClusterConfig(_clusterName, clusterConfig);
+  }
+
+  private void enableRelaxedConstraintAtResourceLevel(String resourceName, boolean enabled) {
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ResourceConfig resourceConfig = configAccessor.getResourceConfig(_clusterName, resourceName);
+    if (resourceConfig == null) {
+      resourceConfig = new ResourceConfig(resourceName);
+    }
+    resourceConfig.setRelaxedDisabledPartitionConstraint(enabled);
+    configAccessor.setResourceConfig(_clusterName, resourceName, resourceConfig);
+  }
+
+  private void resetClusterConfigToDefault() {
+    try {
+      ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+      ClusterConfig clusterConfig = configAccessor.getClusterConfig(_clusterName);
+      clusterConfig.setRelaxedDisabledPartitionConstraint(false); // Default is disabled
+      configAccessor.setClusterConfig(_clusterName, clusterConfig);
+    } catch (Exception e) {
+      // Ignore - cluster might not exist yet during setup
+    }
+  }
+
+  private String getPartitionStateOnInstance(String dbName, String partition, String instance) {
+    ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+    if (ev == null) return null;
+    
+    Map<String, String> stateMap = ev.getStateMap(partition);
+    return stateMap != null ? stateMap.get(instance) : null;
+  }
+
+  private void validatePartitionRemainsOfflineOnInstance(String dbName, String partition, String instance) throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null) return false;
+      
+      Map<String, String> stateMap = ev.getStateMap(partition);
+      if (stateMap == null || !stateMap.containsKey(instance)) {
+        return false; // Partition should still be on the instance
+      }
+      
+      String state = stateMap.get(instance);
+      return OFFLINE.equals(state); // Should be OFFLINE, not reassigned
+    }, TestHelper.WAIT_DURATION), "Partition " + partition + " should remain OFFLINE on instance " + instance);
+  }
+
+  private void validatePartitionsRemainOfflineOnInstance(String dbName, String instance, Iterable<String> partitions) throws Exception {
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+      if (ev == null) return false;
+      
+      for (String partition : partitions) {
+        Map<String, String> stateMap = ev.getStateMap(partition);
+        if (stateMap == null || !stateMap.containsKey(instance)) {
+          return false; // Partition should still be on the instance
+        }
+        
+        String state = stateMap.get(instance);
+        if (!OFFLINE.equals(state)) {
+          return false; // Should be OFFLINE
+        }
+      }
+      return true;
+    }, TestHelper.WAIT_DURATION), "All partitions should remain OFFLINE on instance " + instance);
+  }
+
+  private void disableInstance(String instanceName) {
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(_clusterName, instanceName,
+        InstanceConstants.InstanceOperation.DISABLE);
+  }
+
+  private String generateUniqueResourceName(String testName) {
+    return "TestDB_" + testName + "_" + System.currentTimeMillis();
+  }
+
+  // Additional helper methods from parent class
+  protected void createResourceWithWagedRebalance(String dbName, int partitions, int replicas) throws Exception {
+    IdealState idealState =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(_clusterName, dbName);
+    if (idealState == null) {
+      idealState = new IdealState(dbName);
+      idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+      idealState.setNumPartitions(partitions);
+      idealState.setReplicas(String.valueOf(replicas));
+      idealState.setMinActiveReplicas(2);
+      idealState.setRebalancerClassName(
+          "org.apache.helix.controller.rebalancer.waged.WagedRebalancer");
+      idealState.setRebalanceStrategy(
+          "org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy");
+      idealState.setStateModelDefRef("MasterSlave");
+      idealState.setStateModelFactoryName("DEFAULT");
+      _gSetupTool.getClusterManagementTool().addResource(_clusterName, dbName, idealState);
+    }
+    // Explicit rebalance call is still needed to trigger rebalancing
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, replicas);
+
+    // Wait for the resource to be properly assigned
+    Assert.assertTrue(TestHelper.verify(new TestHelper.Verifier() {
+      @Override
+      public boolean verify() throws Exception {
+        ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+        return ev != null && ev.getPartitionSet().size() == partitions;
+      }
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  protected void createResourceWithDelayedRebalance(String dbName, int partitions, int replicas, int delay) throws Exception {
+    IdealState idealState =
+        _gSetupTool.getClusterManagementTool().getResourceIdealState(_clusterName, dbName);
+    if (idealState == null) {
+      idealState = new IdealState(dbName);
+      idealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+      idealState.setNumPartitions(partitions);
+      idealState.setReplicas(String.valueOf(replicas));
+      idealState.setMinActiveReplicas(2);
+      idealState.setRebalancerClassName(
+          "org.apache.helix.controller.rebalancer.waged.WagedRebalancer");
+      idealState.setRebalanceStrategy(
+          "org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy");
+      idealState.setStateModelDefRef("MasterSlave");
+      idealState.setStateModelFactoryName("DEFAULT");
+      idealState.setRebalanceDelay(delay);
+      idealState.setDelayRebalanceEnabled(true); // Enable delayed rebalance feature
+      _gSetupTool.getClusterManagementTool().addResource(_clusterName, dbName, idealState);
+    }
+    // Explicit rebalance call is still needed to trigger rebalancing
+    _gSetupTool.getClusterManagementTool().rebalance(_clusterName, dbName, replicas);
+
+    // Wait for the resource to be properly assigned
+    Assert.assertTrue(TestHelper.verify(new TestHelper.Verifier() {
+      @Override
+      public boolean verify() throws Exception {
+        ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+        return ev != null && ev.getPartitionSet().size() == partitions;
+      }
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  protected String findPartitionOnInstance(String dbName, String instanceName) {
+    ExternalView externalView =
+        _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+    if (externalView == null) {
+      return null;
+    }
+
+    for (String partitionName : externalView.getPartitionSet()) {
+      Map<String, String> stateMap = externalView.getStateMap(partitionName);
+      if (stateMap != null && stateMap.containsKey(instanceName)) {
+        return partitionName;
+      }
+    }
+    return null;
+  }
+
+  protected Map<String, String> getPartitionAssignmentForInstance(String dbName, String instanceName) {
+    ExternalView externalView =
+        _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+    if (externalView == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> assignments = new HashMap<>();
+    for (String partition : externalView.getPartitionSet()) {
+      Map<String, String> stateMap = externalView.getStateMap(partition);
+      if (stateMap != null && stateMap.containsKey(instanceName)) {
+        assignments.put(partition, stateMap.get(instanceName));
+      }
+    }
+    return assignments;
+  }
+
+  protected void validateExternalView(String dbName, String disabledInstance) throws Exception {
+    Assert.assertTrue(TestHelper.verify(new TestHelper.Verifier() {
+      @Override
+      public boolean verify() throws Exception {
+        ExternalView externalView =
+            _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+        if (externalView == null) {
+          return false;
+        }
+        for (String partitionName : externalView.getPartitionSet()) {
+          Map<String, String> stateMap = externalView.getStateMap(partitionName);
+          if (stateMap == null) {
+            return false;
+          }
+          if (stateMap.containsKey(disabledInstance)) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  protected void validatePartitionDisabledBehavior(String dbName, String partitionName, String disabledInstance) throws Exception {
+    Assert.assertTrue(TestHelper.verify(new TestHelper.Verifier() {
+      @Override
+      public boolean verify() throws Exception {
+        ExternalView externalView =
+            _gSetupTool.getClusterManagementTool().getResourceExternalView(_clusterName, dbName);
+        if (externalView == null) {
+          return false;
+        }
+        Map<String, String> stateMap = externalView.getStateMap(partitionName);
+        if (stateMap == null) {
+          return false; // Partition should still exist
+        }
+
+        // For WAGED rebalancer with FULL_AUTO mode, when a partition is disabled on an instance:
+        // 1. The disabled instance should not have this partition in active state
+        // 2. The partition should maintain some active replicas on other instances
+
+        // Check that the disabled instance does not have this partition in active states
+        boolean partitionNotActiveOnDisabledInstance = true;
+        if (stateMap.containsKey(disabledInstance)) {
+          String state = stateMap.get(disabledInstance);
+          // If the partition exists on disabled instance, it should be in OFFLINE state or DROPPED
+          if (!OFFLINE.equals(state) && !"DROPPED".equals(state)) {
+            partitionNotActiveOnDisabledInstance = false;
+          }
+        }
+
+        if (!partitionNotActiveOnDisabledInstance) {
+          return false;
+        }
+
+        // Check that the partition has some active replicas on other instances
+        long activeReplicas = stateMap.values().stream()
+            .filter(state -> !OFFLINE.equals(state) && !"DROPPED".equals(state))
+            .count();
+
+        // Should have at least 1 active replica (preferably meet min active replicas)
+        // But in some edge cases with partition disable, we might have less than ideal replica count
+        return activeReplicas >= 1;
+      }
+    }, TestHelper.WAIT_DURATION));
+  }
+
+  private void enableAllInstances() {
+    for (String instanceName : _instanceNames) {
+      _gSetupTool.getClusterManagementTool().setInstanceOperation(_clusterName, instanceName,
+          InstanceConstants.InstanceOperation.ENABLE);
+
+      // Also re-enable all partitions on the instance for all resources
+      try {
+        for (String resourceName : _gSetupTool.getClusterManagementTool().getResourcesInCluster(_clusterName)) {
+          _gSetupTool.getClusterManagementTool().resetPartition(_clusterName, instanceName, resourceName, Collections.emptyList());
+        }
+      } catch (Exception e) {
+        // Ignore errors during cleanup - might not have resources yet
+      }
+    }
+  }
+
+  private void cleanupResourcesAndResetInstances() {
+    try {
+      // Remove all resources that were created during tests
+      for (String resourceName : _gSetupTool.getClusterManagementTool().getResourcesInCluster(_clusterName)) {
+        if (resourceName.startsWith("TestDB_")) {
+          _gSetupTool.getClusterManagementTool().dropResource(_clusterName, resourceName);
+        }
+      }
+
+      // Re-enable all instances to clean state
+      enableAllInstances();
+
+      // Wait for cleanup to take effect
+      TestHelper.verify(new TestHelper.Verifier() {
+        @Override
+        public boolean verify() throws Exception {
+          long testResourceCount = _gSetupTool.getClusterManagementTool().getResourcesInCluster(_clusterName)
+              .stream().filter(name -> name.startsWith("TestDB_")).count();
+          return testResourceCount == 0;
+        }
+      }, 5000);
+
+    } catch (Exception e) {
+      System.err.println("Warning: Error during test cleanup: " + e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces an optional feature to make WAGED rebalancer behavior more consistent with CrushEd for disabled partition scenarios. When enabled, disabled partitions remain in OFFLINE state on their current instances rather than being immediately reassigned.

### Description

Current WAGED behavior differs significantly from CrushEd for disabled partitions:
- **Instance Disabled**: WAGED respects delay window (✓ correct)
- **Partition Disabled**: WAGED immediately reassigns due to hard constraint (✗ inconsistent)  
- **ALL_RESOURCES Disabled**: WAGED immediately reassigns (✗ inconsistent)

This inconsistency creates challenges for users migrating from CrushEd or expecting
uniform behavior across rebalancer strategies.

### Configuration Infrastructure
- **ClusterConfig**: New `relaxedDisabledPartitionConstraint` property with cluster-level default
- **ResourceConfig**: Resource-level override capability with proper inheritance
- **Backward Compatibility**: Feature disabled by default, no impact on existing deployments

### Core Implementation  
- **ReplicaActivateConstraint**: Enhanced with conditional logic to bypass hard constraint
  when relaxed mode is enabled for the resource
- **ClusterContext**: New method `isRelaxedDisabledPartitionConstraintEnabled()` with 
  proper resource-level override resolution

### Key Behavioral Changes (when enabled)
1. **Partition Disabled**: Partitions stay OFFLINE on current instance instead of reassignment
2. **ALL_RESOURCES Disabled**: All partitions stay OFFLINE on current instance  
3. **Instance Disabled**: No change - continues to respect delay window as before
4. **Delayed Rebalance**: Works in conjunction with existing delay mechanisms

### Tests

### Integration Test Categories  
1. **Backward Compatibility** (2 tests): Ensures existing behavior unchanged when disabled
2. **Cluster-Level Configuration** (2 tests): Validates cluster-wide relaxed mode
3. **Resource-Level Configuration** (2 tests): Tests resource overrides and inheritance  
4. **Mixed Scenarios** (3 tests): Complex multi-resource and delay window interactions

### Validation Methods
- `validatePartitionRemainsOfflineOnInstance()`: Confirms CrushEd-like behavior
- `validatePartitionDisabledBehavior()`: Ensures proper reassignment when disabled
- Comprehensive delay window and MinActiveReplica constraint testing
