### PR TITLE
Simplify InstanceMonitor metric reset to eliminate thread overhead

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -24,9 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import javax.management.JMException;
 import javax.management.ObjectName;
 
@@ -105,9 +102,6 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   // A map of dynamic capacity Gauges. The map's keys could change.
   private final Map<String, SimpleDynamicMetric<Long>> _dynamicCapacityMetricsMap;
 
-  // Background executor for resetting gauges
-  private final ScheduledExecutorService _resetExecutor;
-
   /**
    * Initialize the bean
    * @param clusterName the cluster to monitor
@@ -123,11 +117,6 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     // Initialize to 0 so that if we haven't received operation info yet, duration will be large
     // and will be corrected when we receive the actual operation start time from InstanceConfig
     _currentOperationStartTime = 0L;
-    _resetExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
-      Thread thread = new Thread(r, "InstanceMonitor-ResetGauges-" + participantName);
-      thread.setDaemon(true);
-      return thread;
-    });
 
     createMetrics();
   }
@@ -381,34 +370,17 @@ public class InstanceMonitor extends DynamicMBeanProvider {
 
     // Check if operation changed
     if (_currentOperation != newOperation) {
-      // Only update final duration if we had a valid start time
-      // On first call after controller restart, _currentOperationStartTime may be 0
-      if (_currentOperationStartTime > 0L) {
-        long finalDuration = currentTime - _currentOperationStartTime;
-        updateOperationDurationGauge(_currentOperation, finalDuration);
-      }
-
-      // Now switch to the new operation
+      // Switch to the new operation
       _currentOperation = newOperation;
       _currentOperationStartTime = operationStartTime;
+
+      // Reset all gauges except the current (new) operation
+      resetAllExceptOperations(Collections.singleton(_currentOperation));
     }
 
-    // Update the duration gauge for the current operation
+    // Update the duration gauge for the current operation (called on every update)
     long currentDuration = currentTime - _currentOperationStartTime;
     updateOperationDurationGauge(_currentOperation, currentDuration);
-
-    // Capture the current operation at scheduling time to avoid race conditions
-    // If we transition from ENABLE -> EVACUATE -> ENABLE within 2 minutes,
-    // we want to reset based on what the operation was when we scheduled the task,
-    // not what it becomes later.
-    final InstanceConstants.InstanceOperation operationToExclude = _currentOperation;
-
-    // Schedule a background task to reset all gauges except the captured operation after 2 minutes
-    _resetExecutor.schedule(() -> {
-      synchronized (InstanceMonitor.this) {
-        resetAllExceptOperations(Collections.singleton(operationToExclude));
-      }
-    }, 2, TimeUnit.MINUTES);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
@@ -111,11 +111,9 @@ public class TestInstanceMonitor {
     Assert.assertTrue(evacuateDuration >= 100L,
         "EVACUATE duration should be >= 100ms, but was " + evacuateDuration);
 
-    // The previous operation (ENABLE) should still show its final duration
-    // until the background thread resets it after 2 minutes
-    // So we just verify it's >= 0 (it will have some duration from before the switch)
-    Assert.assertTrue(monitor.getInstanceOperationDurationEnable() >= 0L,
-        "ENABLE duration should retain its final value until background reset");
+    // The previous operation (ENABLE) should be reset to 0 immediately
+    Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
+        "ENABLE duration should be reset to 0 when switching to EVACUATE");
 
     // All other operations should be 0
     Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L);
@@ -137,13 +135,13 @@ public class TestInstanceMonitor {
     long disableStartTime = System.currentTimeMillis();
     monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.DISABLE, disableStartTime);
 
-    // EVACUATE should retain its final duration (until background reset after 2 mins)
-    // DISABLE should start counting from 0
-    long finalEvacuateDuration = monitor.getInstanceOperationDurationEvacuate();
-    Assert.assertTrue(finalEvacuateDuration > 0L,
-        "EVACUATE duration should retain its final value after switching to DISABLE");
+    // All gauges except DISABLE should be reset to 0
+    Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
+        "EVACUATE duration should be reset to 0 when switching to DISABLE");
     Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L,
         "DISABLE duration should start at 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
+        "ENABLE duration should be reset to 0");
 
     // Wait and verify DISABLE duration increases
     Thread.sleep(100);
@@ -151,9 +149,9 @@ public class TestInstanceMonitor {
     long disableDuration = monitor.getInstanceOperationDurationDisable();
     Assert.assertTrue(disableDuration >= 100L,
         "DISABLE duration should be >= 100ms, but was " + disableDuration);
-    // EVACUATE retains its final duration
-    Assert.assertTrue(monitor.getInstanceOperationDurationEvacuate() > 0L,
-        "EVACUATE should still show its final duration");
+    // EVACUATE should remain reset at 0
+    Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
+        "EVACUATE should remain at 0");
 
     // Test SWAP_IN operation
     long swapInStartTime = System.currentTimeMillis();
@@ -164,11 +162,13 @@ public class TestInstanceMonitor {
     long swapInDuration = monitor.getInstanceOperationDurationSwapIn();
     Assert.assertTrue(swapInDuration >= 50L,
         "SWAP_IN duration should be >= 50ms, but was " + swapInDuration);
-    // Previous operations retain their final durations
-    Assert.assertTrue(monitor.getInstanceOperationDurationDisable() > 0L,
-        "DISABLE should still show its final duration");
-    Assert.assertTrue(monitor.getInstanceOperationDurationEvacuate() > 0L,
-        "EVACUATE should still show its final duration");
+    // All others (DISABLE, EVACUATE, ENABLE) should be reset to 0
+    Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L,
+        "DISABLE should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
+        "EVACUATE should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
+        "ENABLE should be reset to 0");
 
     // Test UNKNOWN operation
     long unknownStartTime = System.currentTimeMillis();
@@ -179,25 +179,31 @@ public class TestInstanceMonitor {
     long unknownDuration = monitor.getInstanceOperationDurationUnknown();
     Assert.assertTrue(unknownDuration >= 50L,
         "UNKNOWN duration should be >= 50ms, but was " + unknownDuration);
-    // SWAP_IN retains its final duration
-    Assert.assertTrue(monitor.getInstanceOperationDurationSwapIn() > 0L,
-        "SWAP_IN should still show its final duration");
+    // All others (SWAP_IN, DISABLE, EVACUATE, ENABLE) should be reset to 0
+    Assert.assertEquals(monitor.getInstanceOperationDurationSwapIn(), 0L,
+        "SWAP_IN should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L,
+        "DISABLE should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
+        "EVACUATE should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
+        "ENABLE should be reset to 0");
 
-    // Test going back to ENABLE - previous operations retain their final values
+    // Test going back to ENABLE - all others reset to 0
     long enableStartTime = System.currentTimeMillis();
     monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.ENABLE, enableStartTime);
     Thread.sleep(50);
     monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.ENABLE, enableStartTime);
 
-    // Previous operations retain their final durations until background reset
-    Assert.assertTrue(monitor.getInstanceOperationDurationDisable() > 0L,
-        "DISABLE should retain its final duration");
-    Assert.assertTrue(monitor.getInstanceOperationDurationEvacuate() > 0L,
-        "EVACUATE should retain its final duration");
-    Assert.assertTrue(monitor.getInstanceOperationDurationSwapIn() > 0L,
-        "SWAP_IN should retain its final duration");
-    Assert.assertTrue(monitor.getInstanceOperationDurationUnknown() > 0L,
-        "UNKNOWN should retain its final duration");
+    // All gauges except ENABLE should be reset to 0
+    Assert.assertEquals(monitor.getInstanceOperationDurationUnknown(), 0L,
+        "UNKNOWN should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L,
+        "DISABLE should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
+        "EVACUATE should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationSwapIn(), 0L,
+        "SWAP_IN should be reset to 0");
 
     // ENABLE duration should be > 0
     long enableDuration = monitor.getInstanceOperationDurationEnable();


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
Simplify InstanceMonitor metric reset to eliminate thread overhead

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
Removed the delayed gauge-reset mechanism that previously created per-instance threads. Earlier, whenever an instance’s operation changed, the system scheduled a background task to reset other operation gauges after a 2-minute delay. In clusters with ~10,000 instances, this resulted in excessive thread creation and contributed to OutOfMemoryError conditions due to hitting thread limits.

The new implementation performs all non-current operation gauge resets immediately and synchronously when an operation change is detected. This removes all thread creation, delayed tasks, and executor-management overhead while preserving the intended behavior of tracking per-instance operation durations.

Only the currently active operation gauge will show a non-zero duration. When an operation changes, all other operation gauges are reset to zero instantly, and the new operation begins timing from its start

### Tests
Manually tested + UTs
- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
