### PR TITLE
Add exclusion support to isEvacuateFinished for graceful evacuation handling

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -22,12 +22,14 @@ package org.apache.helix;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
 import org.apache.helix.api.status.ClusterManagementMode;
 import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
+import org.apache.helix.constants.EvacuateExclusionType;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConstraints;
@@ -806,6 +808,21 @@ public interface HelixAdmin {
    */
   default boolean isEvacuateFinished(String clusterName, String instancesName) {
     throw new UnsupportedOperationException("isEvacuateFinished is not implemented.");
+  }
+
+  /**
+   * Return if instance operation 'Evacuate' is finished with exclusions.
+   * This method allows certain resources or partitions to be excluded from blocking evacuation completion.
+   *
+   * @param clusterName The name of the cluster
+   * @param instancesName The name of the instance
+   * @param exclusionTypes Set of exclusion types to apply (e.g., DISABLED_RESOURCE, ERROR_PARTITIONS, DISABLED_PARTITION)
+   * @return Return true if there is no FULL_AUTO or CUSTOMIZED resources (after applying exclusions)
+   *         in the current state nor any pending message on the instance.
+   */
+  default boolean isEvacuateFinished(String clusterName, String instancesName,
+      Set<EvacuateExclusionType> exclusionTypes) {
+    throw new UnsupportedOperationException("isEvacuateFinished with exclusions is not implemented.");
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.helix.api.status.ClusterManagementMode;
 import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
-import org.apache.helix.constants.EvacuateExclusionType;
+import org.apache.helix.constants.InstanceDrainExclusionType;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConstraints;
@@ -821,7 +821,7 @@ public interface HelixAdmin {
    *         in the current state nor any pending message on the instance.
    */
   default boolean isEvacuateFinished(String clusterName, String instancesName,
-      Set<EvacuateExclusionType> exclusionTypes) {
+      Set<InstanceDrainExclusionType> exclusionTypes) {
     throw new UnsupportedOperationException("isEvacuateFinished with exclusions is not implemented.");
   }
 

--- a/helix-core/src/main/java/org/apache/helix/constants/EvacuateExclusionType.java
+++ b/helix-core/src/main/java/org/apache/helix/constants/EvacuateExclusionType.java
@@ -1,0 +1,63 @@
+package org.apache.helix.constants;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Types of exclusions that can be applied when checking if evacuation is finished.
+ * These exclusions allow certain resources or partitions to be ignored when determining
+ * if an instance has completed evacuation.
+ */
+public enum EvacuateExclusionType {
+  /**
+   * Exclude resources that are disabled from blocking evacuation completion
+   */
+  DISABLED_RESOURCE,
+
+  /**
+   * Exclude partitions that are in ERROR state from blocking evacuation completion
+   */
+  ERROR_PARTITIONS,
+
+  /**
+   * Exclude partitions that are disabled from blocking evacuation completion
+   */
+  DISABLED_PARTITION;
+
+  /**
+   * Parse a comma-separated string of exclusion types into a Set
+   * @param exclusionStr comma-separated string of exclusion types (e.g., "DISABLED_RESOURCE,ERROR_PARTITIONS")
+   * @return Set of EvacuateExclusionType enums
+   */
+  public static Set<EvacuateExclusionType> parseExclusionTypes(String exclusionStr) {
+    if (exclusionStr == null || exclusionStr.trim().isEmpty()) {
+      return Collections.emptySet();
+    }
+    return Stream.of(exclusionStr.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(EvacuateExclusionType::valueOf)
+        .collect(Collectors.toSet());
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/constants/InstanceDrainExclusionType.java
+++ b/helix-core/src/main/java/org/apache/helix/constants/InstanceDrainExclusionType.java
@@ -25,39 +25,40 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Types of exclusions that can be applied when checking if evacuation is finished.
+ * Types of exclusions that can be applied when checking instance drain status (evacuation, instance drain, etc.).
  * These exclusions allow certain resources or partitions to be ignored when determining
- * if an instance has completed evacuation.
+ * if an instance has completed draining/evacuation.
  */
-public enum EvacuateExclusionType {
+public enum InstanceDrainExclusionType {
   /**
-   * Exclude resources that are disabled from blocking evacuation completion
+   * Exclude resources that are disabled from blocking instance drain completion
    */
   DISABLED_RESOURCE,
 
   /**
-   * Exclude partitions that are in ERROR state from blocking evacuation completion
+   * Exclude partitions that are in ERROR state from blocking instance drain completion
    */
   ERROR_PARTITIONS,
 
   /**
-   * Exclude partitions that are disabled from blocking evacuation completion
+   * Exclude partitions that are disabled from blocking instance drain completion
    */
   DISABLED_PARTITION;
 
   /**
    * Parse a comma-separated string of exclusion types into a Set
    * @param exclusionStr comma-separated string of exclusion types (e.g., "DISABLED_RESOURCE,ERROR_PARTITIONS")
-   * @return Set of EvacuateExclusionType enums
+   * @return Set of InstanceDrainExclusionType enums
    */
-  public static Set<EvacuateExclusionType> parseExclusionTypes(String exclusionStr) {
+  public static Set<InstanceDrainExclusionType> parseExclusionTypes(String exclusionStr) {
     if (exclusionStr == null || exclusionStr.trim().isEmpty()) {
       return Collections.emptySet();
     }
     return Stream.of(exclusionStr.split(","))
         .map(String::trim)
         .filter(s -> !s.isEmpty())
-        .map(EvacuateExclusionType::valueOf)
+        .map(InstanceDrainExclusionType::valueOf)
         .collect(Collectors.toSet());
   }
 }
+

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -60,7 +60,7 @@ import org.apache.helix.api.exceptions.HelixConflictException;
 import org.apache.helix.api.status.ClusterManagementMode;
 import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
-import org.apache.helix.constants.EvacuateExclusionType;
+import org.apache.helix.constants.InstanceDrainExclusionType;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.rebalancer.strategy.RebalanceStrategy;
 import org.apache.helix.manager.zk.evacuation.PartitionExclusionFilter;
@@ -469,7 +469,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public boolean isEvacuateFinished(String clusterName, String instanceName,
-      Set<EvacuateExclusionType> exclusionTypes) {
+      Set<InstanceDrainExclusionType> exclusionTypes) {
     InstanceConfig config = getInstanceConfig(clusterName, instanceName);
     if (config == null || config.getInstanceOperation().getOperation() !=
         InstanceConstants.InstanceOperation.EVACUATE ) {
@@ -810,7 +810,7 @@ public class ZKHelixAdmin implements HelixAdmin {
    * @return true if instance has current state or messages that block evacuation, false otherwise
    */
   private boolean instanceHasCurrentStateOrMessage(String clusterName,
-      String instanceName, Set<EvacuateExclusionType> exclusionTypes) {
+      String instanceName, Set<InstanceDrainExclusionType> exclusionTypes) {
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, _baseDataAccessor);
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
 
@@ -844,21 +844,12 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates(), true);
 
-    // Step 1: Get set of FULL_AUTO and CUSTOMIZED resources, applying DISABLED_RESOURCE exclusion
+    // Step 1: Get set of FULL_AUTO and CUSTOMIZED resources, except for excluded ones through exclusion list
     Set<String> allowedResources = filterResourcesByModeAndExclusions(idealStates, exclusionTypes);
 
-    // Step 2: Only fetch InstanceConfig if DISABLED_PARTITION exclusion is requested
-    // This addresses the performance concern from review comment #2
-    Map<String, List<String>> disabledPartitionsMap = null;
-    if (exclusionTypes.contains(EvacuateExclusionType.DISABLED_PARTITION)) {
-      InstanceConfig instanceConfig = accessor.getProperty(keyBuilder.instanceConfig(instanceName));
-      disabledPartitionsMap = instanceConfig != null ?
-          instanceConfig.getDisabledPartitionsMap() : Collections.emptyMap();
-    }
-
-    // Step 3: Create exclusion filters based on requested exclusion types
-    Map<EvacuateExclusionType, PartitionExclusionFilter> filters =
-        PartitionExclusionHelper.createExclusionFilters(exclusionTypes, disabledPartitionsMap);
+    // Step 2: Create exclusion filters based on requested exclusion types
+    Map<InstanceDrainExclusionType, PartitionExclusionFilter> filters =
+        PartitionExclusionHelper.createExclusionFilters(exclusionTypes, accessor, instanceName);
 
     // Handle offline instances - check if CUSTOMIZED resources are reassigned
     if (liveInstance == null) {
@@ -905,7 +896,7 @@ public class ZKHelixAdmin implements HelixAdmin {
    * @return Set of resource names that match the criteria
    */
   private Set<String> filterResourcesByModeAndExclusions(List<IdealState> idealStates,
-      Set<EvacuateExclusionType> exclusionTypes) {
+      Set<InstanceDrainExclusionType> exclusionTypes) {
     if (idealStates == null) {
       return Collections.emptySet();
     }
@@ -913,7 +904,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     return idealStates.stream()
         .filter(idealState -> idealState.getRebalanceMode() == RebalanceMode.FULL_AUTO ||
             idealState.getRebalanceMode() == RebalanceMode.CUSTOMIZED)
-        .filter(idealState -> !exclusionTypes.contains(EvacuateExclusionType.DISABLED_RESOURCE) ||
+        .filter(idealState -> !exclusionTypes.contains(InstanceDrainExclusionType.DISABLED_RESOURCE) ||
             idealState.isEnabled())
         .map(IdealState::getResourceName)
         .collect(Collectors.toSet());

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/DisabledPartitionExclusionFilter.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/DisabledPartitionExclusionFilter.java
@@ -1,0 +1,44 @@
+package org.apache.helix.manager.zk.evacuation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Filter that excludes partitions that are disabled at the instance level from blocking evacuation completion.
+ */
+public class DisabledPartitionExclusionFilter implements PartitionExclusionFilter {
+  
+  private final Map<String, List<String>> disabledPartitionsMap;
+  
+  public DisabledPartitionExclusionFilter(Map<String, List<String>> disabledPartitionsMap) {
+    this.disabledPartitionsMap = disabledPartitionsMap;
+  }
+  
+  @Override
+  public boolean shouldExclude(String partition, String state, String resourceName) {
+    if (disabledPartitionsMap == null) {
+      return false;
+    }
+    List<String> disabledPartitions = disabledPartitionsMap.get(resourceName);
+    return disabledPartitions != null && disabledPartitions.contains(partition);
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/ErrorPartitionExclusionFilter.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/ErrorPartitionExclusionFilter.java
@@ -1,0 +1,33 @@
+package org.apache.helix.manager.zk.evacuation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.HelixDefinedState;
+
+/**
+ * Filter that excludes partitions in ERROR state from blocking evacuation completion.
+ */
+public class ErrorPartitionExclusionFilter implements PartitionExclusionFilter {
+  
+  @Override
+  public boolean shouldExclude(String partition, String state, String resourceName) {
+    return HelixDefinedState.ERROR.name().equals(state);
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionExclusionFilter.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionExclusionFilter.java
@@ -1,0 +1,37 @@
+package org.apache.helix.manager.zk.evacuation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Interface for filtering partitions during evacuation completion checks.
+ * Each exclusion type should implement this interface to provide its own filtering logic.
+ */
+public interface PartitionExclusionFilter {
+  
+  /**
+   * Determines if a partition should be excluded from evacuation completion check.
+   *
+   * @param partition The partition name
+   * @param state The current state of the partition
+   * @param resourceName The resource name
+   * @return true if partition should be excluded (not block evacuation), false otherwise
+   */
+  boolean shouldExclude(String partition, String state, String resourceName);
+}

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionExclusionHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionExclusionHelper.java
@@ -1,0 +1,216 @@
+package org.apache.helix.manager.zk.evacuation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.helix.constants.EvacuateExclusionType;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.IdealState;
+
+/**
+ * Helper class for applying exclusion filters to partitions during evacuation checks.
+ */
+public class PartitionExclusionHelper {
+
+  /**
+   * Collects all partitions from current states that belong to FULL_AUTO or CUSTOMIZED resources.
+   *
+   * @param currentStates List of current states for the instance
+   * @param allowedResources Set of resources that are FULL_AUTO/CUSTOMIZED and enabled (if required)
+   * @return List of PartitionInfo objects representing all partitions on the instance
+   */
+  public static List<PartitionInfo> collectPartitions(List<CurrentState> currentStates,
+      Set<String> allowedResources) {
+    if (currentStates == null || currentStates.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<PartitionInfo> partitions = new ArrayList<>();
+    for (CurrentState cs : currentStates) {
+      String resourceName = cs.getResourceName();
+
+      // Only consider resources in the allowed set (FULL_AUTO/CUSTOMIZED and possibly enabled)
+      if (!allowedResources.contains(resourceName)) {
+        continue;
+      }
+
+      Map<String, String> partitionStateMap = cs.getPartitionStateMap();
+      if (partitionStateMap == null || partitionStateMap.isEmpty()) {
+        continue;
+      }
+
+      // Collect all partitions for this resource
+      for (Map.Entry<String, String> entry : partitionStateMap.entrySet()) {
+        partitions.add(new PartitionInfo(entry.getKey(), entry.getValue(), resourceName));
+      }
+    }
+
+    return partitions;
+  }
+
+  /**
+   * Creates exclusion filters based on the requested exclusion types.
+   * This method only creates filters for exclusion types that are present in the exclusionTypes set.
+   *
+   * @param exclusionTypes Set of exclusion types to apply
+   * @param disabledPartitionsMap Map of resource to disabled partitions (can be null if not needed)
+   * @return Map of exclusion type to corresponding filter
+   */
+  public static Map<EvacuateExclusionType, PartitionExclusionFilter> createExclusionFilters(
+      Set<EvacuateExclusionType> exclusionTypes, Map<String, List<String>> disabledPartitionsMap) {
+
+    if (exclusionTypes == null || exclusionTypes.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<EvacuateExclusionType, PartitionExclusionFilter> filters = new HashMap<>();
+
+    for (EvacuateExclusionType exclusionType : exclusionTypes) {
+      switch (exclusionType) {
+        case ERROR_PARTITIONS:
+          filters.put(exclusionType, new ErrorPartitionExclusionFilter());
+          break;
+        case DISABLED_PARTITION:
+          filters.put(exclusionType, new DisabledPartitionExclusionFilter(disabledPartitionsMap));
+          break;
+        case DISABLED_RESOURCE:
+          // DISABLED_RESOURCE is handled at resource level, not partition level
+          // It's applied during resource filtering, not partition filtering
+          break;
+      }
+    }
+
+    return filters;
+  }
+
+  /**
+   * Applies exclusion filters to a list of partitions and returns partitions that are NOT excluded.
+   *
+   * @param partitions List of partitions to filter
+   * @param filters Map of exclusion filters to apply
+   * @return List of partitions that should NOT be excluded (i.e., should block evacuation)
+   */
+  public static List<PartitionInfo> applyExclusions(List<PartitionInfo> partitions,
+      Map<EvacuateExclusionType, PartitionExclusionFilter> filters) {
+
+    if (partitions == null || partitions.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    if (filters == null || filters.isEmpty()) {
+      return partitions; // No exclusions, return all partitions
+    }
+
+    return partitions.stream()
+        .filter(partition -> !shouldExcludePartition(partition, filters))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Determines if a partition should be excluded based on the provided filters.
+   *
+   * @param partition The partition to check
+   * @param filters Map of exclusion filters
+   * @return true if the partition should be excluded, false otherwise
+   */
+  private static boolean shouldExcludePartition(PartitionInfo partition,
+      Map<EvacuateExclusionType, PartitionExclusionFilter> filters) {
+
+    // If ANY filter says to exclude this partition, then exclude it
+    for (PartitionExclusionFilter filter : filters.values()) {
+      if (filter.shouldExclude(partition.getPartitionName(), partition.getState(),
+          partition.getResourceName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Gets partitions from current states for customized resources that are still assigned 
+   * to the instance (i.e., not yet reassigned to other instances).
+   * This is used for offline instances.
+   *
+   * @param currentStates List of current states
+   * @param idealStates List of ideal states
+   * @param instanceName The instance being checked
+   * @param allowedResources Set of allowed resources (already filtered)
+   * @param filters Exclusion filters to apply
+   * @return List of partitions that are still assigned to the instance (after exclusions)
+   */
+  public static List<PartitionInfo> getCustomizedPartitionsStillOnInstance(
+      List<CurrentState> currentStates, List<IdealState> idealStates, String instanceName,
+      Set<String> allowedResources, Map<EvacuateExclusionType, PartitionExclusionFilter> filters) {
+
+    if (currentStates == null || idealStates == null) {
+      return Collections.emptyList();
+    }
+
+    // Create a map of resourceName -> CurrentState
+    Map<String, CurrentState> currentStateMap = currentStates.stream()
+        .collect(Collectors.toMap(CurrentState::getResourceName, cs -> cs));
+
+    // Create a map of resourceName -> IdealState for CUSTOMIZED resources
+    Map<String, IdealState> customizedIdealStateMap = idealStates.stream()
+        .filter(is -> is.getRebalanceMode() == IdealState.RebalanceMode.CUSTOMIZED &&
+            currentStateMap.containsKey(is.getResourceName()) &&
+            allowedResources.contains(is.getResourceName()))
+        .collect(Collectors.toMap(IdealState::getResourceName, is -> is));
+
+    List<PartitionInfo> partitionsStillOnInstance = new ArrayList<>();
+
+    // For each customized resource, check which partitions are still assigned to the instance
+    for (Map.Entry<String, IdealState> entry : customizedIdealStateMap.entrySet()) {
+      String resourceName = entry.getKey();
+      IdealState idealState = entry.getValue();
+      CurrentState cs = currentStateMap.get(resourceName);
+
+      if (cs == null || cs.getPartitionStateMap() == null) {
+        continue;
+      }
+
+      for (Map.Entry<String, String> partitionEntry : cs.getPartitionStateMap().entrySet()) {
+        String partition = partitionEntry.getKey();
+        String state = partitionEntry.getValue();
+
+        PartitionInfo partitionInfo = new PartitionInfo(partition, state, resourceName);
+
+        // Apply exclusion filters
+        if (shouldExcludePartition(partitionInfo, filters)) {
+          continue; // Skip excluded partitions
+        }
+
+        // Check if this partition is still assigned to the instance in IdealState
+        Map<String, String> instanceStateMap = idealState.getInstanceStateMap(partition);
+        if (instanceStateMap != null && instanceStateMap.containsKey(instanceName)) {
+          partitionsStillOnInstance.add(partitionInfo);
+        }
+      }
+    }
+
+    return partitionsStillOnInstance;
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionExclusionHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionExclusionHelper.java
@@ -26,9 +26,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.helix.constants.EvacuateExclusionType;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.constants.InstanceDrainExclusionType;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
 
 /**
  * Helper class for applying exclusion filters to partitions during evacuation checks.
@@ -36,10 +38,10 @@ import org.apache.helix.model.IdealState;
 public class PartitionExclusionHelper {
 
   /**
-   * Collects all partitions from current states that belong to FULL_AUTO or CUSTOMIZED resources.
+   * Collects all partitions from current states for the specified resources.
    *
    * @param currentStates List of current states for the instance
-   * @param allowedResources Set of resources that are FULL_AUTO/CUSTOMIZED and enabled (if required)
+   * @param allowedResources Set of resources to consider
    * @return List of PartitionInfo objects representing all partitions on the instance
    */
   public static List<PartitionInfo> collectPartitions(List<CurrentState> currentStates,
@@ -52,7 +54,7 @@ public class PartitionExclusionHelper {
     for (CurrentState cs : currentStates) {
       String resourceName = cs.getResourceName();
 
-      // Only consider resources in the allowed set (FULL_AUTO/CUSTOMIZED and possibly enabled)
+      // Only consider resources in the allowed set
       if (!allowedResources.contains(resourceName)) {
         continue;
       }
@@ -76,24 +78,31 @@ public class PartitionExclusionHelper {
    * This method only creates filters for exclusion types that are present in the exclusionTypes set.
    *
    * @param exclusionTypes Set of exclusion types to apply
-   * @param disabledPartitionsMap Map of resource to disabled partitions (can be null if not needed)
+   * @param accessor HelixDataAccessor to fetch instance configuration data if needed
+   * @param instanceName Instance name for which to fetch configuration
    * @return Map of exclusion type to corresponding filter
    */
-  public static Map<EvacuateExclusionType, PartitionExclusionFilter> createExclusionFilters(
-      Set<EvacuateExclusionType> exclusionTypes, Map<String, List<String>> disabledPartitionsMap) {
+  public static Map<InstanceDrainExclusionType, PartitionExclusionFilter> createExclusionFilters(
+      Set<InstanceDrainExclusionType> exclusionTypes, HelixDataAccessor accessor,
+      String instanceName) {
 
     if (exclusionTypes == null || exclusionTypes.isEmpty()) {
       return Collections.emptyMap();
     }
 
-    Map<EvacuateExclusionType, PartitionExclusionFilter> filters = new HashMap<>();
+    Map<InstanceDrainExclusionType, PartitionExclusionFilter> filters = new HashMap<>();
 
-    for (EvacuateExclusionType exclusionType : exclusionTypes) {
+    for (InstanceDrainExclusionType exclusionType : exclusionTypes) {
       switch (exclusionType) {
         case ERROR_PARTITIONS:
           filters.put(exclusionType, new ErrorPartitionExclusionFilter());
           break;
         case DISABLED_PARTITION:
+          // Fetch InstanceConfig only when DISABLED_PARTITION exclusion is requested
+          InstanceConfig instanceConfig =
+              accessor.getProperty(accessor.keyBuilder().instanceConfig(instanceName));
+          Map<String, List<String>> disabledPartitionsMap = instanceConfig != null ?
+              instanceConfig.getDisabledPartitionsMap() : Collections.emptyMap();
           filters.put(exclusionType, new DisabledPartitionExclusionFilter(disabledPartitionsMap));
           break;
         case DISABLED_RESOURCE:
@@ -114,7 +123,7 @@ public class PartitionExclusionHelper {
    * @return List of partitions that should NOT be excluded (i.e., should block evacuation)
    */
   public static List<PartitionInfo> applyExclusions(List<PartitionInfo> partitions,
-      Map<EvacuateExclusionType, PartitionExclusionFilter> filters) {
+      Map<InstanceDrainExclusionType, PartitionExclusionFilter> filters) {
 
     if (partitions == null || partitions.isEmpty()) {
       return Collections.emptyList();
@@ -137,7 +146,7 @@ public class PartitionExclusionHelper {
    * @return true if the partition should be excluded, false otherwise
    */
   private static boolean shouldExcludePartition(PartitionInfo partition,
-      Map<EvacuateExclusionType, PartitionExclusionFilter> filters) {
+      Map<InstanceDrainExclusionType, PartitionExclusionFilter> filters) {
 
     // If ANY filter says to exclude this partition, then exclude it
     for (PartitionExclusionFilter filter : filters.values()) {
@@ -163,7 +172,7 @@ public class PartitionExclusionHelper {
    */
   public static List<PartitionInfo> getCustomizedPartitionsStillOnInstance(
       List<CurrentState> currentStates, List<IdealState> idealStates, String instanceName,
-      Set<String> allowedResources, Map<EvacuateExclusionType, PartitionExclusionFilter> filters) {
+      Set<String> allowedResources, Map<InstanceDrainExclusionType, PartitionExclusionFilter> filters) {
 
     if (currentStates == null || idealStates == null) {
       return Collections.emptyList();

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionInfo.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionInfo.java
@@ -1,0 +1,53 @@
+package org.apache.helix.manager.zk.evacuation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Data class representing partition information for evacuation checks.
+ */
+public class PartitionInfo {
+  private final String partitionName;
+  private final String state;
+  private final String resourceName;
+  
+  public PartitionInfo(String partitionName, String state, String resourceName) {
+    this.partitionName = partitionName;
+    this.state = state;
+    this.resourceName = resourceName;
+  }
+  
+  public String getPartitionName() {
+    return partitionName;
+  }
+  
+  public String getState() {
+    return state;
+  }
+  
+  public String getResourceName() {
+    return resourceName;
+  }
+  
+  @Override
+  public String toString() {
+    return String.format("PartitionInfo{partition=%s, state=%s, resource=%s}", 
+        partitionName, state, resourceName);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
@@ -1,0 +1,443 @@
+package org.apache.helix.integration.rebalancer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.TestHelper;
+import org.apache.helix.constants.EvacuateExclusionType;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Integration tests for isEvacuateFinished with exclusion types.
+ * Focuses on testing the new exclusion functionality.
+ */
+public class TestEvacuateWithExclusions extends TaskTestBase {
+
+  private HelixAdmin _admin;
+  private BestPossibleExternalViewVerifier _clusterVerifier;
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _numNodes = 5;
+    _numPartitions = 10;
+    _numReplicas = 3;
+    super.beforeClass();
+
+    _admin = new ZKHelixAdmin(_gZkClient);
+    _clusterVerifier = new BestPossibleExternalViewVerifier.Builder(CLUSTER_NAME)
+        .setZkAddr(ZK_ADDR)
+        .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+        .build();
+  }
+
+  @AfterClass
+  public void afterClass() throws Exception {
+    super.afterClass();
+  }
+
+  /**
+   * Test backward compatibility: isEvacuateFinished without exclusions should work
+   */
+  @Test
+  public void testBackwardCompatibility() throws Exception {
+    System.out.println("START testBackwardCompatibility at " + new Date(System.currentTimeMillis()));
+
+    String db = "TestDB_BackwardCompat";
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, db, _numPartitions,
+        BuiltInStateModelDefinitions.MasterSlave.name(), IdealState.RebalanceMode.FULL_AUTO.name());
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _numReplicas);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    String instanceToEvacuate = _participants[0].getInstanceName();
+
+    // Set instance to EVACUATE
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+
+    // Wait for evacuation
+    Thread.sleep(5000);
+
+    // Verify using old method (no exclusions)
+    boolean evacuated = TestHelper.verify(() -> _admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate), TestHelper.WAIT_DURATION);
+
+    Assert.assertTrue(evacuated, "Evacuation should finish");
+
+    // Also verify using new method with empty exclusions
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet()));
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, db);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  /**
+   * Negative test: Old method (without exclusions) fails when disabled resources block evacuation
+   * This demonstrates the problem that the exclusion feature solves
+   */
+  @Test
+  public void testNegativeCase_OldMethodFailsWithDisabledResources() throws Exception {
+    System.out.println("START testNegativeCase_OldMethodFailsWithDisabledResources at " + new Date(System.currentTimeMillis()));
+
+    String enabledDB = "TestDB_Enabled_Negative";
+    String disabledDB = "TestDB_Disabled_Negative";
+
+    // Create enabled resource
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, enabledDB, _numPartitions,
+        BuiltInStateModelDefinitions.MasterSlave.name(), IdealState.RebalanceMode.FULL_AUTO.name());
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, enabledDB, _numReplicas);
+
+    // Create CUSTOMIZED resource (this will have the instance in IdealState even when disabled)
+    IdealState customizedIS = new IdealState(disabledDB);
+    customizedIS.setStateModelDefRef(BuiltInStateModelDefinitions.MasterSlave.name());
+    customizedIS.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+    customizedIS.setReplicas(String.valueOf(_numReplicas));
+    customizedIS.setNumPartitions(2);
+
+    String instanceToEvacuate = _participants[0].getInstanceName();
+    String otherInstance = _participants[1].getInstanceName();
+
+    // Assign partitions to the instance we'll evacuate
+    customizedIS.setPartitionState(disabledDB + "_0", instanceToEvacuate, "MASTER");
+    customizedIS.setPartitionState(disabledDB + "_0", otherInstance, "SLAVE");
+    customizedIS.setPartitionState(disabledDB + "_1", instanceToEvacuate, "SLAVE");
+    customizedIS.setPartitionState(disabledDB + "_1", otherInstance, "MASTER");
+
+    _gSetupTool.getClusterManagementTool().addResource(CLUSTER_NAME, disabledDB, customizedIS);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Disable the CUSTOMIZED resource (this is the blocker)
+    _gSetupTool.getClusterManagementTool().enableResource(CLUSTER_NAME, disabledDB, false);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Set instance to EVACUATE
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+
+    // Wait for evacuation of enabled resources to complete
+    Thread.sleep(5000);
+
+    // NEGATIVE TEST: Old method (without exclusions) should return FALSE
+    // because the disabled CUSTOMIZED resource still has this instance in its IdealState
+    boolean evacuatedOldMethod = TestHelper.verify(
+        () -> _admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate),
+        5000); // Short timeout - we expect this to fail
+
+    Assert.assertFalse(evacuatedOldMethod,
+        "OLD METHOD SHOULD FAIL: Evacuation blocked by disabled CUSTOMIZED resource with instance in IdealState");
+
+    // POSITIVE TEST: New method with DISABLED_RESOURCE exclusion should return TRUE
+    // because we're ignoring the disabled resource
+    Set<EvacuateExclusionType> exclusions = new HashSet<>();
+    exclusions.add(EvacuateExclusionType.DISABLED_RESOURCE);
+
+    boolean evacuatedWithExclusions = _admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions);
+    Assert.assertTrue(evacuatedWithExclusions,
+        "NEW METHOD SHOULD SUCCEED: Evacuation completes when excluding disabled resources");
+
+    // This clearly demonstrates the value of the exclusion feature!
+    System.out.println("✓ Verified: Old method fails (returns false), new method with exclusions succeeds (returns true)");
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, enabledDB);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, disabledDB);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  /**
+   * Negative test with FULL_AUTO: Old method fails when disabled FULL_AUTO resources block evacuation
+   */
+  @Test
+  public void testNegativeCase_OldMethodFailsWithDisabledFullAutoResources() throws Exception {
+    System.out.println("START testNegativeCase_OldMethodFailsWithDisabledFullAutoResources at " + new Date(System.currentTimeMillis()));
+
+    String enabledDB = "TestDB_Enabled_FullAuto_Negative";
+    String disabledDB = "TestDB_Disabled_FullAuto_Negative";
+
+    // Create two FULL_AUTO resources
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, enabledDB, _numPartitions,
+        BuiltInStateModelDefinitions.MasterSlave.name(), IdealState.RebalanceMode.FULL_AUTO.name());
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, enabledDB, _numReplicas);
+
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, disabledDB, _numPartitions,
+        BuiltInStateModelDefinitions.MasterSlave.name(), IdealState.RebalanceMode.FULL_AUTO.name());
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, disabledDB, _numReplicas);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Disable one resource (partitions might still be in CurrentState)
+    _gSetupTool.getClusterManagementTool().enableResource(CLUSTER_NAME, disabledDB, false);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    String instanceToEvacuate = _participants[0].getInstanceName();
+
+    // Set instance to EVACUATE
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+
+    // Wait for evacuation of enabled resource
+    Thread.sleep(5000);
+
+    // NEGATIVE TEST: Old method should return FALSE if disabled resource still has partitions
+    // (In practice, disabled FULL_AUTO resources may still have partitions in CurrentState)
+    boolean evacuatedOldMethod = TestHelper.verify(
+        () -> _admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate),
+        5000); // Short timeout
+
+    // OLD METHOD may fail if disabled resource blocks evacuation
+    System.out.println("Old method result (without exclusions): " + evacuatedOldMethod);
+
+    // POSITIVE TEST: New method with DISABLED_RESOURCE exclusion should handle this gracefully
+    Set<EvacuateExclusionType> exclusions = new HashSet<>();
+    exclusions.add(EvacuateExclusionType.DISABLED_RESOURCE);
+
+    boolean evacuatedWithExclusions = _admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions);
+    System.out.println("New method result (with DISABLED_RESOURCE exclusion): " + evacuatedWithExclusions);
+
+    // New method with exclusions should succeed or at least not be blocked by disabled resources
+    Assert.assertTrue(evacuatedWithExclusions || !evacuatedOldMethod,
+        "NEW METHOD: Should succeed when excluding disabled FULL_AUTO resources");
+
+    System.out.println("✓ Verified: FULL_AUTO resources - old method behavior vs new method with exclusions");
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, enabledDB);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, disabledDB);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  /**
+   * Test DISABLED_RESOURCE exclusion with CUSTOMIZED resources
+   */
+  @Test
+  public void testDisabledResourceExclusion() throws Exception {
+    System.out.println("START testDisabledResourceExclusion at " + new Date(System.currentTimeMillis()));
+
+    String enabledDB = "TestDB_Enabled";
+    String disabledDB = "TestDB_Disabled_Custom";
+
+    // Create enabled resource
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, enabledDB, _numPartitions,
+        BuiltInStateModelDefinitions.MasterSlave.name(), IdealState.RebalanceMode.FULL_AUTO.name());
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, enabledDB, _numReplicas);
+
+    // Create CUSTOMIZED resource
+    IdealState customizedIS = new IdealState(disabledDB);
+    customizedIS.setStateModelDefRef(BuiltInStateModelDefinitions.MasterSlave.name());
+    customizedIS.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+    customizedIS.setReplicas(String.valueOf(_numReplicas));
+    customizedIS.setNumPartitions(2);
+
+    String instanceToEvacuate = _participants[0].getInstanceName();
+    String otherInstance = _participants[1].getInstanceName();
+
+    // Assign 2 partitions to evacuating instance
+    customizedIS.setPartitionState(disabledDB + "_0", instanceToEvacuate, "MASTER");
+    customizedIS.setPartitionState(disabledDB + "_0", otherInstance, "SLAVE");
+    customizedIS.setPartitionState(disabledDB + "_1", instanceToEvacuate, "SLAVE");
+    customizedIS.setPartitionState(disabledDB + "_1", otherInstance, "MASTER");
+
+    _gSetupTool.getClusterManagementTool().addResource(CLUSTER_NAME, disabledDB, customizedIS);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Disable the CUSTOMIZED resource
+    _gSetupTool.getClusterManagementTool().enableResource(CLUSTER_NAME, disabledDB, false);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Set instance to EVACUATE
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+
+    // Wait for evacuation of enabled resource
+    Thread.sleep(5000);
+
+    // Without exclusions, NOT finished (disabled CUSTOMIZED resource still has instance in IdealState)
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet()));
+
+    // With DISABLED_RESOURCE exclusion, SHOULD be finished
+    Set<EvacuateExclusionType> exclusions = new HashSet<>();
+    exclusions.add(EvacuateExclusionType.DISABLED_RESOURCE);
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions),
+        "Evacuation should be considered finished when excluding disabled resources");
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, enabledDB);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, disabledDB);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  /**
+   * Test offline instance with CUSTOMIZED resources
+   */
+  @Test
+  public void testOfflineInstanceWithCustomizedResource() throws Exception {
+    System.out.println("START testOfflineInstanceWithCustomizedResource at " + new Date(System.currentTimeMillis()));
+
+    String customDB = "TestDB_Customized_Offline";
+
+    // Create CUSTOMIZED resource
+    IdealState customizedIS = new IdealState(customDB);
+    customizedIS.setStateModelDefRef(BuiltInStateModelDefinitions.MasterSlave.name());
+    customizedIS.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+    customizedIS.setReplicas(String.valueOf(2));
+    customizedIS.setNumPartitions(3);
+
+    String instanceToEvacuate = _participants[0].getInstanceName();
+    String otherInstance = _participants[1].getInstanceName();
+
+    // Assign partitions
+    for (int i = 0; i < 3; i++) {
+      customizedIS.setPartitionState(customDB + "_" + i, instanceToEvacuate, i == 0 ? "MASTER" : "SLAVE");
+      customizedIS.setPartitionState(customDB + "_" + i, otherInstance, i == 0 ? "SLAVE" : "MASTER");
+    }
+
+    _gSetupTool.getClusterManagementTool().addResource(CLUSTER_NAME, customDB, customizedIS);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Stop the instance (make it offline)
+    _participants[0].syncStop();
+    Thread.sleep(2000);
+
+    // Set instance to EVACUATE while offline
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+
+    // Evacuation NOT finished - instance still in CUSTOMIZED resource IdealState
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet()));
+
+    // Update IdealState to remove the offline instance
+    IdealState newIdealState = new IdealState(customDB);
+    newIdealState.setStateModelDefRef(BuiltInStateModelDefinitions.MasterSlave.name());
+    newIdealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+    newIdealState.setReplicas(String.valueOf(2));
+    newIdealState.setNumPartitions(3);
+
+    for (int i = 0; i < 3; i++) {
+      newIdealState.setPartitionState(customDB + "_" + i, otherInstance, "MASTER");
+      newIdealState.setPartitionState(customDB + "_" + i, _participants[2].getInstanceName(), "SLAVE");
+    }
+
+    _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, customDB, newIdealState);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Now evacuation SHOULD be finished
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet()),
+        "Evacuation should be finished after removing instance from CUSTOMIZED IdealState");
+
+    // Cleanup
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, customDB);
+
+    // Restart participant
+    _participants[0] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceToEvacuate);
+    _participants[0].syncStart();
+
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  /**
+   * Test combined exclusions
+   */
+  @Test
+  public void testCombinedExclusions() throws Exception {
+    System.out.println("START testCombinedExclusions at " + new Date(System.currentTimeMillis()));
+
+    String enabledDB = "TestDB_Enabled_Combo";
+    String disabledDB = "TestDB_Disabled_Combo";
+
+    // Create resources
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, enabledDB, _numPartitions,
+        BuiltInStateModelDefinitions.MasterSlave.name(), IdealState.RebalanceMode.FULL_AUTO.name());
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, enabledDB, _numReplicas);
+
+    IdealState disabledIS = new IdealState(disabledDB);
+    disabledIS.setStateModelDefRef(BuiltInStateModelDefinitions.MasterSlave.name());
+    disabledIS.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+    disabledIS.setReplicas(String.valueOf(_numReplicas));
+    disabledIS.setNumPartitions(2);
+
+    String instanceToEvacuate = _participants[0].getInstanceName();
+    String otherInstance = _participants[1].getInstanceName();
+
+    disabledIS.setPartitionState(disabledDB + "_0", instanceToEvacuate, "MASTER");
+    disabledIS.setPartitionState(disabledDB + "_0", otherInstance, "SLAVE");
+
+    _gSetupTool.getClusterManagementTool().addResource(CLUSTER_NAME, disabledDB, disabledIS);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Disable one resource
+    _gSetupTool.getClusterManagementTool().enableResource(CLUSTER_NAME, disabledDB, false);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Set instance to EVACUATE
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+
+    Thread.sleep(5000);
+
+    // With DISABLED_RESOURCE exclusion, SHOULD be finished
+    Set<EvacuateExclusionType> exclusions = new HashSet<>();
+    exclusions.add(EvacuateExclusionType.DISABLED_RESOURCE);
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions),
+        "Evacuation should be finished with DISABLED_RESOURCE exclusion");
+
+    // Test multiple exclusions together
+    exclusions.add(EvacuateExclusionType.ERROR_PARTITIONS);
+    exclusions.add(EvacuateExclusionType.DISABLED_PARTITION);
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions),
+        "Evacuation should be finished with multiple exclusions");
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, enabledDB);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, disabledDB);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.TestHelper;
-import org.apache.helix.constants.EvacuateExclusionType;
+import org.apache.helix.constants.InstanceDrainExclusionType;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
@@ -165,8 +165,8 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
 
     // POSITIVE TEST: New method with DISABLED_RESOURCE exclusion should return TRUE
     // because we're ignoring the disabled resource
-    Set<EvacuateExclusionType> exclusions = new HashSet<>();
-    exclusions.add(EvacuateExclusionType.DISABLED_RESOURCE);
+    Set<InstanceDrainExclusionType> exclusions = new HashSet<>();
+    exclusions.add(InstanceDrainExclusionType.DISABLED_RESOURCE);
 
     boolean evacuatedWithExclusions = _admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions);
     Assert.assertTrue(evacuatedWithExclusions,
@@ -227,8 +227,8 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     System.out.println("Old method result (without exclusions): " + evacuatedOldMethod);
 
     // POSITIVE TEST: New method with DISABLED_RESOURCE exclusion should handle this gracefully
-    Set<EvacuateExclusionType> exclusions = new HashSet<>();
-    exclusions.add(EvacuateExclusionType.DISABLED_RESOURCE);
+    Set<InstanceDrainExclusionType> exclusions = new HashSet<>();
+    exclusions.add(InstanceDrainExclusionType.DISABLED_RESOURCE);
 
     boolean evacuatedWithExclusions = _admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions);
     System.out.println("New method result (with DISABLED_RESOURCE exclusion): " + evacuatedWithExclusions);
@@ -297,8 +297,8 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet()));
 
     // With DISABLED_RESOURCE exclusion, SHOULD be finished
-    Set<EvacuateExclusionType> exclusions = new HashSet<>();
-    exclusions.add(EvacuateExclusionType.DISABLED_RESOURCE);
+    Set<InstanceDrainExclusionType> exclusions = new HashSet<>();
+    exclusions.add(InstanceDrainExclusionType.DISABLED_RESOURCE);
     Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions),
         "Evacuation should be considered finished when excluding disabled resources");
 
@@ -422,14 +422,14 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     Thread.sleep(5000);
 
     // With DISABLED_RESOURCE exclusion, SHOULD be finished
-    Set<EvacuateExclusionType> exclusions = new HashSet<>();
-    exclusions.add(EvacuateExclusionType.DISABLED_RESOURCE);
+    Set<InstanceDrainExclusionType> exclusions = new HashSet<>();
+    exclusions.add(InstanceDrainExclusionType.DISABLED_RESOURCE);
     Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions),
         "Evacuation should be finished with DISABLED_RESOURCE exclusion");
 
     // Test multiple exclusions together
-    exclusions.add(EvacuateExclusionType.ERROR_PARTITIONS);
-    exclusions.add(EvacuateExclusionType.DISABLED_PARTITION);
+    exclusions.add(InstanceDrainExclusionType.ERROR_PARTITIONS);
+    exclusions.add(InstanceDrainExclusionType.DISABLED_PARTITION);
     Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, exclusions),
         "Evacuation should be finished with multiple exclusions");
 

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -34,6 +35,7 @@ import org.apache.helix.PropertyType;
 import org.apache.helix.api.status.ClusterManagementMode;
 import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
+import org.apache.helix.constants.EvacuateExclusionType;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConfig;
@@ -574,6 +576,12 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override
   public boolean isEvacuateFinished(String clusterName, String instancesNames) {
+    return false;
+  }
+
+  @Override
+  public boolean isEvacuateFinished(String clusterName, String instancesNames,
+      Set<EvacuateExclusionType> exclusionTypes) {
     return false;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -35,7 +35,7 @@ import org.apache.helix.PropertyType;
 import org.apache.helix.api.status.ClusterManagementMode;
 import org.apache.helix.api.status.ClusterManagementModeRequest;
 import org.apache.helix.api.topology.ClusterTopology;
-import org.apache.helix.constants.EvacuateExclusionType;
+import org.apache.helix.constants.InstanceDrainExclusionType;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConfig;
@@ -581,7 +581,7 @@ public class MockHelixAdmin implements HelixAdmin {
 
   @Override
   public boolean isEvacuateFinished(String clusterName, String instancesNames,
-      Set<EvacuateExclusionType> exclusionTypes) {
+      Set<InstanceDrainExclusionType> exclusionTypes) {
     return false;
   }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -49,7 +49,7 @@ import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
-import org.apache.helix.constants.EvacuateExclusionType;
+import org.apache.helix.constants.InstanceDrainExclusionType;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
@@ -506,8 +506,8 @@ public class PerInstanceAccessor extends AbstractHelixResource {
           boolean evacuateFinished;
           try {
             if (exclusions != null && !exclusions.trim().isEmpty()) {
-              Set<EvacuateExclusionType> exclusionTypes =
-                  EvacuateExclusionType.parseExclusionTypes(exclusions);
+              Set<InstanceDrainExclusionType> exclusionTypes =
+                  InstanceDrainExclusionType.parseExclusionTypes(exclusions);
               evacuateFinished = admin.isEvacuateFinished(clusterId, instanceName, exclusionTypes);
             } else {
               evacuateFinished = admin.isEvacuateFinished(clusterId, instanceName);


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)
This PR adds exclusion support to the `isEvacuateFinished()` API, allowing operators to gracefully handle edge cases where certain resources or partitions should not block evacuation completion.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
Currently, `isEvacuateFinished()` returns `false` if **any** resource has partitions on the evacuating instance, even if:
  - The resource is disabled (operator intentionally turned it off)
  - Partitions are in ERROR state (stuck, requires manual intervention)
  - Partitions are disabled at instance level (operator excluded them)

How my PR solves this?
Added an exclusion mechanism via a new enum `EvacuateExclusionType`:
  - **DISABLED_RESOURCE**: Ignore disabled resources when checking evacuation
  - **ERROR_PARTITIONS**: Ignore partitions in ERROR state
  - **DISABLED_PARTITION**: Ignore instance-disabled partitions

Note: backward compatibility is maintainted in this change.

Added exclusions query parameter to /clusters/{cluster}/instances/{instance}?command=isEvacuateFinished:

1. Exclude disabled resources
POST /clusters/myCluster/instances/instance1?command=isEvacuateFinished&exclusions=DISABLED_RESOURCE

2. Multiple exclusions (comma-separated)
POST /clusters/myCluster/instances/instance1?command=isEvacuateFinished&exclusions=DISABLED_RESOURCE,ERROR_PARTITIONS

### Tests

New Integration tests added

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
