### PR TITLE
Add resource-level configuration for custom active states in min active replica check

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
@@ -60,7 +60,8 @@ public class ResourceConfig extends HelixProperty {
     EXTERNAL_VIEW_DISABLED,
     DELAY_REBALANCE_ENABLED,
     PARTITION_CAPACITY_MAP,
-    RELAXED_DISABLED_PARTITION_CONSTRAINT // Resource-level override for relaxed disabled partition constraint
+    RELAXED_DISABLED_PARTITION_CONSTRAINT, // Resource-level override for relaxed disabled partition constraint
+    ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK // List of states to be considered as "active" for min active replica check
   }
 
   public enum ResourceConfigConstants {
@@ -277,6 +278,33 @@ public class ResourceConfig extends HelixProperty {
    */
   public int getMinActiveReplica() {
     return _record.getIntField(ResourceConfigProperty.MIN_ACTIVE_REPLICAS.name(), -1);
+  }
+
+  /**
+   * Get the list of states that should be considered as "active" for min active replica check.
+   * If not configured, the default behavior applies (all states except DROPPED, ERROR, and initial state).
+   *
+   * @return List of state names to be considered active, or null if not configured
+   */
+  public List<String> getActiveStatesForMinActiveReplicaCheck() {
+    return _record.getListField(ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name());
+  }
+
+  /**
+   * Set the list of states that should be considered as "active" for min active replica check.
+   * When configured, only replicas in these states will count toward the min active replica constraint.
+   * 
+   * Example: For a state model with states [LEADER, STANDBY, BOOTSTRAP, OFFLINE],
+   * setting this to ["LEADER", "STANDBY"] will only count replicas in LEADER or STANDBY states.
+   *
+   * @param activeStates List of state names to be considered active, or null to use default behavior
+   */
+  public void setActiveStatesForMinActiveReplicaCheck(List<String> activeStates) {
+    if (activeStates == null) {
+      _record.getListFields().remove(ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name());
+    } else {
+      _record.setListField(ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name(), activeStates);
+    }
   }
 
   public int getMaxPartitionsPerInstance() {

--- a/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
@@ -283,6 +283,9 @@ public class ResourceConfig extends HelixProperty {
   /**
    * Get the list of states that should be considered as "active" for min active replica check.
    * If not configured, the default behavior applies (all states except DROPPED, ERROR, and initial state).
+   * 
+   * Note: The configured states should be valid states from the resource's state model definition.
+   * Any state NOT in this list will NOT count as active (including top states like LEADER).
    *
    * @return List of state names to be considered active, or null if not configured
    */
@@ -293,6 +296,12 @@ public class ResourceConfig extends HelixProperty {
   /**
    * Set the list of states that should be considered as "active" for min active replica check.
    * When configured, only replicas in these states will count toward the min active replica constraint.
+   * 
+   * IMPORTANT:
+   * - The configured states should be valid states from the resource's state model definition.
+   * - If a state is NOT in this list, it will NOT be counted as active, even if it's a top state like LEADER.
+   *   For example, if you configure ["STANDBY"] only, then LEADER replicas will NOT count as active.
+   * - State names are matched case-insensitively.
    * 
    * Example: For a state model with states [LEADER, STANDBY, BOOTSTRAP, OFFLINE],
    * setting this to ["LEADER", "STANDBY"] will only count replicas in LEADER or STANDBY states.

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceValidationUtil.java
@@ -461,14 +461,10 @@ public class InstanceValidationUtil {
             resourceName);
         continue;
       }
-      String stateModeDef = externalView.getStateModelDefRef();
-      StateModelDefinition stateModelDefinition =
-          dataAccessor.getProperty(propertyKeyBuilder.stateModelDef(stateModeDef));
-      
       // Determine which states should be considered "unhealthy" (not active)
-      Set<String> unhealthyStates = getUnhealthyStates(dataAccessor, propertyKeyBuilder, 
-          resourceName, stateModelDefinition);
-      
+      Set<String> unhealthyStates = getUnhealthyStates(dataAccessor, propertyKeyBuilder,
+          resourceName, idealState.getStateModelDefRef());
+
       for (String partition : externalView.getPartitionSet()) {
         Map<String, String> stateByInstanceMap = externalView.getStateMap(partition);
         // found the resource hosted on the instance
@@ -499,46 +495,54 @@ public class InstanceValidationUtil {
 
     return MinActiveReplicaCheckResult.passed();
   }
-  
+
   /**
    * Get the set of states that should be considered "unhealthy" (not active) for min active replica checks.
-   * 
+   *
    * The logic is as follows:
    * 1. If the resource has ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK configured in ResourceConfig,
    *    use that list and consider all other states as unhealthy.
    * 2. Otherwise, use the default behavior: DROPPED, ERROR, and the initial state are unhealthy.
    *
+   * Note: If an empty list is configured for ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK,
+   * the default behavior is used (empty list does NOT mean "no states are active").
+   *
    * @param dataAccessor The data accessor
    * @param propertyKeyBuilder The property key builder
    * @param resourceName The resource name
-   * @param stateModelDefinition The state model definition
+   * @param stateModelDefRef The state model definition reference name
    * @return Set of state names considered unhealthy
    */
-  private static Set<String> getUnhealthyStates(HelixDataAccessor dataAccessor, 
-      PropertyKey.Builder propertyKeyBuilder, String resourceName, 
-      StateModelDefinition stateModelDefinition) {
-    
+  private static Set<String> getUnhealthyStates(HelixDataAccessor dataAccessor,
+      PropertyKey.Builder propertyKeyBuilder, String resourceName,
+      String stateModelDefRef) {
+
+    StateModelDefinition stateModelDefinition = stateModelDefRef != null
+        ? dataAccessor.getProperty(propertyKeyBuilder.stateModelDef(stateModelDefRef))
+        : null;
+
+    Set<String> unhealthyStates = new HashSet<>(UNHEALTHY_STATES);
+
     // Try to get resource config to check for custom active states configuration
     ResourceConfig resourceConfig = dataAccessor.getProperty(propertyKeyBuilder.resourceConfig(resourceName));
-    
+
     if (resourceConfig != null) {
       List<String> customActiveStates = resourceConfig.getActiveStatesForMinActiveReplicaCheck();
+      // Note: Empty list falls back to default behavior (empty list does NOT mean "no states are active")
       if (customActiveStates != null && !customActiveStates.isEmpty()) {
-        // Custom active states are configured - all other states are unhealthy
-        Set<String> unhealthyStates = new HashSet<>(UNHEALTHY_STATES);
         if (stateModelDefinition != null && stateModelDefinition.getStatesPriorityList() != null) {
           unhealthyStates.addAll(stateModelDefinition.getStatesPriorityList());
         }
-        // Remove the custom active states - what remains are unhealthy
-        unhealthyStates.removeAll(customActiveStates);
+        // Remove custom active states (case-insensitive) - what remains are unhealthy
+        unhealthyStates.removeIf(state ->
+            customActiveStates.stream().anyMatch(active -> active.equalsIgnoreCase(state)));
         _logger.debug("Resource {} using custom active states for min active replica check: {}. Unhealthy states: {}",
             resourceName, customActiveStates, unhealthyStates);
         return unhealthyStates;
       }
     }
-    
+
     // Default behavior: DROPPED, ERROR, and initial state are unhealthy
-    Set<String> unhealthyStates = new HashSet<>(UNHEALTHY_STATES);
     if (stateModelDefinition != null) {
       unhealthyStates.add(stateModelDefinition.getInitialState());
     }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestCustomActiveStatesStoppableCheck.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestCustomActiveStatesStoppableCheck.java
@@ -1,0 +1,310 @@
+package org.apache.helix.rest.server;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.ResourceConfig;
+import org.apache.helix.rest.server.resources.helix.InstancesAccessor;
+import org.apache.helix.rest.server.util.JerseyUriRequestBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Integration test for custom active states configuration in min active replica check.
+ * 
+ * This test uses the STOPPABLE_CLUSTER2 which has:
+ * - 15 instances (instance0-14) spread across 5 zones
+ * - Resources with MasterSlave state model
+ * - minActiveReplicas = 2, replicas = 3
+ * 
+ * We test that custom active states configuration actually affects stoppability decisions.
+ */
+public class TestCustomActiveStatesStoppableCheck extends AbstractTestClass {
+  
+  @Test
+  public void testWithDefaultBehavior_BothMasterAndSlaveCountAsActive() throws IOException, InterruptedException {
+    System.out.println("Start test: testWithDefaultBehavior_BothMasterAndSlaveCountAsActive");
+    
+    String clusterName = STOPPABLE_CLUSTER2;
+    String resourceName = clusterName + "_db_0";
+    
+    // Ensure NO custom active states configured - use default behavior
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ResourceConfig resourceConfig = configAccessor.getResourceConfig(clusterName, resourceName);
+    if (resourceConfig != null) {
+      resourceConfig.setActiveStatesForMinActiveReplicaCheck(null);
+      configAccessor.setResourceConfig(clusterName, resourceName, resourceConfig);
+    }
+    
+    Thread.sleep(1000);
+    
+    // Get actual external view to see what replicas exist
+    ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(clusterName, resourceName);
+    System.out.println("External View for " + resourceName + ": " + ev.getRecord().toString());
+    
+    // Find instance with Slave - but cluster may use "SLAVE" not "Slave"
+    String instanceWithSlave = null;
+    for (String partition : ev.getPartitionSet()) {
+      Map<String, String> stateMap = ev.getStateMap(partition);
+      System.out.println("Partition " + partition + " states: " + stateMap);
+      for (Map.Entry<String, String> entry : stateMap.entrySet()) {
+        if ("SLAVE".equalsIgnoreCase(entry.getValue())) {
+          instanceWithSlave = entry.getKey();
+          break;
+        }
+      }
+      if (instanceWithSlave != null) break;
+    }
+    
+    Assert.assertNotNull(instanceWithSlave, "Could not find instance with SLAVE replica");
+    System.out.println("Testing stoppability of instance with SLAVE: " + instanceWithSlave);
+    
+    String content = String.format(
+        "{\"%s\":[\"%s\"]}",
+        InstancesAccessor.InstancesProperties.instances.name(),
+        instanceWithSlave);
+    
+    Response response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK")
+        .format(clusterName)
+        .post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    
+    JsonNode jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
+    System.out.println("Response: " + jsonNode.toString());
+    
+    Set<String> stoppableInstances = getStringSet(jsonNode,
+        InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
+    
+    // With default behavior (both MASTER and SLAVE count as active),
+    // the instance with SLAVE should be stoppable
+    Assert.assertTrue(stoppableInstances.contains(instanceWithSlave),
+        "Instance with SLAVE should be stoppable with default behavior. Stoppable: " + stoppableInstances);
+    
+    System.out.println("✓ Default behavior: Instance with SLAVE is stoppable (MASTER + SLAVE both count as active)");
+    System.out.println("End test: testWithDefaultBehavior_BothMasterAndSlaveCountAsActive");
+  }
+  
+  @Test(dependsOnMethods = "testWithDefaultBehavior_BothMasterAndSlaveCountAsActive")
+  public void testWithCustomActiveStates_OnlyMasterCountsAsActive() throws IOException, InterruptedException {
+    System.out.println("Start test: testWithCustomActiveStates_OnlyMasterCountsAsActive");
+    
+    String clusterName = STOPPABLE_CLUSTER2;
+    String resourceName = clusterName + "_db_0";
+    
+    // Configure custom active states - ONLY MASTER counts as active
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ResourceConfig resourceConfig = configAccessor.getResourceConfig(clusterName, resourceName);
+    if (resourceConfig == null) {
+      resourceConfig = new ResourceConfig(resourceName);
+    }
+    resourceConfig.setActiveStatesForMinActiveReplicaCheck(Arrays.asList("MASTER"));
+    configAccessor.setResourceConfig(clusterName, resourceName, resourceConfig);
+    
+    Thread.sleep(1000);
+    
+    // Verify configuration
+    ResourceConfig verifyConfig = configAccessor.getResourceConfig(clusterName, resourceName);
+    Assert.assertEquals(verifyConfig.getActiveStatesForMinActiveReplicaCheck(), Arrays.asList("MASTER"));
+    System.out.println("✓ Successfully configured custom active states: [MASTER]");
+    
+    // Try to check stoppability of multiple instances
+    ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(clusterName, resourceName);
+    String instanceWithMaster = null;
+    String instanceWithSlave = null;
+    
+    for (String partition : ev.getPartitionSet()) {
+      Map<String, String> stateMap = ev.getStateMap(partition);
+      for (Map.Entry<String, String> entry : stateMap.entrySet()) {
+        if ("MASTER".equalsIgnoreCase(entry.getValue()) && instanceWithMaster == null) {
+          instanceWithMaster = entry.getKey();
+        }
+        if ("SLAVE".equalsIgnoreCase(entry.getValue()) && instanceWithSlave == null) {
+          instanceWithSlave = entry.getKey();
+        }
+      }
+      if (instanceWithMaster != null && instanceWithSlave != null) break;
+    }
+    
+    Assert.assertNotNull(instanceWithMaster, "Could not find instance with MASTER");
+    Assert.assertNotNull(instanceWithSlave, "Could not find instance with SLAVE");
+    
+    // Test instance with MASTER
+    System.out.println("Testing stoppability of instance with MASTER: " + instanceWithMaster);
+    String content = String.format(
+        "{\"%s\":[\"%s\"]}",
+        InstancesAccessor.InstancesProperties.instances.name(),
+        instanceWithMaster);
+    
+    Response response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK")
+        .format(clusterName)
+        .post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    
+    JsonNode jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
+    System.out.println("Response for instance with MASTER: " + jsonNode.toString());
+    
+    JsonNode nonStoppableInstances = jsonNode.get(
+        InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
+    
+    // Instance with MASTER should NOT be stoppable
+    Assert.assertTrue(nonStoppableInstances.has(instanceWithMaster),
+        "Instance with MASTER should NOT be stoppable when only MASTER counts as active");
+    Assert.assertTrue(nonStoppableInstances.get(instanceWithMaster).toString().contains("MIN_ACTIVE_REPLICA_CHECK_FAILED"),
+        "Should fail with MIN_ACTIVE_REPLICA_CHECK_FAILED");
+    
+    System.out.println("✓ Custom behavior: Instance with MASTER is NOT stoppable (only 1 active < minActiveReplicas=2)");
+    
+    // Test instance with SLAVE
+    System.out.println("Testing stoppability of instance with SLAVE: " + instanceWithSlave);
+    content = String.format(
+        "{\"%s\":[\"%s\"]}",
+        InstancesAccessor.InstancesProperties.instances.name(),
+        instanceWithSlave);
+    
+    response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK")
+        .format(clusterName)
+        .post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    
+    jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
+    System.out.println("Response for instance with SLAVE: " + jsonNode.toString());
+    
+    // With only 1 MASTER counting as active and minActiveReplicas=2,
+    // even the SLAVE instance should NOT be stoppable because the partition
+    // is already in a degraded state (1 < 2)
+    nonStoppableInstances = jsonNode.get(
+        InstancesAccessor.InstancesProperties.instance_not_stoppable_with_reasons.name());
+    
+    Assert.assertTrue(nonStoppableInstances.has(instanceWithSlave),
+        "Instance with SLAVE should also NOT be stoppable when partition only has 1 active (MASTER) but needs 2");
+    Assert.assertTrue(nonStoppableInstances.get(instanceWithSlave).toString().contains("MIN_ACTIVE_REPLICA_CHECK_FAILED"),
+        "Should fail with MIN_ACTIVE_REPLICA_CHECK_FAILED");
+    
+    System.out.println("✓ Custom behavior: Instance with SLAVE is also NOT stoppable (partition has 1 active < minActiveReplicas=2)");
+    System.out.println("✓ Summary: When only MASTER counts as active, with just 1 MASTER per partition, NO instance is stoppable!");
+    
+    System.out.println("End test: testWithCustomActiveStates_OnlyMasterCountsAsActive");
+  }
+  
+  @Test(dependsOnMethods = "testWithCustomActiveStates_OnlyMasterCountsAsActive")
+  public void testRevertToDefaultBehavior() throws IOException, InterruptedException {
+    System.out.println("Start test: testRevertToDefaultBehavior");
+    
+    String clusterName = STOPPABLE_CLUSTER2;
+    String resourceName = clusterName + "_db_0";
+    
+    // Clear custom active states - revert to default
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ResourceConfig resourceConfig = configAccessor.getResourceConfig(clusterName, resourceName);
+    resourceConfig.setActiveStatesForMinActiveReplicaCheck(null);
+    configAccessor.setResourceConfig(clusterName, resourceName, resourceConfig);
+    
+    Thread.sleep(1000);
+    
+    // Verify cleared
+    ResourceConfig verifyConfig = configAccessor.getResourceConfig(clusterName, resourceName);
+    Assert.assertNull(verifyConfig.getActiveStatesForMinActiveReplicaCheck());
+    System.out.println("✓ Successfully cleared custom active states");
+    
+    // Now behavior should be back to default
+    ExternalView ev = _gSetupTool.getClusterManagementTool().getResourceExternalView(clusterName, resourceName);
+    String instanceWithSlave = null;
+    for (String partition : ev.getPartitionSet()) {
+      Map<String, String> stateMap = ev.getStateMap(partition);
+      for (Map.Entry<String, String> entry : stateMap.entrySet()) {
+        if ("SLAVE".equalsIgnoreCase(entry.getValue())) {
+          instanceWithSlave = entry.getKey();
+          break;
+        }
+      }
+      if (instanceWithSlave != null) break;
+    }
+    
+    String content = String.format(
+        "{\"%s\":[\"%s\"]}",
+        InstancesAccessor.InstancesProperties.instances.name(),
+        instanceWithSlave);
+    
+    Response response = new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=stoppable&skipHealthCheckCategories=CUSTOM_INSTANCE_CHECK,CUSTOM_PARTITION_CHECK")
+        .format(clusterName)
+        .post(this, Entity.entity(content, MediaType.APPLICATION_JSON_TYPE));
+    
+    JsonNode jsonNode = OBJECT_MAPPER.readTree(response.readEntity(String.class));
+    System.out.println("Response after reverting: " + jsonNode.toString());
+    
+    Set<String> stoppableInstances = getStringSet(jsonNode,
+        InstancesAccessor.InstancesProperties.instance_stoppable_parallel.name());
+    
+    // Should be stoppable again with default behavior
+    Assert.assertTrue(stoppableInstances.contains(instanceWithSlave),
+        "After reverting to default, instance with SLAVE should be stoppable again");
+    
+    System.out.println("✓ After reverting: Instance with SLAVE is stoppable again (default behavior restored)");
+    System.out.println("End test: testRevertToDefaultBehavior");
+  }
+  
+  @Test
+  public void testConfigPersistsInZooKeeper() throws IOException {
+    System.out.println("Start test: testConfigPersistsInZooKeeper");
+    
+    String clusterName = STOPPABLE_CLUSTER2;
+    String resourceName = clusterName + "_db_1";
+    
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    
+    // Set custom active states
+    ResourceConfig resourceConfig = new ResourceConfig(resourceName);
+    resourceConfig.setActiveStatesForMinActiveReplicaCheck(Arrays.asList("MASTER", "SLAVE"));
+    configAccessor.setResourceConfig(clusterName, resourceName, resourceConfig);
+    
+    // Read back
+    ResourceConfig readConfig = configAccessor.getResourceConfig(clusterName, resourceName);
+    Assert.assertNotNull(readConfig.getActiveStatesForMinActiveReplicaCheck());
+    Assert.assertEquals(readConfig.getActiveStatesForMinActiveReplicaCheck().size(), 2);
+    Assert.assertTrue(readConfig.getActiveStatesForMinActiveReplicaCheck().contains("MASTER"));
+    Assert.assertTrue(readConfig.getActiveStatesForMinActiveReplicaCheck().contains("SLAVE"));
+    
+    System.out.println("✓ Configuration persisted in ZooKeeper: " + 
+        readConfig.getActiveStatesForMinActiveReplicaCheck());
+    
+    // Clean up
+    resourceConfig.setActiveStatesForMinActiveReplicaCheck(null);
+    configAccessor.setResourceConfig(clusterName, resourceName, resourceConfig);
+    
+    System.out.println("End test: testConfigPersistsInZooKeeper");
+  }
+  
+  private Set<String> getStringSet(JsonNode jsonNode, String key) {
+    Set<String> result = new java.util.HashSet<>();
+    jsonNode.withArray(key).forEach(s -> result.add(s.textValue()));
+    return result;
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
This PR adds support for resource-level configuration of which replica states are considered "active" for the min active replica check in the stoppable check API.

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

Different state models have different semantics for which states should be considered "healthy" or "active". For example:
  • In IndexerStateModel: Only CAUGHT_UP replicas should be considered active.
  • In AmbryLeaderStandby: Only LEADER and STANDBY should be considered active.

Previously, Helix used a hardcoded default where all states except DROPPED, ERROR, and initialState were considered active. This PR allows users to customize this behavior per resource. The default behavior is preserved, but can now be overridden using the new ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK property in ResourceConfig. Stoppable checks will honour whatever the values in this config is and will act based on this. 

### Tests
New Integration tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
