### PR TITLE
Add ERROR partitions metric to Instance Monitor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -83,7 +83,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             Map<String, LiveInstance> liveInstanceMap = dataProvider.getLiveInstances();
             Map<String, Set<Message>> instanceMessageMap = Maps.newHashMap();
             Map<String, InstanceConfig> instanceConfigMap = dataProvider.getInstanceConfigMap();
-            Map<String, Long> errorPartitionCounts = Maps.newHashMap();
+            Map<String, Long> instanceErrorPartitionCounts = Maps.newHashMap();
             
             for (Map.Entry<String, InstanceConfig> e : instanceConfigMap.entrySet()) {
               String instanceName = e.getKey();
@@ -96,7 +96,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
                 
                 // Count ERROR partitions for this live instance
                 long errorCount = countErrorPartitions(dataProvider, instanceName);
-                errorPartitionCounts.put(instanceName, errorCount);
+                instanceErrorPartitionCounts.put(instanceName, errorCount);
               }
               if (!config.getInstanceEnabled()) {
                 disabledInstanceSet.add(instanceName);
@@ -112,7 +112,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             clusterStatusMonitor
                 .setClusterInstanceStatus(liveInstanceSet, instanceSet, disabledInstanceSet,
                     disabledPartitions, oldDisabledPartitions, tags, instanceMessageMap,
-                    instanceConfigMap, errorPartitionCounts);
+                    instanceConfigMap, instanceErrorPartitionCounts);
             LogUtil.logDebug(logger, _eventId, "Complete cluster status monitors update.");
           }
           return null;
