### PR TITLE
Validate instance config has fault zone type key

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -265,7 +265,8 @@ public class Topology {
           String value = domainAsMap.get(key);
           if (value == null || value.isEmpty()) {
             value = clusterTopologyConfig.getTopologyKeyDefaultValue().get(key);
-            if (clusterTopologyConfig.getRequiredMatchingTopologyKeys().contains(key)) {
+            if (!clusterTopologyConfig.isDisableFaultZoneTypeToInstanceTopologyMatching()
+                && key.equals(clusterTopologyConfig.getFaultZoneType())) {
               shouldThrowExceptionDueToMissingConfigs = true;
             }
           } else {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -259,15 +259,14 @@ public class Topology {
                   instanceName));
         }
         int numOfMatchedKeys = 0;
-        boolean shouldThrowExceptionDueToMissingConfigs = false;
+        boolean missingRequiredFaultZoneKey = false;
         for (String key : clusterTopologyConfig.getTopologyKeyDefaultValue().keySet()) {
           // if a key does not exist in the instance domain config, using the default domain value.
           String value = domainAsMap.get(key);
           if (value == null || value.isEmpty()) {
             value = clusterTopologyConfig.getTopologyKeyDefaultValue().get(key);
-            if (clusterTopologyConfig.isTopologyAwareEnabled()
-                    && key.equals(clusterTopologyConfig.getFaultZoneType())) {
-              shouldThrowExceptionDueToMissingConfigs = true;
+            if (key.equals(clusterTopologyConfig.getFaultZoneType())) {
+                missingRequiredFaultZoneKey = true;
             }
           } else {
             numOfMatchedKeys++;
@@ -282,7 +281,7 @@ public class Topology {
               String.format("Instance %s does not have all the keys in ClusterConfig. Topology %s.", instanceName,
                   clusterTopologyConfig.getTopologyKeyDefaultValue().keySet());
           logger.warn(errorMessage);
-          if (shouldThrowExceptionDueToMissingConfigs) {
+          if (missingRequiredFaultZoneKey) {
             throw new InstanceConfigMismatchException(errorMessage);
           }
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -265,8 +265,8 @@ public class Topology {
           String value = domainAsMap.get(key);
           if (value == null || value.isEmpty()) {
             value = clusterTopologyConfig.getTopologyKeyDefaultValue().get(key);
-            if (!clusterTopologyConfig.isDisableFaultZoneTypeToInstanceTopologyMatching()
-                && key.equals(clusterTopologyConfig.getFaultZoneType())) {
+            if (clusterTopologyConfig.isTopologyAwareEnabled()
+                    && key.equals(clusterTopologyConfig.getFaultZoneType())) {
               shouldThrowExceptionDueToMissingConfigs = true;
             }
           } else {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -619,8 +619,9 @@ public class ClusterModelProvider {
           } catch (IllegalArgumentException e) {
             // Log the filtering of invalid instance configuration
             // This helps with debugging when instances are unexpectedly excluded
-            logger.warn("Instance {} has invalid configuration and will be excluded from the assignable nodes: {}",
-                instanceName, e.getMessage());
+            logger.warn(
+                "Instance {} of cluster {} has invalid configuration and will be excluded from the assignable nodes: {}",
+                instanceName, clusterConfig.getClusterName(), e.getMessage());
             return null;
           }
         })

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -172,8 +172,8 @@ public class ClusterConfig extends HelixProperty {
     // Allow disabled partitions to remain OFFLINE instead of being reassigned in WAGED rebalancer
     RELAXED_DISABLED_PARTITION_CONSTRAINT,
 
-    // Ignore instances which do not match the required topology keys of the cluster
-    REQUIRED_INSTANCE_TOPOLOGY_KEYS,
+    // Do not ignore instances which do not match the fault zone type of the cluster
+    DISABLE_FAULT_ZONE_TYPE_TO_INSTANCE_TOPOLOGY_MATCHING,
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -894,24 +894,19 @@ public class ClusterConfig extends HelixProperty {
   }
 
   /**
-   * Get the required Instance Topology Keys. If not configured, return an empty list.
-   * @return a list of required topology keys
+   * Whether to ignore instances which do not match the fault zone type of the cluster
+   * @return true if disable fault zone type to instance topology matching, false otherwise
    */
-  public List<String> getRequiredInstanceTopologyKeys() {
-    List<String> topologyKeys = _record.getListField(ClusterConfigProperty.REQUIRED_INSTANCE_TOPOLOGY_KEYS.name());
-    if (topologyKeys == null) {
-      return Collections.emptyList();
-    }
-    return Collections.unmodifiableList(topologyKeys);
+  public boolean isDisableFaultZoneTypeToInstanceTopologyMatching() {
+    return _record.getBooleanField(ClusterConfigProperty.DISABLE_FAULT_ZONE_TYPE_TO_INSTANCE_TOPOLOGY_MATCHING.name(), false);
   }
 
   /**
-   * Set the required Instance Topology Keys which must be present on all instances in the cluster
-   * if they are present in cluster config.
-   * @param topologyKeys
+   * Set whether to ignore instances which do not match the fault zone type of the cluster
+   * @param disable
    */
-  public void setRequiredInstanceTopologyKeys(List<String> topologyKeys) {
-    _record.setListField(ClusterConfigProperty.REQUIRED_INSTANCE_TOPOLOGY_KEYS.name(), topologyKeys);
+  public void setDisableFaultZoneTypeToInstanceTopologyMatching(boolean disable) {
+    _record.setBooleanField(ClusterConfigProperty.DISABLE_FAULT_ZONE_TYPE_TO_INSTANCE_TOPOLOGY_MATCHING.name(), disable);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -171,9 +171,6 @@ public class ClusterConfig extends HelixProperty {
 
     // Allow disabled partitions to remain OFFLINE instead of being reassigned in WAGED rebalancer
     RELAXED_DISABLED_PARTITION_CONSTRAINT,
-
-    // Do not ignore instances which do not match the fault zone type of the cluster
-    DISABLE_FAULT_ZONE_TYPE_TO_INSTANCE_TOPOLOGY_MATCHING,
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -891,22 +888,6 @@ public class ClusterConfig extends HelixProperty {
    */
   public void setRelaxedDisabledPartitionConstraint(boolean enabled) {
     _record.setBooleanField(ClusterConfigProperty.RELAXED_DISABLED_PARTITION_CONSTRAINT.name(), enabled);
-  }
-
-  /**
-   * Whether to ignore instances which do not match the fault zone type of the cluster
-   * @return true if disable fault zone type to instance topology matching, false otherwise
-   */
-  public boolean isDisableFaultZoneTypeToInstanceTopologyMatching() {
-    return _record.getBooleanField(ClusterConfigProperty.DISABLE_FAULT_ZONE_TYPE_TO_INSTANCE_TOPOLOGY_MATCHING.name(), false);
-  }
-
-  /**
-   * Set whether to ignore instances which do not match the fault zone type of the cluster
-   * @param disable
-   */
-  public void setDisableFaultZoneTypeToInstanceTopologyMatching(boolean disable) {
-    _record.setBooleanField(ClusterConfigProperty.DISABLE_FAULT_ZONE_TYPE_TO_INSTANCE_TOPOLOGY_MATCHING.name(), disable);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterTopologyConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterTopologyConfig.java
@@ -32,15 +32,13 @@ public class ClusterTopologyConfig {
   private final String _endNodeType;
   private final String _faultZoneType;
   private final LinkedHashMap<String, String> _topologyKeyDefaultValue;
-  private final boolean _disableFaultZoneTypeToInstanceTopologyMatching;
 
   private ClusterTopologyConfig(boolean topologyAwareEnabled, String endNodeType, String faultZoneType,
-      LinkedHashMap<String, String> topologyKeyDefaultValue, boolean disableFaultZoneTypeToInstanceTopologyMatching) {
+      LinkedHashMap<String, String> topologyKeyDefaultValue) {
     _topologyAwareEnabled = topologyAwareEnabled;
     _endNodeType = endNodeType;
     _faultZoneType = faultZoneType;
     _topologyKeyDefaultValue = topologyKeyDefaultValue;
-    _disableFaultZoneTypeToInstanceTopologyMatching = disableFaultZoneTypeToInstanceTopologyMatching;
   }
 
   /**
@@ -55,8 +53,7 @@ public class ClusterTopologyConfig {
           false,
           Topology.Types.INSTANCE.name(),
           Topology.Types.INSTANCE.name(),
-          new LinkedHashMap<>(),
-          true);
+          new LinkedHashMap<>());
     }
     // Assign default cluster topology definition, i,e. /root/zone/instance
     String endNodeType = Topology.Types.INSTANCE.name();
@@ -83,8 +80,7 @@ public class ClusterTopologyConfig {
                 faultZoneType, clusterConfig.getTopology()));
       }
     }
-    return new ClusterTopologyConfig(true, endNodeType, faultZoneType, topologyKeyDefaultValue,
-        clusterConfig.isDisableFaultZoneTypeToInstanceTopologyMatching());
+    return new ClusterTopologyConfig(true, endNodeType, faultZoneType, topologyKeyDefaultValue);
   }
 
   public boolean isTopologyAwareEnabled() {
@@ -101,9 +97,5 @@ public class ClusterTopologyConfig {
 
   public LinkedHashMap<String, String> getTopologyKeyDefaultValue() {
     return _topologyKeyDefaultValue;
-  }
-
-  public boolean isDisableFaultZoneTypeToInstanceTopologyMatching() {
-    return _disableFaultZoneTypeToInstanceTopologyMatching;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterTopologyConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterTopologyConfig.java
@@ -19,9 +19,7 @@ package org.apache.helix.model;
  * under the License.
  */
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.controller.rebalancer.topology.Topology;
@@ -34,15 +32,15 @@ public class ClusterTopologyConfig {
   private final String _endNodeType;
   private final String _faultZoneType;
   private final LinkedHashMap<String, String> _topologyKeyDefaultValue;
-  private final List<String> _requiredMatchingTopologyKeys;
+  private final boolean _disableFaultZoneTypeToInstanceTopologyMatching;
 
   private ClusterTopologyConfig(boolean topologyAwareEnabled, String endNodeType, String faultZoneType,
-      LinkedHashMap<String, String> topologyKeyDefaultValue, List<String> requiredMatchingTopologyKeys) {
+      LinkedHashMap<String, String> topologyKeyDefaultValue, boolean disableFaultZoneTypeToInstanceTopologyMatching) {
     _topologyAwareEnabled = topologyAwareEnabled;
     _endNodeType = endNodeType;
     _faultZoneType = faultZoneType;
     _topologyKeyDefaultValue = topologyKeyDefaultValue;
-    _requiredMatchingTopologyKeys = requiredMatchingTopologyKeys;
+    _disableFaultZoneTypeToInstanceTopologyMatching = disableFaultZoneTypeToInstanceTopologyMatching;
   }
 
   /**
@@ -57,14 +55,13 @@ public class ClusterTopologyConfig {
           false,
           Topology.Types.INSTANCE.name(),
           Topology.Types.INSTANCE.name(),
-          new LinkedHashMap<>(), 
-          new ArrayList<>());
+          new LinkedHashMap<>(),
+          true);
     }
     // Assign default cluster topology definition, i,e. /root/zone/instance
     String endNodeType = Topology.Types.INSTANCE.name();
     String faultZoneType = Topology.Types.ZONE.name();
     LinkedHashMap<String, String> topologyKeyDefaultValue = new LinkedHashMap<>();
-    List<String> requiredMatchingTopologyKeys = clusterConfig.getRequiredInstanceTopologyKeys();
 
     String topologyDef = clusterConfig.getTopology();
     if (topologyDef != null) {
@@ -86,7 +83,8 @@ public class ClusterTopologyConfig {
                 faultZoneType, clusterConfig.getTopology()));
       }
     }
-    return new ClusterTopologyConfig(true, endNodeType, faultZoneType, topologyKeyDefaultValue, requiredMatchingTopologyKeys);
+    return new ClusterTopologyConfig(true, endNodeType, faultZoneType, topologyKeyDefaultValue,
+        clusterConfig.isDisableFaultZoneTypeToInstanceTopologyMatching());
   }
 
   public boolean isTopologyAwareEnabled() {
@@ -105,7 +103,7 @@ public class ClusterTopologyConfig {
     return _topologyKeyDefaultValue;
   }
 
-  public List<String> getRequiredMatchingTopologyKeys() {
-    return _requiredMatchingTopologyKeys;
+  public boolean isDisableFaultZoneTypeToInstanceTopologyMatching() {
+    return _disableFaultZoneTypeToInstanceTopologyMatching;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterTopologyConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterTopologyConfig.java
@@ -36,7 +36,6 @@ public class TestClusterTopologyConfig {
     Assert.assertEquals(clusterTopologyConfig.getEndNodeType(), Topology.Types.INSTANCE.name());
     Assert.assertEquals(clusterTopologyConfig.getFaultZoneType(), Topology.Types.INSTANCE.name());
     Assert.assertTrue(clusterTopologyConfig.getTopologyKeyDefaultValue().isEmpty());
-    Assert.assertTrue(clusterTopologyConfig.isDisableFaultZoneTypeToInstanceTopologyMatching());
   }
 
   @Test
@@ -44,7 +43,6 @@ public class TestClusterTopologyConfig {
     ClusterConfig testConfig = new ClusterConfig("testId");
     testConfig.setTopologyAwareEnabled(true);
     testConfig.setTopology("/zone/instance");
-    testConfig.setDisableFaultZoneTypeToInstanceTopologyMatching(false);
     // no fault zone setup
     ClusterTopologyConfig clusterTopologyConfig = ClusterTopologyConfig.createFromClusterConfig(testConfig);
     Assert.assertEquals(clusterTopologyConfig.getEndNodeType(), "instance");
@@ -73,7 +71,6 @@ public class TestClusterTopologyConfig {
     for (String k : keys) {
       Assert.assertEquals(k, itr.next());
     }
-    Assert.assertFalse(clusterTopologyConfig.isDisableFaultZoneTypeToInstanceTopologyMatching());
   }
 
   @Test(expectedExceptions = HelixException.class)

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterTopologyConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterTopologyConfig.java
@@ -19,8 +19,6 @@ package org.apache.helix.model;
  * under the License.
  */
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import org.apache.helix.HelixException;
 import org.apache.helix.controller.rebalancer.topology.Topology;
@@ -38,7 +36,7 @@ public class TestClusterTopologyConfig {
     Assert.assertEquals(clusterTopologyConfig.getEndNodeType(), Topology.Types.INSTANCE.name());
     Assert.assertEquals(clusterTopologyConfig.getFaultZoneType(), Topology.Types.INSTANCE.name());
     Assert.assertTrue(clusterTopologyConfig.getTopologyKeyDefaultValue().isEmpty());
-    Assert.assertTrue(clusterTopologyConfig.getRequiredMatchingTopologyKeys().isEmpty());
+    Assert.assertTrue(clusterTopologyConfig.isDisableFaultZoneTypeToInstanceTopologyMatching());
   }
 
   @Test
@@ -46,7 +44,7 @@ public class TestClusterTopologyConfig {
     ClusterConfig testConfig = new ClusterConfig("testId");
     testConfig.setTopologyAwareEnabled(true);
     testConfig.setTopology("/zone/instance");
-    testConfig.setRequiredInstanceTopologyKeys(Collections.singletonList("mz_virtualzone"));
+    testConfig.setDisableFaultZoneTypeToInstanceTopologyMatching(false);
     // no fault zone setup
     ClusterTopologyConfig clusterTopologyConfig = ClusterTopologyConfig.createFromClusterConfig(testConfig);
     Assert.assertEquals(clusterTopologyConfig.getEndNodeType(), "instance");
@@ -75,8 +73,7 @@ public class TestClusterTopologyConfig {
     for (String k : keys) {
       Assert.assertEquals(k, itr.next());
     }
-    Assert.assertEquals(clusterTopologyConfig.getRequiredMatchingTopologyKeys().size(), 1);
-    Assert.assertEquals(clusterTopologyConfig.getRequiredMatchingTopologyKeys().get(0), "mz_virtualzone");
+    Assert.assertFalse(clusterTopologyConfig.isDisableFaultZoneTypeToInstanceTopologyMatching());
   }
 
   @Test(expectedExceptions = HelixException.class)

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -1286,12 +1286,6 @@ public class ClusterAccessor extends AbstractHelixResource {
         throw new IllegalArgumentException(
             "Topology and fault zone type must be set when topology aware is enabled.");
       }
-      // Verify fault zone is one of the cluster config key
-      ClusterTopologyConfig updatedTopologyConfig = ClusterTopologyConfig.createFromClusterConfig(updatedConfig);
-      if (!updatedTopologyConfig.getTopologyKeyDefaultValue().containsKey(updatedTopologyConfig.getFaultZoneType())) {
-        throw new IllegalArgumentException(
-            "Fault zone type " + updatedConfig.getFaultZoneType() + " is not present in the topology path.");
-      }
 
       boolean isTopologyAwareChanged =
           !oldConfig.isTopologyAwareEnabled() && updatedConfig.isTopologyAwareEnabled();

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -57,6 +57,7 @@ import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope;
@@ -1284,6 +1285,12 @@ public class ClusterAccessor extends AbstractHelixResource {
       if (updatedConfig.getTopology() == null || updatedConfig.getFaultZoneType() == null) {
         throw new IllegalArgumentException(
             "Topology and fault zone type must be set when topology aware is enabled.");
+      }
+      // Verify fault zone is one of the cluster config key
+      ClusterTopologyConfig updatedTopologyConfig = ClusterTopologyConfig.createFromClusterConfig(updatedConfig);
+      if (!updatedTopologyConfig.getTopologyKeyDefaultValue().containsKey(updatedConfig.getFaultZoneType())) {
+        throw new IllegalArgumentException(
+            "Fault zone type " + updatedConfig.getFaultZoneType() + " is not present in the topology path.");
       }
 
       boolean isTopologyAwareChanged =

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -1288,7 +1288,7 @@ public class ClusterAccessor extends AbstractHelixResource {
       }
       // Verify fault zone is one of the cluster config key
       ClusterTopologyConfig updatedTopologyConfig = ClusterTopologyConfig.createFromClusterConfig(updatedConfig);
-      if (!updatedTopologyConfig.getTopologyKeyDefaultValue().containsKey(updatedConfig.getFaultZoneType())) {
+      if (!updatedTopologyConfig.getTopologyKeyDefaultValue().containsKey(updatedTopologyConfig.getFaultZoneType())) {
         throw new IllegalArgumentException(
             "Fault zone type " + updatedConfig.getFaultZoneType() + " is not present in the topology path.");
       }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -57,7 +57,6 @@ import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConfig;
-import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope;
@@ -1295,19 +1294,6 @@ public class ClusterAccessor extends AbstractHelixResource {
       boolean isFaultZoneTypeChanged =
           oldConfig.getFaultZoneType() == null || (oldConfig.getFaultZoneType() != null
               && !oldConfig.getFaultZoneType().equals(updatedConfig.getFaultZoneType()));
-      boolean isRequiredInstanceTopologyKeysChanged =
-          !oldConfig.getRequiredInstanceTopologyKeys().equals(updatedConfig.getRequiredInstanceTopologyKeys());
-
-      if (isTopologyPathChanged || isRequiredInstanceTopologyKeysChanged) {
-        // All required instance topology keys must be present in the topology path.
-        ClusterTopologyConfig topologyConfig = ClusterTopologyConfig.createFromClusterConfig(updatedConfig);
-        for (String key : updatedConfig.getRequiredInstanceTopologyKeys()) {
-          if (!topologyConfig.getTopologyKeyDefaultValue().keySet().contains(key)) {
-            throw new IllegalArgumentException(
-                "Required instance topology key " + key + " is not present in the topology path.");
-          }
-        }
-      }
 
       if (isTopologyAwareChanged || isTopologyPathChanged || isFaultZoneTypeChanged) {
         HelixDataAccessor dataAccessor = getDataAccssor(clusterName);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -157,39 +157,6 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
-  @Test(dependsOnMethods = "testValidateClusterConfigChange")
-  public void testValidateClusterConfigChange_missingRequiredTopologyKey_throwsException() throws IOException {
-    System.out.println("Start test :" + TestHelper.getTestMethodName());
-    ClusterConfig config = getClusterConfigFromRest(TEST_CLUSTER);
-
-    // Update config with mismatching required topology key while enabling topology aware
-    {
-      ClusterConfig newConfig = new ClusterConfig(config.getClusterName());
-      newConfig.setTopologyAwareEnabled(true);
-      newConfig.setTopology("/zone/rack/host");
-      newConfig.setFaultZoneType("zone");
-      newConfig.setRequiredInstanceTopologyKeys(Arrays.asList("rack", "missingKey"));
-      _auditLogger.clearupLogs();
-      Entity entity = Entity.entity(OBJECT_MAPPER.writeValueAsString(newConfig.getRecord()),
-          MediaType.APPLICATION_JSON_TYPE);
-      post("clusters/" + TEST_CLUSTER + "/configs", ImmutableMap.of("command", Command.update.name()),
-          entity, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
-
-      validateAuditLogSize(1);
-      AuditLog auditLog = _auditLogger.getAuditLogs().get(0);
-      Assert.assertEquals(auditLog.getHttpMethod(), HTTPMethods.POST.name());
-      Assert.assertEquals(auditLog.getRequestPath(), "clusters/" + TEST_CLUSTER + "/configs");
-      Assert.assertEquals(auditLog.getExceptions().size(), 1);
-      Assert.assertEquals(auditLog.getExceptions().get(0).getMessage(),
-          "Required instance topology key missingKey is not present in the topology path.");
-    }
-
-    // Restore the cluster config
-    updateClusterConfigFromRest(TEST_CLUSTER, config, Command.update);
-
-    System.out.println("End test :" + TestHelper.getTestMethodName());
-  }
-
   @Test(dependsOnMethods = "testValidateClusterConfigChange_missingRequiredTopologyKey_throwsException")
   public void testGetClusters() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -158,39 +158,6 @@ public class TestClusterAccessor extends AbstractTestClass {
   }
 
   @Test(dependsOnMethods = "testValidateClusterConfigChange")
-  public void testValidateClusterConfigChange_missingFaultZoneTypeInClusterConfigKeys_throwsException()
-          throws IOException {
-    System.out.println("Start test :" + TestHelper.getTestMethodName());
-    ClusterConfig config = getClusterConfigFromRest(TEST_CLUSTER);
-
-    // Update config with mismatching fault zone type to default topology keys of the cluster
-    {
-      ClusterConfig newConfig = new ClusterConfig(config.getClusterName());
-      newConfig.setTopologyAwareEnabled(true);
-      newConfig.setTopology("/zone/rack/host");
-      newConfig.setFaultZoneType("mz_virtual_zone");
-      _auditLogger.clearupLogs();
-      Entity entity = Entity.entity(OBJECT_MAPPER.writeValueAsString(newConfig.getRecord()),
-              MediaType.APPLICATION_JSON_TYPE);
-      post("clusters/" + TEST_CLUSTER + "/configs", ImmutableMap.of("command", Command.update.name()),
-              entity, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
-
-      validateAuditLogSize(1);
-      AuditLog auditLog = _auditLogger.getAuditLogs().get(0);
-      Assert.assertEquals(auditLog.getHttpMethod(), HTTPMethods.POST.name());
-      Assert.assertEquals(auditLog.getRequestPath(), "clusters/" + TEST_CLUSTER + "/configs");
-      Assert.assertEquals(auditLog.getExceptions().size(), 1);
-      Assert.assertEquals(auditLog.getExceptions().get(0).getMessage(),
-              "Fault zone type mz_virtual_zone is not present in the topology path.");
-    }
-
-    // Restore the cluster config
-    updateClusterConfigFromRest(TEST_CLUSTER, config, Command.update);
-
-    System.out.println("End test :" + TestHelper.getTestMethodName());
-  }
-
-  @Test(dependsOnMethods = "testValidateClusterConfigChange_missingFaultZoneTypeInClusterConfigKeys_throwsException")
   public void testGetClusters() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Support ignoring instances if the required instance topology configuration does not match the required fault zone type. Previously, an instance might join the cluster with incorrect topology configurations, leading to uneven partitions. This PR adds support to skip such instances in case a required config is missing.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

1. Delete the unnecessary key `REQUIRED_INSTANCE_TOPOLOGY_KEYS`.
  a. This is a follow up on https://github.com/linkedin/helix/pull/40
2. Match fault zone key to the topology keys.

### Tests

- [x] The following tests are written for this issue:

1. Updated the current tests.

- The following is the result of the "mvn test" command on the appropriate module:

### Changes that Break Backward Compatibility (Optional)

NA

### Code Quality

- My diff has been formatted using helix-style.xml 
Yes
