### PR TITLE
Do not record metrics for disabled resource

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -335,7 +335,11 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _numOfErrorPartitions.updateValue(numOfErrorPartitions);
     _externalViewIdealStateDiff.updateValue(numOfDiff);
     _numOfPartitionsInExternalView.updateValue((long) externalView.getPartitionSet().size());
-    _numNonTopStatePartitions.updateValue(_numOfPartitions.getValue() - numOfPartitionWithTopState);
+    
+    // Only record missing top state gauge if the resource is enabled
+    if (idealState.isEnabled()) {
+      _numNonTopStatePartitions.updateValue(_numOfPartitions.getValue() - numOfPartitionWithTopState);
+    }
 
     String tag = idealState.getInstanceGroupTag();
     if (tag == null || tag.equals("") || tag.equals("null")) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -265,8 +265,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
 
     resetResourceStateGauges();
 
-    if (idealState == null) {
-      _logger.warn("ideal state is null for {}", _resourceName);
+    if (idealState == null || !idealState.isEnabled()) {
+      _logger.warn("ideal state is null or disabled for {}", _resourceName);
       return;
     }
 
@@ -335,11 +335,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _numOfErrorPartitions.updateValue(numOfErrorPartitions);
     _externalViewIdealStateDiff.updateValue(numOfDiff);
     _numOfPartitionsInExternalView.updateValue((long) externalView.getPartitionSet().size());
-    
-    // Only record missing top state gauge if the resource is enabled
-    if (idealState.isEnabled()) {
-      _numNonTopStatePartitions.updateValue(_numOfPartitions.getValue() - numOfPartitionWithTopState);
-    }
+    _numNonTopStatePartitions.updateValue(_numOfPartitions.getValue() - numOfPartitionWithTopState);
 
     String tag = idealState.getInstanceGroupTag();
     if (tag == null || tag.equals("") || tag.equals("null")) {

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestResourceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestResourceMonitor.java
@@ -248,10 +248,10 @@ public class TestResourceMonitor {
   }
 
   @Test
-  public void testDisabledResourceMissingTopState() throws JMException {
+  public void testNoMetricsRecordedForNullOrDisabledIdealState() throws JMException {
     final int n = 5;
     ResourceMonitor monitor =
-        new ResourceMonitor(_clusterName, _dbName, new ObjectName("testDomain:key=disabledResource"));
+        new ResourceMonitor(_clusterName, _dbName, new ObjectName("testDomain:key=nullOrDisabledTest"));
     monitor.register();
 
     try {
@@ -269,9 +269,11 @@ public class TestResourceMonitor {
       StateModelDefinition stateModelDef =
           BuiltInStateModelDefinitions.MasterSlave.getStateModelDefinition();
 
-      // create missing top state for all partitions
-      int missTopState = _partitions;
-      for (int i = 0; i < missTopState; i++) {
+      // Create a scenario where some partitions are missing top state
+      int missTopState = 10;
+      Random r = new Random();
+      int start = r.nextInt(_partitions - missTopState - 1);
+      for (int i = start; i < start + missTopState; i++) {
         String partition = _dbName + "_" + i;
         Map<String, String> map = externalView.getStateMap(partition);
         for (String key : map.keySet()) {
@@ -283,23 +285,53 @@ public class TestResourceMonitor {
         externalView.setStateMap(partition, map);
       }
 
-      // Should record missing top state
-      monitor.updateResourceState(externalView, idealState, stateModelDef);
-      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), missTopState,
-          "Missing top state should be recorded for enabled resource");
+      // Update with null ideal state - should not record any metrics
+      monitor.updateResourceState(externalView, null, stateModelDef);
 
-
-      idealState.enable(false);
-      // Missing top state gauge should not be updated 
-      monitor.updateResourceState(externalView, idealState, stateModelDef);
+      Assert.assertEquals(monitor.getPartitionGauge(), 0,
+          "PartitionGauge should be 0 when ideal state is null");
       Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0,
-          "Missing top state should not be recorded for disabled resource");
+          "MissingTopStatePartitionGauge should be 0 when ideal state is null");
+      Assert.assertEquals(monitor.getErrorPartitionGauge(), 0,
+          "ErrorPartitionGauge should be 0 when ideal state is null");
+      Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), 0,
+          "DifferenceWithIdealStateGauge should be 0 when ideal state is null");
+      Assert.assertEquals(monitor.getExternalViewPartitionGauge(), 0,
+          "ExternalViewPartitionGauge should be 0 when ideal state is null");
+      Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0,
+          "MissingMinActiveReplicaPartitionGauge should be 0 when ideal state is null");
+      Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), 0,
+          "MissingReplicaPartitionGauge should be 0 when ideal state is null");
 