@@ -144,23 +144,31 @@ public class ReadClusterDataStage extends AbstractBaseStage {
       Map<String, LiveInstance> liveInstances = dataProvider.getLiveInstances();
       LiveInstance liveInstance = liveInstances.get(instanceName);
       
-      if (liveInstance != null) {
-        String sessionId = liveInstance.getEphemeralOwner();
-        Map<String, CurrentState> currentStateMap = 
-            dataProvider.getCurrentState(instanceName, sessionId, false);
+      if (liveInstance == null) {
+        return errorCount;
+      }
+      
+      String sessionId = liveInstance.getEphemeralOwner();
+      Map<String, CurrentState> currentStateMap = 
+          dataProvider.getCurrentState(instanceName, sessionId, false);
+      
+      if (currentStateMap == null) {
+        return errorCount;
+      }
+      
+      for (CurrentState currentState : currentStateMap.values()) {
+        if (currentState == null) {
+          continue;
+        }
         
-        if (currentStateMap != null) {
-          for (CurrentState currentState : currentStateMap.values()) {
-            if (currentState != null) {
-              Map<String, String> partitionStateMap = currentState.getPartitionStateMap();
-              if (partitionStateMap != null) {
-                for (String state : partitionStateMap.values()) {
-                  if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
-                    errorCount++;
-                  }
-                }
-              }
-            }
+        Map<String, String> partitionStateMap = currentState.getPartitionStateMap();
+        if (partitionStateMap == null) {
+          continue;
+        }
+        
+        for (String state : partitionStateMap.values()) {
+          if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
+            errorCount++;
           }
         }
       }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -226,7 +226,7 @@ public class TestClusterStatusMonitor {
 
     monitor.setClusterInstanceStatus(liveInstanceSet, liveInstanceSet, Collections.emptySet(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), instanceMessageMap,
-        Collections.emptyMap());
+        Collections.emptyMap(), Collections.emptyMap());
 
     Assert.assertEquals(monitor.getInstanceMessageQueueBacklog(), 25 * n);
     Assert.assertEquals(monitor.getTotalPastDueMessageGauge(), 15 * n);
@@ -446,7 +446,8 @@ public class TestClusterStatusMonitor {
     // Call setClusterInstanceStatus to register instance monitors.
     monitor.setClusterInstanceStatus(maxUsageMap.keySet(), maxUsageMap.keySet(),
         Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap(),
-        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap());
 
     // Update instance capacity status.
     for (Map.Entry<String, Double> usageEntry : maxUsageMap.entrySet()) {
@@ -694,7 +695,8 @@ public class TestClusterStatusMonitor {
         Collections.emptyMap(),      // oldDisabledPartitions
         Collections.emptyMap(),      // tags
         Collections.emptyMap(),      // instanceMessageMap
-        instanceConfigMap            // instanceConfigMap
+        instanceConfigMap,           // instanceConfigMap
+        Collections.emptyMap()       // errorPartitionCounts
     );
 
     // Verify cluster-level counts
@@ -750,7 +752,8 @@ public class TestClusterStatusMonitor {
         Collections.emptyMap(),
         Collections.emptyMap(),
         Collections.emptyMap(),
-        instanceConfigMap
+        instanceConfigMap,
+        Collections.emptyMap()
     );
 
     // Verify updated counts

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
@@ -61,7 +61,7 @@ public class TestInstanceMonitor {
     // Update metrics.
     monitor.updateMaxCapacityUsage(0.5d);
     monitor.increaseMessageCount(10L);
-    monitor.updateInstance(tags, disabledPartitions, Collections.emptyList(), true, true);
+    monitor.updateInstance(tags, disabledPartitions, Collections.emptyList(), true, true, 0L);
     monitor.updateMessageQueueSize(100L);
     monitor.updatePastDueMessageGauge(50L);
 
@@ -77,6 +77,7 @@ public class TestInstanceMonitor {
     Assert.assertEquals(monitor.getMaxCapacityUsageGauge(), 0.5d);
     Assert.assertEquals(monitor.getMessageQueueSizeGauge(), 100L);
     Assert.assertEquals(monitor.getPastDueMessageGauge(), 50L);
+    Assert.assertEquals(monitor.getErrorPartitions(), 0L);
 
     monitor.unregister();
   }
@@ -312,5 +313,94 @@ public class TestInstanceMonitor {
     // Clean up
     monitor.unregister();
     monitor2.unregister();
+  }
+
+  @Test
+  public void testErrorPartitionsGauge() throws JMException {
+    String testCluster = "testCluster";
+    String testInstance = "testInstance";
+    String testDomain = "testDomain:key=value";
+    Set<String> tags = ImmutableSet.of("test");
+    
+    InstanceMonitor monitor =
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+
+    // Verify initial state - no error partitions
+    Assert.assertEquals(monitor.getErrorPartitions(), 0L);
+
+    // Simulate instance with 3 error partitions
+    monitor.updateInstance(tags, ImmutableMap.of(), Collections.emptyList(), true, true, 3L);
+    Assert.assertEquals(monitor.getErrorPartitions(), 3L);
+
+    // Update with more error partitions
+    monitor.updateInstance(tags, ImmutableMap.of(), Collections.emptyList(), true, true, 5L);
+    Assert.assertEquals(monitor.getErrorPartitions(), 5L);
+
+    // Update with zero error partitions (partitions recovered)
+    monitor.updateInstance(tags, ImmutableMap.of(), Collections.emptyList(), true, true, 0L);
+    Assert.assertEquals(monitor.getErrorPartitions(), 0L);
+
+    // Test with instance offline - error partition count should still be tracked
+    monitor.updateInstance(tags, ImmutableMap.of(), Collections.emptyList(), false, true, 2L);
+    Assert.assertEquals(monitor.getErrorPartitions(), 2L);
+    Assert.assertEquals(monitor.getOnline(), 0L);
+
+    // Test with instance disabled - error partition count should still be tracked
+    monitor.updateInstance(tags, ImmutableMap.of(), Collections.emptyList(), true, false, 4L);
+    Assert.assertEquals(monitor.getErrorPartitions(), 4L);
+    Assert.assertEquals(monitor.getEnabled(), 0L);
+
+    monitor.unregister();
+  }
+
+  @Test
+  public void testErrorPartitionsWithDisabledPartitions() throws JMException {
+    String testCluster = "testCluster";
+    String testInstance = "testInstance";
+    String testDomain = "testDomain:key=value";
+    Set<String> tags = ImmutableSet.of("test");
+    Map<String, List<String>> disabledPartitions = ImmutableMap.of(
+        "resource1", ImmutableList.of("partition1", "partition2"),
+        "resource2", ImmutableList.of("partition3")
+    );
+    
+    InstanceMonitor monitor =
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+
+    // Instance has both disabled partitions and error partitions
+    monitor.updateInstance(tags, disabledPartitions, Collections.emptyList(), true, true, 2L);
+    
+    // Verify both metrics are tracked independently
+    Assert.assertEquals(monitor.getDisabledPartitions(), 3L, "Should have 3 disabled partitions");
+    Assert.assertEquals(monitor.getErrorPartitions(), 2L, "Should have 2 error partitions");
+
+    // Update error partition count while keeping disabled partitions the same
+    monitor.updateInstance(tags, disabledPartitions, Collections.emptyList(), true, true, 5L);
+    Assert.assertEquals(monitor.getDisabledPartitions(), 3L, "Disabled partitions should remain 3");
+    Assert.assertEquals(monitor.getErrorPartitions(), 5L, "Error partitions should now be 5");
+
+    monitor.unregister();
+  }
+
+  @Test
+  public void testErrorPartitionsMultipleUpdates() throws JMException {
+    String testCluster = "testCluster";
+    String testInstance = "testInstance";
+    String testDomain = "testDomain:key=value";
+    Set<String> tags = ImmutableSet.of("test");
+    
+    InstanceMonitor monitor =
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+
+    // Simulate multiple updates with varying error partition counts
+    long[] errorCounts = {0L, 1L, 3L, 2L, 5L, 0L, 1L};
+    
+    for (long errorCount : errorCounts) {
+      monitor.updateInstance(tags, ImmutableMap.of(), Collections.emptyList(), true, true, errorCount);
+      Assert.assertEquals(monitor.getErrorPartitions(), errorCount,
+          "Error partition count should be " + errorCount);
+    }
+
+    monitor.unregister();
   }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -487,7 +487,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
           admin.enablePartition(true, clusterId, instanceName,
               node.get(PerInstanceProperties.resource.name()).textValue(),
               (List<String>) OBJECT_MAPPER.readValue(
-                  node.get(PerInstanceProperties.partitions.name()).toString(),
+                  node.get(PerInstanceProperties.partitions.name()).toString()lemaintenace
                   OBJECT_MAPPER.getTypeFactory()
                       .constructCollectionType(List.class, String.class)));
           break;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -487,7 +487,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
           admin.enablePartition(true, clusterId, instanceName,
               node.get(PerInstanceProperties.resource.name()).textValue(),
               (List<String>) OBJECT_MAPPER.readValue(
-                  node.get(PerInstanceProperties.partitions.name()).toString()lemaintenace
+                  node.get(PerInstanceProperties.partitions.name()).toString(),
                   OBJECT_MAPPER.getTypeFactory()
                       .constructCollectionType(List.class, String.class)));
           break;


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
Currently, there is no easy way to monitor how many partitions are in ERROR state  on each participant instance, this makes troubleshooting and monitoring difficult.

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
This PR introduces a new `ErrorPartitions` gauge metric in the Instance Monitor that tracks the number of partitions in ERROR state for each participant in real-time.

### Tests

New UTs added.

Tested manually in a Actual helix Cluster
1. Transitioned paritions to ERROR for multiple paritions for the Participant
2. Called resetPartitions to check if the metric decrement works fine.

<img width="786" height="232" alt="image" src="https://github.com/user-attachments/assets/6610a626-4883-41a6-863f-c8f6803a1d15" />


- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
