### PR TITLE
Simplify InstanceMonitor metric reset to eliminate thread overhead

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.management.JMException;
 import javax.management.ObjectName;
 
@@ -32,9 +34,24 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.InstanceConfig;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TestInstanceMonitor {
+  private ScheduledExecutorService _testExecutor;
+
+  @BeforeMethod
+  public void setUp() {
+    _testExecutor = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    if (_testExecutor != null) {
+      _testExecutor.shutdownNow();
+    }
+  }
   @Test
   public void testInstanceMonitor()
       throws JMException {
@@ -45,7 +62,7 @@ public class TestInstanceMonitor {
     Map<String, List<String>> disabledPartitions = ImmutableMap.of("instance1",
         ImmutableList.of("partition1", "partition2", InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY));
     InstanceMonitor monitor =
-        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain), _testExecutor);
 
     // Verify init status.
     Assert.assertEquals(monitor.getSensorName(),
@@ -87,7 +104,7 @@ public class TestInstanceMonitor {
     String testInstance = "testInstance";
     String testDomain = "testDomain:key=value";
     InstanceMonitor monitor =
-        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain), _testExecutor);
 
     // Initially, all duration metrics should be 0 (instance starts in ENABLE state)
     Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L);
@@ -227,7 +244,7 @@ public class TestInstanceMonitor {
 
     // Create InstanceMonitor
     InstanceMonitor monitor =
-        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain), _testExecutor);
 
     // Verify initial state - instance starts in ENABLE
     Assert.assertEquals(instanceConfig.getInstanceOperation().getOperation(),
@@ -278,7 +295,7 @@ public class TestInstanceMonitor {
     // Creating a fresh instance to avoid backwards compatibility issues
     InstanceConfig instanceConfig2 = new InstanceConfig(testInstance + "_2");
     InstanceMonitor monitor2 =
-        new InstanceMonitor(testCluster, testInstance + "_2", new ObjectName(testDomain + "2"));
+        new InstanceMonitor(testCluster, testInstance + "_2", new ObjectName(testDomain + "2"), _testExecutor);
 
     InstanceConfig.InstanceOperation disableOp =
         new InstanceConfig.InstanceOperation.Builder()
@@ -320,7 +337,7 @@ public class TestInstanceMonitor {
     String testInstance = "testInstance";
     String testDomain = "testDomain:key=value";
     InstanceMonitor monitor =
-        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain), _testExecutor);
 
     // Verify initial state
     Assert.assertEquals(monitor.getPartitionCount(), 0L);
@@ -358,7 +375,7 @@ public class TestInstanceMonitor {
     String testInstance = "testInstance";
     String testDomain = "testDomain:key=value";
     InstanceMonitor monitor =
-        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain), _testExecutor);
 
     // Test 1: Initial state should be 0
     Assert.assertEquals(monitor.getPartitionCount(), 0L);


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
Simplify InstanceMonitor metric reset to eliminate thread overhead

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
Removed the delayed gauge-reset mechanism that previously created per-instance threads. Earlier, whenever an instance’s operation changed, the system scheduled a background task to reset other operation gauges after a 2-minute delay. In clusters with ~10,000 instances, this resulted in excessive thread creation and contributed to OutOfMemoryError conditions due to hitting thread limits.

The new implementation performs all non-current operation gauge resets immediately and synchronously when an operation change is detected. This removes all thread creation, delayed tasks, and executor-management overhead while preserving the intended behavior of tracking per-instance operation durations.

Only the currently active operation gauge will show a non-zero duration. When an operation changes, all other operation gauges are reset to zero instantly, and the new operation begins timing from its start

### Tests
Manually tested + UTs
- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
