### PR TITLE
Add Support for Query Params For Audit Log

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/filters/AuditLogFilter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/filters/AuditLogFilter.java
@@ -36,6 +36,7 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
 
 import com.google.common.io.CharStreams;
@@ -63,8 +64,9 @@ public class AuditLogFilter implements ContainerRequestFilter, ContainerResponse
   public void filter(ContainerRequestContext request) throws IOException {
     AuditLog.Builder auditLogBuilder = new AuditLog.Builder();
 
-    String path = request.getUriInfo().getPath();
-    String queryString = request.getUriInfo().getRequestUri().getRawQuery();
+    UriInfo uriInfo = request.getUriInfo();
+    String path = uriInfo.getPath();
+    String queryString = uriInfo.getRequestUri().getRawQuery();
     String fullRequestPath = Optional.ofNullable(queryString)
                     .map(q -> path + "?" + q)
                     .orElse(path);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/filters/AuditLogFilter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/filters/AuditLogFilter.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -62,8 +63,14 @@ public class AuditLogFilter implements ContainerRequestFilter, ContainerResponse
   public void filter(ContainerRequestContext request) throws IOException {
     AuditLog.Builder auditLogBuilder = new AuditLog.Builder();
 
+    String path = request.getUriInfo().getPath();
+    String queryString = request.getUriInfo().getRequestUri().getRawQuery();
+    String fullRequestPath = Optional.ofNullable(queryString)
+                    .map(q -> path + "?" + q)
+                    .orElse(path);
+
     auditLogBuilder.namespace(getNamespace())
-        .requestPath(request.getUriInfo().getPath())
+        .requestPath(fullRequestPath)
         .httpMethod(request.getMethod())
         .startTime(new Date())
         .requestHeaders(getHeaders(request.getHeaders()))

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -192,17 +192,9 @@ public class TestClusterAccessor extends AbstractTestClass {
     AuditLog auditLog = _auditLogger.getAuditLogs().get(0);
 
     // Verify that query parameters are included in the request path
-    String requestPath = auditLog.getRequestPath();
-    Assert.assertTrue(requestPath.contains("?"),
-        "Request path should contain query string separator '?'. Actual: " + requestPath);
-    Assert.assertTrue(requestPath.indexOf("?") == requestPath.lastIndexOf("?"),
-        "Request path should have only one query string separator '?'. Actual: " + requestPath);
-    Assert.assertTrue(requestPath.contains("command=activate"),
-        "Request path should contain 'command=activate'. Actual: " + requestPath);
-    Assert.assertTrue(requestPath.indexOf("command=activate") == requestPath.lastIndexOf("command=activate"),
-        "Request path should have only one \"command=activate\". Actual: " + requestPath);
-    Assert.assertTrue(requestPath.contains("superCluster=" + _superCluster),
-        "Request path should contain 'superCluster=" + _superCluster + "'. Actual: " + requestPath);
+    String expectedPath = "clusters/" + cluster + "?command=activate&superCluster=" + _superCluster;
+    Assert.assertEquals(auditLog.getRequestPath(), expectedPath,
+        "Request path should include query parameters");
 
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -195,8 +195,12 @@ public class TestClusterAccessor extends AbstractTestClass {
     String requestPath = auditLog.getRequestPath();
     Assert.assertTrue(requestPath.contains("?"),
         "Request path should contain query string separator '?'. Actual: " + requestPath);
+    Assert.assertTrue(requestPath.indexOf("?") == requestPath.lastIndexOf("?"),
+        "Request path should have only one query string separator '?'. Actual: " + requestPath);
     Assert.assertTrue(requestPath.contains("command=activate"),
         "Request path should contain 'command=activate'. Actual: " + requestPath);
+    Assert.assertTrue(requestPath.indexOf("command=activate") == requestPath.lastIndexOf("command=activate"),
+        "Request path should have only one \"command=activate\". Actual: " + requestPath);
     Assert.assertTrue(requestPath.contains("superCluster=" + _superCluster),
         "Request path should contain 'superCluster=" + _superCluster + "'. Actual: " + requestPath);
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -178,6 +178,31 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
+  @Test
+  public void testAuditLogIncludesQueryParams() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+
+    _auditLogger.clearupLogs();
+    String cluster = _clusters.iterator().next();
+    // Make a request with query parameters
+    Map<String, String> queryParams = ImmutableMap.of("command", "activate", "superCluster", _superCluster);
+    get("clusters/" + cluster, queryParams, Response.Status.OK.getStatusCode(), true);
+
+    validateAuditLogSize(1);
+    AuditLog auditLog = _auditLogger.getAuditLogs().get(0);
+
+    // Verify that query parameters are included in the request path
+    String requestPath = auditLog.getRequestPath();
+    Assert.assertTrue(requestPath.contains("?"),
+        "Request path should contain query string separator '?'. Actual: " + requestPath);
+    Assert.assertTrue(requestPath.contains("command=activate"),
+        "Request path should contain 'command=activate'. Actual: " + requestPath);
+    Assert.assertTrue(requestPath.contains("superCluster=" + _superCluster),
+        "Request path should contain 'superCluster=" + _superCluster + "'. Actual: " + requestPath);
+
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
   @Test(dependsOnMethods = "testGetClusters")
   public void testGetClusterTopology() {
     System.out.println("Start test :" + TestHelper.getTestMethodName());


### PR DESCRIPTION
### Issues
When we see logs in Kusto, we see only request paths but query params (if any) were being removed.

```
helixacm_service_logs
| where timestamp >= ago(1d)
| where message has "AuditLog"
| project timestamp, message, appData, defaultLog__logger, level
| top 20 by timestamp asc
```

<img width="2248" height="579" alt="image" src="https://github.com/user-attachments/assets/ac019410-0bca-4480-8f49-c24bda5ad4ac" />

- [x] My PR addresses the following Helix issues and references them in the PR description: CICP-3095

### Description

- [x] Here are some details about my PR:
`AuditLogFilter.java` sets value for `AUDIT_LOG` key.
<img width="753" height="603" alt="Screenshot 2025-12-11 at 1 47 33 PM" src="https://github.com/user-attachments/assets/9c8a5052-a324-4745-8f03-4d27abe77b38" />

Which is passed to `logger.write()` method.

<img width="764" height="494" alt="Screenshot 2025-12-11 at 1 47 56 PM" src="https://github.com/user-attachments/assets/63fd8f90-e297-438a-a94b-c63c0e19accb" />

This method is overwritten by `HelixRestAuditLogger` and `DefaultHelixRestAuditLogger.java`.

<img width="687" height="303" alt="Screenshot 2025-12-11 at 1 48 52 PM" src="https://github.com/user-attachments/assets/75e06c0a-87a3-49f5-bd1b-8f98ca193faa" />

### Tests

- [x] The following tests are written for this issue:

`TestClusterAccessor.testAuditLogIncludesQueryParams`

- The following is the result of the "mvn test" command on the appropriate module:

`mvn test -pl helix-rest -Dtest=TestClusterAccessor#testAuditLogIncludesQueryParams 2>&1`

<img width="1089" height="404" alt="Screenshot 2025-12-11 at 1 53 20 PM" src="https://github.com/user-attachments/assets/bd628f7f-e5c8-4f97-a85d-c41f28660d2b" />

### Estimation for Log Volume Increase

```
helixacm_service_logs
| where timestamp >= ago(1d)
| where message has "AuditLog"
| count 
```

> 556376798


```
helixacm_service_logs
| where timestamp >= ago(1d)
| count 
```

> 1526658348

So `AuditLog` consists of roughly 36.4%.

By Paretto principle of 80-20 say 80% of requests have query parameters.
And also assuming having query params increases request path length by 40 chars (In UTF-8 if a char is 1B then 40B per request path).


Volume Increase Calculation

```
Daily AuditLog entries:           556,376,798
Requests with query params (80%): 445,101,438
Average query string size increase:        40 bytes

Additional data per day:
445,101,438 × 40 bytes ~ 18 GB/day
```

Considering disk compression of 5x: `3.6 GB/day`
