### PR TITLE
Add INSTANCE_OPERATION_STATE field for easy instance state visibility

### DIFF
--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -699,6 +699,8 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
     Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
         InstanceConstants.InstanceOperation.EVACUATE);
+    // Verify INSTANCE_OPERATION_STATE field is set correctly
+    Assert.assertEquals(instanceConfig.getInstanceOperationState(), "EVACUATE");
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=INVALIDOP")
         .expectedReturnStatusCode(Response.Status.NOT_FOUND.getStatusCode()).format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=setInstanceOperation&instanceOperation=")
@@ -706,6 +708,8 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     instanceConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, INSTANCE_NAME);
     Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
         InstanceConstants.InstanceOperation.ENABLE);
+    // Verify INSTANCE_OPERATION_STATE field is set correctly
+    Assert.assertEquals(instanceConfig.getInstanceOperationState(), "ENABLE");
 
     // test canCompleteSwap
     Response canCompleteSwapResponse =


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
Add INSTANCE_OPERATION_STATE field for easy instance state visibility

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)


### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
Currently, customers find it difficult to understand the actual active instance operation state from InstanceConfig JSON. 

This commit adds a new simple field INSTANCE_OPERATION_STATE that shows the current active instance operation state as a plain string value (ENABLE, DISABLE, EVACUATE, SWAP_IN, or UNKNOWN).

### Tests

UTs added + Manually tested.

1. If a new instance is added, its intial config gets this field set:
```
{
  "id" : "localhost_12225",
  "simpleFields" : {
    "HELIX_HOST" : "localhost",
    "HELIX_PORT" : "12225",
    "INSTANCE_OPERATION_STATE" : "ENABLE"
  },
  "mapFields" : { },
  "listFields" : { }
}
```
2. setIntanceOperationAPI updates the field as well.
```
{
  "id" : "localhost_12223",
  "simpleFields" : {
    "HELIX_DISABLED_REASON" : "enable",
    "HELIX_ENABLED" : "false",
    "HELIX_ENABLED_TIMESTAMP" : "1763570965923",
    "HELIX_HOST" : "localhost",
    "HELIX_PORT" : "12223",
    "INSTANCE_OPERATION_STATE" : "UNKNOWN"
  },
  "mapFields" : { },
  "listFields" : {
    "HELIX_INSTANCE_OPERATIONS" : [ "{\"OPERATION\":\"ENABLE\",\"TIMESTAMP\":\"1763570941008\",\"SOURCE\":\"ADMIN\",\"REASON\":\"enable\"}", "{\"OPERATION\":\"DISABLE\",\"TIMESTAMP\":\"1763570965923\",\"SOURCE\":\"AUTOMATION\",\"REASON\":\"enable\"}", "{\"OPERATION\":\"UNKNOWN\",\"TIMESTAMP\":\"1763570987431\",\"SOURCE\":\"USER\",\"REASON\":\"enable\"}" ]
  }
}
```
- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
