### PR TITLE
Add diagnostic logging for CRUSHED2 rebalancer failures

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
@@ -112,6 +112,7 @@ public class CrushRebalanceStrategy implements RebalanceStrategy<ResourceControl
         String errorMessage = String
             .format("Could not select enough number of nodes. %s partition %s, required %d",
                 _resourceName, partitionName, _replicas);
+        LogUtil.logError(Log, eventId, errorMessage + ". Hash=" + data);
         throw new HelixException(errorMessage, e);
       }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/CrushRebalanceStrategy.java
@@ -110,9 +110,8 @@ public class CrushRebalanceStrategy implements RebalanceStrategy<ResourceControl
         selected = select(topNode, data, _replicas, eventId);
       } catch (IllegalStateException e) {
         String errorMessage = String
-            .format("Could not select enough number of nodes. %s partition %s, required %d",
-                _resourceName, partitionName, _replicas);
-        LogUtil.logError(Log, eventId, errorMessage + ". Hash=" + data);
+            .format("Could not select enough number of nodes. Resource=%s, partition=%s, hash=%d, required=%d. %s",
+                _resourceName, partitionName, data, _replicas, e.getMessage());
         throw new HelixException(errorMessage, e);
       }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
@@ -134,11 +134,12 @@ public class CRUSHPlacementAlgorithm {
           try {
             out = selector.select(input, rPrime);
           } catch (IllegalStateException e) {
-            logger.error("CRUSH selector failed for node: name={}, type={}, childrenCount={}, input={}, rPrime={}",
-                in.getName(), in.getType(),
-                in.getChildren() == null ? 0 : in.getChildren().size(),
-                input, rPrime);
-            throw e;
+            // Enhance exception with node context for logging at higher level
+            throw new IllegalStateException(
+                String.format("Selector failed for node [name=%s, type=%s, childrenCount=%d]. %s",
+                    in.getName(), in.getType(),
+                    in.getChildren() == null ? 0 : in.getChildren().size(),
+                    e.getMessage()), e);
           }
           if (!out.getType().equalsIgnoreCase(type)) {
             logger.trace("selected output {} for data {} didn't match the type {}: walking down " +

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/CRUSHPlacementAlgorithm.java
@@ -130,7 +130,16 @@ public class CRUSHPlacementAlgorithm {
           rPrime = r + offset + failure;
           logger.trace("{}.select({}, {})", new Object[] {in, input, rPrime});
           Selector selector = SelectorFactory.createSelector(in, strawBucket);
-          out = selector.select(input, rPrime);
+          
+          try {
+            out = selector.select(input, rPrime);
+          } catch (IllegalStateException e) {
+            logger.error("CRUSH selector failed for node: name={}, type={}, childrenCount={}, input={}, rPrime={}",
+                in.getName(), in.getType(),
+                in.getChildren() == null ? 0 : in.getChildren().size(),
+                input, rPrime);
+            throw e;
+          }
           if (!out.getType().equalsIgnoreCase(type)) {
             logger.trace("selected output {} for data {} didn't match the type {}: walking down " +
                 "the hierarchy...", new Object[] {out, input, type});

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/Straw2Selector.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/Straw2Selector.java
@@ -36,10 +36,9 @@ class Straw2Selector implements Selector {
       }
     }
     if (selected == null) {
-      LOG.error("Straw2Selector failed: no node selected. Input={}, round={}, nodeCount={}",
-          input, round, _nodes == null ? 0 : _nodes.size());
       throw new IllegalStateException(
-          String.format("No node selected for input %d and round %d", input, round));
+          String.format("No node selected for input %d and round %d. NodeCount=%d",
+              input, round, _nodes == null ? 0 : _nodes.size()));
     }
     return selected;
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/Straw2Selector.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/strategy/crushMapping/Straw2Selector.java
@@ -3,11 +3,14 @@ package org.apache.helix.controller.rebalancer.strategy.crushMapping;
 import java.util.List;
 import org.apache.helix.controller.rebalancer.topology.Node;
 import org.apache.helix.util.JenkinsHash;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Selection algorithm based on the "straw2" bucket type as described https://www.spinics.net/lists/ceph-devel/msg21635.html.
  */
 class Straw2Selector implements Selector {
+  private static final Logger LOG = LoggerFactory.getLogger(Straw2Selector.class);
 
   private final List<Node> _nodes;
   private final JenkinsHash _hashFunction;
@@ -15,6 +18,11 @@ class Straw2Selector implements Selector {
   Straw2Selector(Node node) {
     _nodes = node.getChildren();
     _hashFunction = new JenkinsHash();
+
+    if (_nodes == null || _nodes.isEmpty()) {
+      LOG.warn("Straw2Selector created with empty node: name={}, type={}, id={}",
+          node.getName(), node.getType(), node.getId());
+    }
   }
 
   public Node select(long input, long round) {
@@ -28,7 +36,10 @@ class Straw2Selector implements Selector {
       }
     }
     if (selected == null) {
-      throw new IllegalStateException("No node selected for input " + input + " and round " + round);
+      LOG.error("Straw2Selector failed: no node selected. Input={}, round={}, nodeCount={}",
+          input, round, _nodes == null ? 0 : _nodes.size());
+      throw new IllegalStateException(
+          String.format("No node selected for input %d and round %d", input, round));
     }
     return selected;
   }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
  Adds critical logging at key failure points in CRUSHED2 rebalancing strategy to help diagnose node selection failures and empty fault zone issues.

  - Straw2Selector.java:
    - WARN log when selector is created with empty node
    - ERROR log when selection fails with input/round/nodeCount details
  - CRUSHPlacementAlgorithm.java:
    - ERROR log when selector throws exception with node details and hash values
  - CrushRebalanceStrategy.java:
    - ERROR log on selection failure with resource/partition/hash information
(Write a concise description including what, why, how)

### Tests
NA, logs will look like below:

> ERROR [BestPossibleStateCalcStage] [Event_1234567] Exception when calculating best possible states for heartbeat_hybrid_venice-10_v7576
> org.apache.helix.HelixException: Could not select enough number of nodes. Resource=heartbeat_hybrid_venice-10_v7576, partition=heartbeat_hybrid_venice-10_v7576_0, hash=-1219343163, required=3. Selector failed for node [name=root, type=ROOT, childrenCount=0]. No node selected for input -1219343163 and round 1. NodeCount=0
> Caused by: java.lang.IllegalStateException: Selector failed for node [name=root, type=ROOT, childrenCount=0]. No node selected for input -1219343163 and round 1. NodeCount=0


- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