-      // Re-enable the resource and verify the metric is recorded again
+      // Update with disabled ideal state - should not record any metrics
+      idealState.enable(false);
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
+      
+      Assert.assertEquals(monitor.getPartitionGauge(), 0,
+          "PartitionGauge should be 0 when ideal state is disabled");
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0,
+          "MissingTopStatePartitionGauge should be 0 when ideal state is disabled");
+      Assert.assertEquals(monitor.getErrorPartitionGauge(), 0,
+          "ErrorPartitionGauge should be 0 when ideal state is disabled");
+      Assert.assertEquals(monitor.getDifferenceWithIdealStateGauge(), 0,
+          "DifferenceWithIdealStateGauge should be 0 when ideal state is disabled");
+      Assert.assertEquals(monitor.getExternalViewPartitionGauge(), 0,
+          "ExternalViewPartitionGauge should be 0 when ideal state is disabled");
+      Assert.assertEquals(monitor.getMissingMinActiveReplicaPartitionGauge(), 0,
+          "MissingMinActiveReplicaPartitionGauge should be 0 when ideal state is disabled");
+      Assert.assertEquals(monitor.getMissingReplicaPartitionGauge(), 0,
+          "MissingReplicaPartitionGauge should be 0 when ideal state is disabled");
+
+      // Enable the resource and verify metrics are now recorded
       idealState.enable(true);
       monitor.updateResourceState(externalView, idealState, stateModelDef);
+      
+      Assert.assertEquals(monitor.getPartitionGauge(), _partitions,
+          "PartitionGauge should be recorded when ideal state is enabled");
       Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), missTopState,
-          "Missing top state should be recorded again when resource is re-enabled");
+          "MissingTopStatePartitionGauge should be recorded when ideal state is enabled");
+      Assert.assertTrue(monitor.getExternalViewPartitionGauge() > 0,
+          "ExternalViewPartitionGauge should be recorded when ideal state is enabled");
     } finally {
       monitor.unregister();
     }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestResourceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestResourceMonitor.java
@@ -248,6 +248,64 @@ public class TestResourceMonitor {
   }
 
   @Test
+  public void testDisabledResourceMissingTopState() throws JMException {
+    final int n = 5;
+    ResourceMonitor monitor =
+        new ResourceMonitor(_clusterName, _dbName, new ObjectName("testDomain:key=disabledResource"));
+    monitor.register();
+
+    try {
+      List<String> instances = new ArrayList<>();
+      for (int i = 0; i < n; i++) {
+        String instance = "localhost_" + (12918 + i);
+        instances.add(instance);
+      }
+
+      ZNRecord idealStateRecord = DefaultIdealStateCalculator
+          .calculateIdealState(instances, _partitions, _replicas - 1, _dbName, "MASTER", "SLAVE");
+      IdealState idealState = new IdealState(deepCopyZNRecord(idealStateRecord));
+      idealState.setMinActiveReplicas(_replicas - 1);
+      ExternalView externalView = new ExternalView(deepCopyZNRecord(idealStateRecord));
+      StateModelDefinition stateModelDef =
+          BuiltInStateModelDefinitions.MasterSlave.getStateModelDefinition();
+
+      // create missing top state for all partitions
+      int missTopState = _partitions;
+      for (int i = 0; i < missTopState; i++) {
+        String partition = _dbName + "_" + i;
+        Map<String, String> map = externalView.getStateMap(partition);
+        for (String key : map.keySet()) {
+          if (map.get(key).equalsIgnoreCase("MASTER")) {
+            map.put(key, "SLAVE");
+            break;
+          }
+        }
+        externalView.setStateMap(partition, map);
+      }
+
+      // Should record missing top state
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), missTopState,
+          "Missing top state should be recorded for enabled resource");
+
+
+      idealState.enable(false);
+      // Missing top state gauge should not be updated 
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), 0,
+          "Missing top state should not be recorded for disabled resource");
+
+      // Re-enable the resource and verify the metric is recorded again
+      idealState.enable(true);
+      monitor.updateResourceState(externalView, idealState, stateModelDef);
+      Assert.assertEquals(monitor.getMissingTopStatePartitionGauge(), missTopState,
+          "Missing top state should be recorded again when resource is re-enabled");
+    } finally {
+      monitor.unregister();
+    }
+  }
+
+  @Test
   public void testUpdatePartitionWeightStats() throws JMException, IOException {
     final MBeanServerConnection mBeanServer = ManagementFactory.getPlatformMBeanServer();
     final String clusterName = TestHelper.getTestMethodName();


### PR DESCRIPTION
### Issues

ResourceMonitor metrics record metrics for disabled resources, which causes a lot of false positive alerts.

### Description

This PR fixes metric sensors to only record missing top state metric if the resource is enabled

### Tests

`mint build`

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
