### PR TITLE
Add metric to detect stuck top state handoffs in progress

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -44,6 +44,7 @@ import org.apache.helix.controller.pipeline.Pipeline;
 import org.apache.helix.controller.rebalancer.strategy.GreedyRebalanceStrategy;
 import org.apache.helix.controller.rebalancer.waged.WagedInstanceCapacity;
 import org.apache.helix.controller.rebalancer.waged.WagedResourceWeightsProvider;
+import org.apache.helix.controller.stages.InProgressHandoffRecord;
 import org.apache.helix.controller.stages.MissingTopStateRecord;
 import org.apache.helix.model.CustomizedState;
 import org.apache.helix.model.CustomizedStateConfig;
@@ -82,6 +83,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
 
   // records for top state handoff
   private Map<String, Map<String, MissingTopStateRecord>> _missingTopStateMap;
+  private Map<String, Map<String, InProgressHandoffRecord>> _inProgressHandoffMap;
   private Map<String, Map<String, String>> _lastTopStateLocationMap;
 
   // Maintain a set of all ChangeTypes for change detection
@@ -145,6 +147,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     _resourceAssignmentCache = new HashMap<>();
     _idealMappingCache = new HashMap<>();
     _missingTopStateMap = new HashMap<>();
+    _inProgressHandoffMap = new HashMap<>();
     _lastTopStateLocationMap = new HashMap<>();
     _refreshedChangeTypes = ConcurrentHashMap.newKeySet();
     _customizedStateCache = new CustomizedStateCache(this, _aggregationEnabledTypes);
