### PR TITLE
Fix NPE in CRUSHPlacementAlgorithm when Straw2Selector encounters nodes with no children during  CRUSHED2 rebalancing.

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/Straw2Selector.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/Straw2Selector.java
@@ -27,6 +27,9 @@ class Straw2Selector implements Selector {
         hiScore = score;
       }
     }
+    if (selected == null) {
+      throw new IllegalStateException("No node selected for input " + input + " and round " + round);
+    }
     return selected;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/TestStraw2SelectorNPEFix.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/TestStraw2SelectorNPEFix.java
@@ -1,0 +1,55 @@
+package org.apache.helix.controller.rebalancer.strategy.crushMapping;
+
+import org.apache.helix.controller.rebalancer.topology.Node;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test to verify that Straw2Selector properly handles empty nodes without throwing NPE.
+ * This reproduces the bug where Straw2Selector returned null causing NPE in CRUSHPlacementAlgorithm.
+ */
+public class TestStraw2SelectorNPEFix {
+
+  private Node createEmptyNode(String name, String type, long id) {
+    Node node = new Node();
+    node.setName(name);
+    node.setType(type);
+    node.setId(id);
+    return node;
+  }
+
+  @DataProvider(name = "inputValues")
+  public Object[][] getInputValues() {
+    return new Object[][] {
+        {12345L, 1L},
+        {-1219343163L, 1L},
+        {0L, 1L},
+        {Long.MAX_VALUE, 1L},
+        {Long.MIN_VALUE, 1L},
+        {999L, 0L},
+        {999L, 100L},
+        {999L, Long.MAX_VALUE}
+    };
+  }
+
+  @Test(dataProvider = "inputValues", expectedExceptions = IllegalStateException.class,
+      expectedExceptionsMessageRegExp = "No node selected.*")
+  public void testStraw2SelectorEmptyNodeThrowsException(long input, long round) {
+    Node emptyNode = createEmptyNode("empty_mz", "mz", 123L);
+    new Straw2Selector(emptyNode).select(input, round);
+  }
+
+  @DataProvider(name = "selectors")
+  public Object[][] getSelectors() {
+    Node emptyNode = createEmptyNode("empty", "test", 1L);
+    return new Object[][] {
+        { new StrawSelector(emptyNode) },
+        { new Straw2Selector(emptyNode) }
+    };
+  }
+
+  @Test(dataProvider = "selectors", expectedExceptions = IllegalStateException.class)
+  public void testSelectorsConsistency(Selector selector) {
+    selector.select(123L, 1L);
+  }
+}


### PR DESCRIPTION
…or encounters nodes with no children during CRUSHED2 rebalancing

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Straw2Selector.select() returned null for empty nodes (e.g., MZ with no live instances or assignable nodes)
Caused NPE at CRUSHPlacementAlgorithm.java:134 when calling out.getType()
(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:
TestStraw2SelectorNPEFix class added
(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
