### PR TITLE
Add missing topology keys in warning log

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/topology/Topology.java
@@ -261,7 +261,7 @@ public class Topology {
               .format("Domain for instance %s is not set, fail the topology-aware placement!",
                   instanceName));
         }
-        int numOfMatchedKeys = 0;
+        List<String> missingKeys = new ArrayList<>();
         boolean missingRequiredFaultZoneKey = false;
         for (String key : clusterTopologyConfig.getTopologyKeyDefaultValue().keySet()) {
           // if a key does not exist in the instance domain config, using the default domain value.
@@ -271,19 +271,18 @@ public class Topology {
             if (key.equals(clusterTopologyConfig.getFaultZoneType())) {
                 missingRequiredFaultZoneKey = true;
             }
-          } else {
-            numOfMatchedKeys++;
+            missingKeys.add(key);
           }
           instanceTopologyMap.put(key, value);
           if (key.equals(faultZoneForEarlyQuit)) {
             return instanceTopologyMap;
           }
         }
-        if (numOfMatchedKeys < clusterTopologyConfig.getTopologyKeyDefaultValue().size()) {
+        if (!missingKeys.isEmpty()) {
           String errorMessage = String.format(
-              "Instance %s in cluster %s does not have all the keys in ClusterConfig. Topology %s.",
-              instanceName, clusterName,
-              clusterTopologyConfig.getTopologyKeyDefaultValue().keySet());
+              "Instance %s in cluster %s does not have all the keys in ClusterConfig. "
+                  + "Topology: %s, missing keys: %s", instanceName, clusterName,
+              clusterTopologyConfig.getTopologyKeyDefaultValue().keySet(), missingKeys);
           logger.warn(errorMessage);
           if (missingRequiredFaultZoneKey) {
             throw new InstanceConfigMismatchException(


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Follow up on https://github.com/linkedin/helix/pull/48 to add the missing key details in the log message.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Add missing topology keys in warning log

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