@@ -382,6 +385,10 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
 
   public Map<String, Map<String, MissingTopStateRecord>> getMissingTopStateMap() {
     return _missingTopStateMap;
+  }
+
+  public Map<String, Map<String, InProgressHandoffRecord>> getInProgressHandoffMap() {
+    return _inProgressHandoffMap;
   }
 
   public Map<String, Map<String, String>> getLastTopStateLocationMap() {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/InProgressHandoffRecord.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/InProgressHandoffRecord.java
@@ -1,0 +1,47 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A record entry in cluster data cache containing information about a partition's
+ * in-progress top state handoff that exceeds threshold
+ */
+public class InProgressHandoffRecord {
+  private final long startTimeStamp;
+  private boolean beyondThreshold;
+
+  public InProgressHandoffRecord(long start) {
+    startTimeStamp = start;
+    beyondThreshold = false;
+  }
+
+  public long getStartTimeStamp() {
+    return startTimeStamp;
+  }
+
+  public void setBeyondThreshold() {
+    // Mark InProgressHandoffRecord as beyond threshold if partition handoff duration exceeds threshold value.
+    beyondThreshold = true;
+  }
+
+  public boolean isBeyondThreshold() {
+    return beyondThreshold;
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -30,6 +30,7 @@ import org.apache.helix.controller.pipeline.AbstractAsyncBaseStage;
 import org.apache.helix.controller.pipeline.AsyncWorkerType;
 import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
@@ -88,15 +89,20 @@ public class TopStateHandoffReportStage extends AbstractAsyncBaseStage {
       long lastPipelineFinishTimestamp) {
     Map<String, Map<String, MissingTopStateRecord>> missingTopStateMap =
         cache.getMissingTopStateMap();
+    Map<String, Map<String, InProgressHandoffRecord>> inProgressHandoffMap =
+        cache.getInProgressHandoffMap();
     Map<String, Map<String, String>> lastTopStateMap = cache.getLastTopStateLocationMap();
 
     long durationThreshold = Long.MAX_VALUE;
+    long handoffDurationThreshold = Long.MAX_VALUE;
     if (cache.getClusterConfig() != null) {
       durationThreshold = cache.getClusterConfig().getMissTopStateDurationThreshold();
+      handoffDurationThreshold = cache.getClusterConfig().getTopStateHandoffDurationThreshold();
     }
 
     // Remove any resource records that no longer exists
     missingTopStateMap.keySet().retainAll(resourceMap.keySet());
+    inProgressHandoffMap.keySet().retainAll(resourceMap.keySet());
     lastTopStateMap.keySet().retainAll(resourceMap.keySet());
 
     for (Resource resource : resourceMap.values()) {
@@ -113,6 +119,8 @@ public class TopStateHandoffReportStage extends AbstractAsyncBaseStage {
       for (Partition partition : resource.getPartitions()) {
         String currentTopStateInstance =
             findCurrentTopStateLocation(currentStateOutput, resourceName, partition, stateModelDef);
+        String expectedTopStateInstance =
+            findExpectedTopStateLocation(cache, resourceName, partition, stateModelDef);
         String lastTopStateInstance = findCachedTopStateLocation(cache, resourceName, partition);
 
         if (currentTopStateInstance != null) {
@@ -120,11 +128,22 @@ public class TopStateHandoffReportStage extends AbstractAsyncBaseStage {
               lastTopStateInstance, currentTopStateInstance, clusterStatusMonitor,
               durationThreshold, lastPipelineFinishTimestamp);
           updateCachedTopStateLocation(cache, resourceName, partition, currentTopStateInstance);
+
+          // Check for in-progress handoff: IdealState expects different instance than current
+          if (expectedTopStateInstance != null && !expectedTopStateInstance.equals(currentTopStateInstance)) {
+            trackInProgressHandoff(cache, resourceName, partition, handoffDurationThreshold, clusterStatusMonitor);
+          } else {
+            // Handoff completed or no handoff in progress, clear tracking if exists
+            clearInProgressHandoffTracking(cache, resourceName, partition, clusterStatusMonitor);
+          }
         } else {
           reportTopStateMissing(cache, resourceName,
               partition, stateModelDef.getTopState(), currentStateOutput);
           reportTopStateHandoffFailIfNecessary(cache, resourceName, partition, durationThreshold,
               clusterStatusMonitor);
+
+          // Also clear in-progress handoff tracking when top state is missing
+          clearInProgressHandoffTracking(cache, resourceName, partition, clusterStatusMonitor);
         }
       }
 
@@ -172,6 +191,36 @@ public class TopStateHandoffReportStage extends AbstractAsyncBaseStage {
     return lastTopStateMap.containsKey(resourceName) && lastTopStateMap.get(resourceName)
         .containsKey(partition.getPartitionName()) ? lastTopStateMap.get(resourceName)
         .get(partition.getPartitionName()) : null;
+  }
+
+  /**
+   * Find expected top state location from IdealState for the given resource and partition
+   *
+   * @param cache cluster data cache object
+   * @param resourceName resource name
+   * @param partition partition of the given resource
+   * @param stateModelDef state model definition
+   * @return expected instance name that should have top state according to IdealState, null if not defined
+   */
+  private String findExpectedTopStateLocation(ResourceControllerDataProvider cache, String resourceName,
+      Partition partition, StateModelDefinition stateModelDef) {
+    IdealState idealState = cache.getIdealState(resourceName);
+    if (idealState == null) {
+      return null;
+    }
+
+    Map<String, String> instanceStateMap = idealState.getInstanceStateMap(partition.getPartitionName());
+    if (instanceStateMap == null || instanceStateMap.isEmpty()) {
+      return null;
+    }
+
+    String topState = stateModelDef.getTopState();
+    for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
+      if (topState.equals(entry.getValue())) {
+        return entry.getKey();
+      }
+    }
+    return null;
   }
 
   /**
@@ -536,5 +585,93 @@ public class TopStateHandoffReportStage extends AbstractAsyncBaseStage {
     LogUtil.logInfo(LOG, _eventId, String.format(
         "Missing top state duration is %s/%s (helix latency / end to end latency) for partition %s. Graceful: %s",
         helixLatency, totalDuration, partitionName, isGraceful));
+  }
+
+  /**
+   * Track in-progress top state handoff and increment gauge if beyond threshold
+   *
+   * @param cache cluster data cache
+   * @param resourceName resource name
+   * @param partition partition of the given resource
+   * @param durationThreshold top state handoff duration threshold
+   * @param clusterStatusMonitor monitor object
+   */
+  private void trackInProgressHandoff(ResourceControllerDataProvider cache, String resourceName,
+      Partition partition, long durationThreshold, ClusterStatusMonitor clusterStatusMonitor) {
+    Map<String, Map<String, InProgressHandoffRecord>> inProgressHandoffMap =
+        cache.getInProgressHandoffMap();
+    String partitionName = partition.getPartitionName();
+
+    // Initialize resource map if not exists
+    if (!inProgressHandoffMap.containsKey(resourceName)) {
+      inProgressHandoffMap.put(resourceName, new HashMap<String, InProgressHandoffRecord>());
+    }
+
+    InProgressHandoffRecord record = inProgressHandoffMap.get(resourceName).get(partitionName);
+
+    if (record == null) {
+      // First time detecting this in-progress handoff, start tracking
+      record = new InProgressHandoffRecord(System.currentTimeMillis());
+      inProgressHandoffMap.get(resourceName).put(partitionName, record);
+      LogUtil.logDebug(LOG, _eventId, String.format(
+          "Started tracking in-progress handoff for partition %s of resource %s",
+          partitionName, resourceName));
+    }
+
+    // Check if handoff duration exceeds threshold
+    long startTime = record.getStartTimeStamp();
+    long handoffDuration = System.currentTimeMillis() - startTime;
+
+    if (startTime > 0 && handoffDuration > durationThreshold && !record.isBeyondThreshold()) {
+      // Mark as beyond threshold and increment gauge
+      record.setBeyondThreshold();
+      inProgressHandoffMap.get(resourceName).put(partitionName, record);
+
+      LogUtil.logWarn(LOG, _eventId, String.format(
+          "In-progress handoff for partition %s of resource %s has exceeded threshold. Duration: %s ms",
+          partitionName, resourceName, handoffDuration));
+
+      if (clusterStatusMonitor != null) {
+        clusterStatusMonitor.incrementInProgressHandoffBeyondThresholdGauge(resourceName);
+      }
+    }
+  }
+
+  /**
+   * Clear in-progress handoff tracking and decrement gauge if it was beyond threshold
+   *
+   * @param cache cluster data cache
+   * @param resourceName resource name
+   * @param partition partition of the given resource
+   * @param clusterStatusMonitor monitor object
+   */
+  private void clearInProgressHandoffTracking(ResourceControllerDataProvider cache,
+      String resourceName, Partition partition, ClusterStatusMonitor clusterStatusMonitor) {
+    Map<String, Map<String, InProgressHandoffRecord>> inProgressHandoffMap =
+        cache.getInProgressHandoffMap();
+    String partitionName = partition.getPartitionName();
+
+    if (!inProgressHandoffMap.containsKey(resourceName)) {
+      return;
+    }
+
+    InProgressHandoffRecord record = inProgressHandoffMap.get(resourceName).get(partitionName);
+    if (record == null) {
+      return;
+    }
+
+    // If the record was beyond threshold, decrement the gauge
+    if (record.isBeyondThreshold() && clusterStatusMonitor != null) {
+      LogUtil.logInfo(LOG, _eventId, String.format(
+          "In-progress handoff completed for partition %s of resource %s. Decrementing gauge.",
+          partitionName, resourceName));
+      clusterStatusMonitor.decrementInProgressHandoffBeyondThresholdGauge(resourceName);
+    }
+
+    // Remove the tracking record
+    inProgressHandoffMap.get(resourceName).remove(partitionName);
+    if (inProgressHandoffMap.get(resourceName).isEmpty()) {
+      inProgressHandoffMap.remove(resourceName);
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -629,7 +629,6 @@ public class TopStateHandoffReportStage extends AbstractAsyncBaseStage {
     if (startTime > 0 && handoffDuration > durationThreshold) {
       // First time exceeding threshold - mark as beyond threshold and increment gauge
       record.setBeyondThreshold();
-      inProgressHandoffMap.get(resourceName).put(partitionName, record);
 
       LogUtil.logWarn(LOG, _eventId, String.format(
           "In-progress handoff for partition %s of resource %s has exceeded threshold. Duration: %s ms",

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -64,6 +64,7 @@ public class ClusterConfig extends HelixProperty {
     STATE_TRANSITION_THROTTLE_CONFIGS,
     STATE_TRANSITION_CANCELLATION_ENABLED,
     MISS_TOP_STATE_DURATION_THRESHOLD,
+    TOP_STATE_HANDOFF_DURATION_THRESHOLD,
     RESOURCE_PRIORITY_FIELD,
     REBALANCE_TIMER_PERIOD,
     MAX_CONCURRENT_TASK_PER_INSTANCE,
@@ -701,6 +702,24 @@ public class ClusterConfig extends HelixProperty {
   public long getMissTopStateDurationThreshold() {
     return _record.getLongField(ClusterConfigProperty.MISS_TOP_STATE_DURATION_THRESHOLD.name(),
         Long.MAX_VALUE);
+  }
+
+  /**
+   * Set the top state handoff duration threshold in milliseconds
+   * @param durationThreshold
+   */
+  public void setTopStateHandoffDurationThreshold(long durationThreshold) {
+    _record.setLongField(ClusterConfigProperty.TOP_STATE_HANDOFF_DURATION_THRESHOLD.name(),
+        durationThreshold);
+  }
+
+  /**
+   * Get the top state handoff duration threshold. If not configured, defaults to 10000ms.
+   * @return the threshold in milliseconds
+   */
+  public long getTopStateHandoffDurationThreshold() {
+    return _record.getLongField(ClusterConfigProperty.TOP_STATE_HANDOFF_DURATION_THRESHOLD.name(),
+        10000L);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -666,6 +666,22 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
+  public void incrementInProgressHandoffBeyondThresholdGauge(String resourceName) {
+    ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
+
+    if (resourceMonitor != null) {
+      resourceMonitor.incrementInProgressHandoffBeyondThresholdGauge();
+    }
+  }
+
+  public void decrementInProgressHandoffBeyondThresholdGauge(String resourceName) {
+    ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
+
+    if (resourceMonitor != null) {
+      resourceMonitor.decrementInProgressHandoffBeyondThresholdGauge();
+    }
+  }
+
   public void updateRebalancerStats(String resourceName, long numPendingRecoveryRebalancePartitions,
       long numPendingLoadRebalancePartitions, long numRecoveryRebalanceThrottledPartitions,
       long numLoadRebalanceThrottledPartitions, boolean rebalanceThrottledByErrorPartitions) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -55,6 +55,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   // Gauges
   private SimpleDynamicMetric<Long> _numOfPartitions;
   private SimpleDynamicMetric<Long> _missingTopStatePartitionsBeyondThresholdGauge;
+  private SimpleDynamicMetric<Long> _inProgressHandoffBeyondThresholdGauge;
   private SimpleDynamicMetric<Long> _numOfPartitionsInExternalView;
   private SimpleDynamicMetric<Long> _numOfErrorPartitions;
   private SimpleDynamicMetric<Long> _numNonTopStatePartitions;
@@ -135,6 +136,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         new SimpleDynamicMetric("MissingMinActiveReplicaPartitionGauge", 0L);
     _numNonTopStatePartitions = new SimpleDynamicMetric("MissingTopStatePartitionGauge", 0L);
     _missingTopStatePartitionsBeyondThresholdGauge = new SimpleDynamicMetric("MissingTopStatePartitionsBeyondThresholdGauge", 0L);
+    _inProgressHandoffBeyondThresholdGauge = new SimpleDynamicMetric("PartitionsTopStateHandoffDurationBeyondThreshold", 0L);
     _numOfErrorPartitions = new SimpleDynamicMetric("ErrorPartitionGauge", 0L);
     _numOfPartitionsInExternalView = new SimpleDynamicMetric("ExternalViewPartitionGauge", 0L);
     _numOfPartitions = new SimpleDynamicMetric("PartitionGauge", 0L);
@@ -201,6 +203,10 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
   public long getMaxSinglePartitionTopStateHandoffDurationGauge() {
     return _maxSinglePartitionTopStateHandoffDuration.getValue();
+  }
+
+  public long getInProgressHandoffBeyondThresholdGauge() {
+    return _inProgressHandoffBeyondThresholdGauge.getValue();
   }
 
   public HistogramDynamicMetric getPartitionTopStateHandoffDurationGauge() {
@@ -486,6 +492,16 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _lastResetTime = System.currentTimeMillis();
   }
 
+  public void incrementInProgressHandoffBeyondThresholdGauge() {
+    _inProgressHandoffBeyondThresholdGauge.updateValue(_inProgressHandoffBeyondThresholdGauge.getValue() + 1);
+    _lastResetTime = System.currentTimeMillis();
+  }
+
+  public void decrementInProgressHandoffBeyondThresholdGauge() {
+    _inProgressHandoffBeyondThresholdGauge.updateValue(Math.max(0, _inProgressHandoffBeyondThresholdGauge.getValue() - 1));
+    _lastResetTime = System.currentTimeMillis();
+  }
+
   private List<DynamicMetric<?, ?>> buildAttributeList() {
     List<DynamicMetric<?, ?>> attributeList = Lists.newArrayList(
         _numOfPartitions,
@@ -493,6 +509,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         _numOfErrorPartitions,
         _numNonTopStatePartitions,
         _missingTopStatePartitionsBeyondThresholdGauge,
+        _inProgressHandoffBeyondThresholdGauge,
         _numLessMinActiveReplicaPartitions,
         _numLessReplicaPartitions,
         _numPendingRecoveryRebalanceReplicas,

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInProgressHandoffMetric.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInProgressHandoffMetric.java
@@ -1,0 +1,106 @@
+package org.apache.helix.monitoring.mbeans;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for InProgressHandoffBeyondThresholdGauge metric
+ */
+public class TestInProgressHandoffMetric {
+
+  private static final String CLUSTER_NAME = "TestCluster";
+  private static final String RESOURCE_NAME = "TestDB";
+
+  @Test
+  public void testGaugeIncrementAndDecrement() {
+    ClusterStatusMonitor clusterMonitor = new ClusterStatusMonitor(CLUSTER_NAME);
+    clusterMonitor.active();
+
+    // Increment gauge - this will create the resource monitor
+    clusterMonitor.incrementInProgressHandoffBeyondThresholdGauge(RESOURCE_NAME);
+
+    // Get the resource monitor and verify
+    ResourceMonitor resourceMonitor = clusterMonitor.getResourceMonitor(RESOURCE_NAME);
+    Assert.assertEquals(resourceMonitor.getInProgressHandoffBeyondThresholdGauge(), 1L);
+
+    // Increment again
+    clusterMonitor.incrementInProgressHandoffBeyondThresholdGauge(RESOURCE_NAME);
+    Assert.assertEquals(resourceMonitor.getInProgressHandoffBeyondThresholdGauge(), 2L);
+
+    // Decrement
+    clusterMonitor.decrementInProgressHandoffBeyondThresholdGauge(RESOURCE_NAME);
+    Assert.assertEquals(resourceMonitor.getInProgressHandoffBeyondThresholdGauge(), 1L);
+
+    // Decrement to 0
+    clusterMonitor.decrementInProgressHandoffBeyondThresholdGauge(RESOURCE_NAME);
+    Assert.assertEquals(resourceMonitor.getInProgressHandoffBeyondThresholdGauge(), 0L);
+
+    // Decrement below 0 should stay at 0
+    clusterMonitor.decrementInProgressHandoffBeyondThresholdGauge(RESOURCE_NAME);
+    Assert.assertEquals(resourceMonitor.getInProgressHandoffBeyondThresholdGauge(), 0L);
+
+    clusterMonitor.reset();
+  }
+
+  @Test
+  public void testMultipleResources() {
+    ClusterStatusMonitor clusterMonitor = new ClusterStatusMonitor(CLUSTER_NAME);
+    clusterMonitor.active();
+
+    // Test with multiple resources
+    String resource1 = "DB1";
+    String resource2 = "DB2";
+
+    clusterMonitor.incrementInProgressHandoffBeyondThresholdGauge(resource1);
+    clusterMonitor.incrementInProgressHandoffBeyondThresholdGauge(resource1);
+    clusterMonitor.incrementInProgressHandoffBeyondThresholdGauge(resource2);
+
+    ResourceMonitor monitor1 = clusterMonitor.getResourceMonitor(resource1);
+    ResourceMonitor monitor2 = clusterMonitor.getResourceMonitor(resource2);
+
+    Assert.assertEquals(monitor1.getInProgressHandoffBeyondThresholdGauge(), 2L);
+    Assert.assertEquals(monitor2.getInProgressHandoffBeyondThresholdGauge(), 1L);
+
+    // Decrement one resource
+    clusterMonitor.decrementInProgressHandoffBeyondThresholdGauge(resource1);
+    Assert.assertEquals(monitor1.getInProgressHandoffBeyondThresholdGauge(), 1L);
+    Assert.assertEquals(monitor2.getInProgressHandoffBeyondThresholdGauge(), 1L);
+
+    clusterMonitor.reset();
+  }
+
+  @Test
+  public void testMetricRegistration() {
+    ClusterStatusMonitor clusterMonitor = new ClusterStatusMonitor(CLUSTER_NAME);
+    clusterMonitor.active();
+
+    // Increment to create resource monitor
+    clusterMonitor.incrementInProgressHandoffBeyondThresholdGauge(RESOURCE_NAME);
+
+    // Verify resource monitor exists and metric can be read
+    ResourceMonitor resourceMonitor = clusterMonitor.getResourceMonitor(RESOURCE_NAME);
+    Assert.assertNotNull(resourceMonitor);
+    Assert.assertEquals(resourceMonitor.getInProgressHandoffBeyondThresholdGauge(), 1L);
+
+    clusterMonitor.reset();
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)
This PR introduces a new metric `PartitionsTopStateHandoffDurationBeyondThreshold` that detects stuck top state handoffs **while they're still in progress**.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
The existing `MaxSinglePartitionTopStateHandoffDuration` metric only emits after handoff completion. During incidents, a stuck L-> F transition went undetected for 91 minutes because the handoff never completed.

How this PR solves it?
When IdealState expects a different instance to have top state than CurrentState shows:
  1. Create/update `InProgressHandoffRecord` with timestamp
  2. If duration exceeds threshold and not already flagged, increment metric
  3. When handoff resolves (IdealState matches CurrentState), decrement metric
 
### Tests
UT file added: TestInProgressHandoffMetric.java

Manually tested in a actual Cluster

1. Created Helix Cluster locally, throttled MASTER->SLAVE transitions to take 180 seconds, set TOP_STATE_HANDOFF_DURATION_THRESHOLD to 30 seconds.
2. Disable instances that were holding MASTER status, paritions will move to OFFLINE, through route MASTER->SLAVE and SLAVE->OFFLINE. Since first transition is throttled and TOP_STATE_HANDOFF_DURATION_THRESHOLD is 30 seconds, we should see new metric getting emitted before the old MaxSinglePartitionTopStateHandoffDuration metric as old one emits only after the handoff succeed. 
3. Can see in the image, the last spikes for both metrics, PartitionsTopStateHandoffDurationBeyondThreshold started getting emitted, and MaxSinglePartitionTopStateHandoffDuration only emitted when handoff completed.

<img width="753" height="227" alt="image" src="https://github.com/user-attachments/assets/62347f32-2393-4690-9ed7-a4b160625aec" />
<img width="759" height="220" alt="image" src="https://github.com/user-attachments/assets/e80c9285-8b23-4e9a-95f0-0df4f2b703b8" />


- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
