### PR TITLE
Add Cluster-Level Instance Operation Count Metrics

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -80,8 +80,8 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             Map<String, Set<String>> tags = Maps.newHashMap();
             Map<String, LiveInstance> liveInstanceMap = dataProvider.getLiveInstances();
             Map<String, Set<Message>> instanceMessageMap = Maps.newHashMap();
-            for (Map.Entry<String, InstanceConfig> e : dataProvider.getInstanceConfigMap()
-                .entrySet()) {
+            Map<String, InstanceConfig> instanceConfigMap = dataProvider.getInstanceConfigMap();
+            for (Map.Entry<String, InstanceConfig> e : instanceConfigMap.entrySet()) {
               String instanceName = e.getKey();
               InstanceConfig config = e.getValue();
               instanceSet.add(instanceName);
@@ -103,7 +103,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             }
             clusterStatusMonitor
                 .setClusterInstanceStatus(liveInstanceSet, instanceSet, disabledInstanceSet,
-                    disabledPartitions, oldDisabledPartitions, tags, instanceMessageMap);
+                    disabledPartitions, oldDisabledPartitions, tags, instanceMessageMap, instanceConfigMap);
             LogUtil.logDebug(logger, _eventId, "Complete cluster status monitors update.");
           }
           return null;

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -371,13 +371,10 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       if (instanceConfigMap != null) {
         for (Map.Entry<String, InstanceConfig> entry : instanceConfigMap.entrySet()) {
           InstanceConfig config = entry.getValue();
-          InstanceConstants.InstanceOperation operation;
+          InstanceConstants.InstanceOperation operation = InstanceConstants.InstanceOperation.ENABLE;
 
           if (config != null && config.getInstanceOperation() != null) {
             operation = config.getInstanceOperation().getOperation();
-          } else {
-            // If no operation is set, default to ENABLE
-            operation = InstanceConstants.InstanceOperation.ENABLE;
           }
 
           // Increment the count for this operation

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -147,4 +147,29 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    * state partition is larger than configured threshold (default is 1).
    */
   long getNumOfResourcesRebalanceThrottledGauge();
+
+  /**
+   * @return number of instances currently in ENABLE operation
+   */
+  long getInstancesInOperationEnableGauge();
+
+  /**
+   * @return number of instances currently in DISABLE operation
+   */
+  long getInstancesInOperationDisableGauge();
+
+  /**
+   * @return number of instances currently in EVACUATE operation
+   */
+  long getInstancesInOperationEvacuateGauge();
+
+  /**
+   * @return number of instances currently in SWAP_IN operation
+   */
+  long getInstancesInOperationSwapInGauge();
+
+  /**
+   * @return number of instances currently in UNKNOWN operation
+   */
+  long getInstancesInOperationUnknownGauge();
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
This PR adds cluster-level metrics to count how many instances are currently in each Instance Operation state.

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
This Change introduces cluster-wide metrics to count instances in each Instance Operation state (ENABLE, DISABLE, EVACUATE, SWAP_IN, UNKNOWN). 

Metrics exposed (cluster-level):
- InstancesInOperationEnableGauge
- InstancesInOperationDisableGauge
- InstancesInOperationEvacuateGauge
- InstancesInOperationSwapInGauge
- InstancesInOperationUnknownGauge

### Tests

- [ ] The following tests are written for this issue:
testClusterLevelInstanceOperationCounts

Manually tested with real Helix Cluster, works fine!
<img width="816" height="714" alt="image" src="https://github.com/user-attachments/assets/7dd7f157-26b3-4aec-bd5d-9af824935bc7" />

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
