### PR TITLE
Configurable Stage Thread Pool

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -213,6 +213,9 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
 
   private HelixManager _helixManager;
 
+  /** Per-controller thread pool helper for parallel execution in pipeline stages */
+  private final StageThreadPoolHelper _stageThreadPoolHelper;
+
   // Since the stateful rebalancer needs to be lazily constructed when the HelixManager instance is
   // ready, the GenericHelixController is not constructed with a stateful rebalancer. This wrapper
   // is to avoid the complexity of handling a nullable value in the event handling process.
@@ -696,6 +699,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     _clusterName = clusterName;
     _lastPipelineEndTimestamp = TopStateHandoffReportStage.TIMESTAMP_NOT_RECORDED;
     _clusterStatusMonitor = new ClusterStatusMonitor(_clusterName);
+    _stageThreadPoolHelper = new StageThreadPoolHelper(_clusterName);
 
     _asyncTasksThreadPool =
         Executors.newScheduledThreadPool(ASYNC_TASKS_THREADPOOL_SIZE, new ThreadFactory() {
@@ -761,9 +765,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     }
 
     int configuredPoolSize = clusterConfig.getStageParallelThreadPoolSize();
-    if (configuredPoolSize > 0) {
-      StageThreadPoolHelper.setPoolSize(configuredPoolSize);
-    }
+    _stageThreadPoolHelper.setPoolSize(configuredPoolSize);
   }
 
   private void initializeAsyncFIFOWorkers() {
@@ -907,8 +909,9 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     event.addAttribute(AttributeName.LastRebalanceFinishTimeStamp.name(), _lastPipelineEndTimestamp);
     event.addAttribute(AttributeName.ControllerDataProvider.name(), dataProvider);
 
-    // Update stage thread pool size from ClusterConfig if configured
+    // Update stage thread pool size from ClusterConfig if configured and add helper to event
     updateStageThreadPoolSize(dataProvider.getClusterConfig());
+    event.addAttribute(AttributeName.STAGE_THREAD_POOL_HELPER.name(), _stageThreadPoolHelper);
 
     logger.info("START: Invoking {} controller pipeline for cluster: {}. Event type: {}, ID: {}. "
             + "Event session ID: {}", dataProvider.getPipelineName(), manager.getClusterName(),
@@ -1492,8 +1495,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     // shutdown async workers
     shutdownAsyncFIFOWorkers();
 
-    // shutdown shared stage thread pool
-    StageThreadPoolHelper.shutdown();
+    // shutdown this controller's stage thread pool
+    _stageThreadPoolHelper.shutdown();
 
     enableClusterStatusMonitor(false);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -752,6 +752,20 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     addController(this);
   }
 
+  /**
+   * Update the stage thread pool size from ClusterConfig if configured.
+   */
+  private void updateStageThreadPoolSize(ClusterConfig clusterConfig) {
+    if (clusterConfig == null) {
+      return;
+    }
+
+    int configuredPoolSize = clusterConfig.getStageParallelThreadPoolSize();
+    if (configuredPoolSize > 0) {
+      StageThreadPoolHelper.setPoolSize(configuredPoolSize);
+    }
+  }
+
   private void initializeAsyncFIFOWorkers() {
     for (AsyncWorkerType type : AsyncWorkerType.values()) {
       DedupEventProcessor<String, Runnable> worker =
@@ -892,6 +906,9 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     dataProvider.setClusterEventId(event.getEventId());
     event.addAttribute(AttributeName.LastRebalanceFinishTimeStamp.name(), _lastPipelineEndTimestamp);
     event.addAttribute(AttributeName.ControllerDataProvider.name(), dataProvider);
+
+    // Update stage thread pool size from ClusterConfig if configured
+    updateStageThreadPoolSize(dataProvider.getClusterConfig());
 
     logger.info("START: Invoking {} controller pipeline for cluster: {}. Event type: {}, ID: {}. "
             + "Event session ID: {}", dataProvider.getPipelineName(), manager.getClusterName(),
@@ -1475,8 +1492,9 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     // shutdown async workers
     shutdownAsyncFIFOWorkers();
 
-    // shutdown shared stage thread pool
-    StageThreadPoolHelper.shutdown();
+    // Note: We intentionally do NOT shutdown StageThreadPoolHelper here because
+    // it's a shared static pool. Other controllers in the same JVM may still need it.
+    // The pool uses daemon threads and will be cleaned up when JVM exits.
 
     enableClusterStatusMonitor(false);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -1492,9 +1492,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     // shutdown async workers
     shutdownAsyncFIFOWorkers();
 
-    // Note: We intentionally do NOT shutdown StageThreadPoolHelper here because
-    // it's a shared static pool. Other controllers in the same JVM may still need it.
-    // The pool uses daemon threads and will be cleaned up when JVM exits.
+    // shutdown shared stage thread pool
+    StageThreadPoolHelper.shutdown();
 
     enableClusterStatusMonitor(false);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/AttributeName.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/AttributeName.java
@@ -54,5 +54,8 @@ public enum AttributeName {
   // This attribute should only be used in TaskGarbageCollectionStage, misuse could cause race conditions.
   JOBS_WITHOUT_CONFIG,
   // This attribute should only be used in TaskGarbageCollectionStage, misuse could cause race conditions.
-  TO_BE_PURGED_JOBS_MAP
+  TO_BE_PURGED_JOBS_MAP,
+
+  /** Thread pool helper for parallel execution in pipeline stages. Each controller has its own instance. */
+  STAGE_THREAD_POOL_HELPER
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -278,6 +278,8 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     ClusterStatusMonitor clusterStatusMonitor =
         event.getAttribute(AttributeName.clusterStatusMonitor.name());
     WagedRebalancer wagedRebalancer = event.getAttribute(AttributeName.STATEFUL_REBALANCER.name());
+    StageThreadPoolHelper stageThreadPoolHelper =
+        event.getAttribute(AttributeName.STAGE_THREAD_POOL_HELPER.name());
 
     // Check whether the offline/disabled instance count in the cluster exceeds the set limit,
     // if yes, put the cluster into maintenance mode.
@@ -319,12 +321,24 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     }
 
     // Run all remaining resource computations in parallel and wait for completion.
-    try {
-      StageThreadPoolHelper.executeAndWait(STAGE_NAME, computeBestPossibleStateTasks);
-    } catch (InterruptedException e) {
-      LogUtil.logError(logger, _eventId,
-          "Interrupted during parallel execution", e);
-      Thread.currentThread().interrupt();
+    if (stageThreadPoolHelper != null) {
+      try {
+        stageThreadPoolHelper.executeAndWait(STAGE_NAME, computeBestPossibleStateTasks);
+      } catch (InterruptedException e) {
+        LogUtil.logError(logger, _eventId,
+            "Interrupted during parallel execution", e);
+        Thread.currentThread().interrupt();
+      }
+    } else {
+      // Fallback: execute tasks sequentially if no thread pool helper is available
+      for (Callable<Void> task : computeBestPossibleStateTasks) {
+        try {
+          task.call();
+        } catch (Exception e) {
+          LogUtil.logError(logger, _eventId,
+              "Exception during sequential task execution", e);
+        }
+      }
     }
 
     // Check and report if resource rebalance has failure

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -962,10 +962,6 @@ public class ClusterConfig extends HelixProperty {
   /**
    * Get the thread pool size for parallel execution in controller pipeline stages.
    * This controls parallelism for stages like BestPossibleStateCalcStage.
-   * <p>
-   * Unlike GLOBAL_TARGET_TASK_THREAD_POOL_SIZE which requires a restart,
-   * changes to this value take effect dynamically within one pipeline cycle.
-   *
    * @return the configured thread pool size, or -1 if not set (default is used)
    */
   public int getStageParallelThreadPoolSize() {
@@ -977,10 +973,6 @@ public class ClusterConfig extends HelixProperty {
   /**
    * Set the thread pool size for parallel execution in controller pipeline stages.
    * This controls parallelism for stages like BestPossibleStateCalcStage.
-   * <p>
-   * Changes take effect dynamically - the controller will pick up the new value
-   * on the next pipeline cycle and recreate the thread pool with the new size.
-   *
    * @param stageParallelThreadPoolSize the thread pool size (must be positive)
    * @throws IllegalArgumentException when the provided thread pool size is not positive
    */

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -144,6 +144,11 @@ public class ClusterConfig extends HelixProperty {
     // TaskConstants.DEFAULT_TASK_THREAD_POOL_SIZE will be used to create pool sizes.
     GLOBAL_TARGET_TASK_THREAD_POOL_SIZE,
 
+    // The thread pool size for parallel execution in controller pipeline stages.
+    // This controls parallelism for stages like BestPossibleStateCalcStage.
+    // Default is min(4, availableProcessors).
+    STAGE_PARALLEL_THREAD_POOL_SIZE,
+
     // The time out window for offline nodes during maintenance mode; if an offline node has been
     // offline for more than this specified time period, it's treated as offline for the rest of
     // the maintenance mode's duration even when it comes online.
@@ -206,6 +211,7 @@ public class ClusterConfig extends HelixProperty {
   public final static boolean DEFAULT_GLOBAL_REBALANCE_ASYNC_MODE_ENABLED = true;
   public final static boolean DEFAULT_PARTIAL_REBALANCE_ASYNC_MODE_ENABLED = true;
   private static final int GLOBAL_TARGET_TASK_THREAD_POOL_SIZE_NOT_SET = -1;
+  private static final int STAGE_PARALLEL_THREAD_POOL_SIZE_NOT_SET = -1;
   private static final int OFFLINE_NODE_TIME_OUT_FOR_MAINTENANCE_MODE_NOT_SET = -1;
   private final static int DEFAULT_VIEW_CLUSTER_REFRESH_PERIOD = 30;
   private final static long DEFAULT_LAST_ON_DEMAND_REBALANCE_TIMESTAMP = -1L;
@@ -951,6 +957,41 @@ public class ClusterConfig extends HelixProperty {
     _record
         .setIntField(ClusterConfig.ClusterConfigProperty.GLOBAL_TARGET_TASK_THREAD_POOL_SIZE.name(),
             globalTargetTaskThreadPoolSize);
+  }
+
+  /**
+   * Get the thread pool size for parallel execution in controller pipeline stages.
+   * This controls parallelism for stages like BestPossibleStateCalcStage.
+   * <p>
+   * Unlike GLOBAL_TARGET_TASK_THREAD_POOL_SIZE which requires a restart,
+   * changes to this value take effect dynamically within one pipeline cycle.
+   *
+   * @return the configured thread pool size, or -1 if not set (default is used)
+   */
+  public int getStageParallelThreadPoolSize() {
+    return _record.getIntField(
+        ClusterConfigProperty.STAGE_PARALLEL_THREAD_POOL_SIZE.name(),
+        STAGE_PARALLEL_THREAD_POOL_SIZE_NOT_SET);
+  }
+
+  /**
+   * Set the thread pool size for parallel execution in controller pipeline stages.
+   * This controls parallelism for stages like BestPossibleStateCalcStage.
+   * <p>
+   * Changes take effect dynamically - the controller will pick up the new value
+   * on the next pipeline cycle and recreate the thread pool with the new size.
+   *
+   * @param stageParallelThreadPoolSize the thread pool size (must be positive)
+   * @throws IllegalArgumentException when the provided thread pool size is not positive
+   */
+  public void setStageParallelThreadPoolSize(int stageParallelThreadPoolSize)
+      throws IllegalArgumentException {
+    if (stageParallelThreadPoolSize <= 0) {
+      throw new IllegalArgumentException("stageParallelThreadPoolSize must be positive!");
+    }
+    _record.setIntField(
+        ClusterConfigProperty.STAGE_PARALLEL_THREAD_POOL_SIZE.name(),
+        stageParallelThreadPoolSize);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/util/StageThreadPoolHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StageThreadPoolHelper.java
@@ -1,68 +1,116 @@
 package org.apache.helix.util;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.util.*;
-import java.util.concurrent.*;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
- * Hybrid version:
- * - Single shared thread pool reused by all Helix stages.
- * - Per-stage thread name prefixes for better debugging.
- * - Ensures all stage tasks complete before next stage runs.
+ * Helper class for parallel execution in Helix controller pipeline stages.
+ * Uses a shared static thread pool with configurable size.
+ * <p>
+ * The pool size can be configured via {@link #setPoolSize(int)} which is typically
+ * called by the controller based on ClusterConfig.STAGE_PARALLEL_THREAD_POOL_SIZE.
+ * <p>
+ * Features:
+ * <ul>
+ *   <li>Single shared thread pool reused by all Helix controller stages</li>
+ *   <li>Configurable pool size via cluster configuration</li>
+ *   <li>Per-stage thread name prefixes for better debugging</li>
+ *   <li>Ensures all stage tasks complete before returning</li>
+ *   <li>Uses daemon threads - automatically cleaned up on JVM exit</li>
+ * </ul>
  */
 public class StageThreadPoolHelper {
   private static final Logger LOG = LoggerFactory.getLogger(StageThreadPoolHelper.class);
 
-  private static final int DEFAULT_POOL_SIZE =
+  /** Default pool size: min(4, available processors) */
+  public static final int DEFAULT_POOL_SIZE =
       Math.min(4, Runtime.getRuntime().availableProcessors());
-  private static final long THREAD_KEEP_ALIVE_MIN = 3;
+
+  private static final long THREAD_KEEP_ALIVE_MINUTES = 3;
+  private static final long SHUTDOWN_TIMEOUT_SECONDS = 30;
   private static final String THREAD_NAME_PREFIX = "HelixStageWorker";
 
   // Shared executor reused across all stages
   private static final AtomicReference<ThreadPoolExecutor> EXECUTOR_REF = new AtomicReference<>();
+  private static volatile int _configuredPoolSize = DEFAULT_POOL_SIZE;
 
   private StageThreadPoolHelper() {
+    // Utility class - prevent instantiation
   }
 
   /**
-   * Lazily initialize shared thread pool.
+   * Set the thread pool size. If the pool already exists with a different size,
+   * it will be recreated with the new size on next use.
+   *
+   * @param poolSize the desired pool size (must be positive, otherwise default is used)
    */
-  private static synchronized ThreadPoolExecutor getExecutor() {
-    ThreadPoolExecutor existing = EXECUTOR_REF.get();
-    if (existing != null && !existing.isShutdown()) {
-      return existing;
+  public static synchronized void setPoolSize(int poolSize) {
+    if (poolSize <= 0) {
+      LOG.warn("Invalid pool size {}, using default {}", poolSize, DEFAULT_POOL_SIZE);
+      poolSize = DEFAULT_POOL_SIZE;
     }
 
-    ThreadFactory threadFactory = new ThreadFactoryBuilder()
-        .setNameFormat(THREAD_NAME_PREFIX + "-%d")
-        .setDaemon(true)
-        .setUncaughtExceptionHandler((t, e) ->
-            LOG.error("Uncaught exception in stage thread {}", t.getName(), e))
-        .build();
+    if (poolSize != _configuredPoolSize) {
+      LOG.info("Updating stage thread pool size from {} to {}", _configuredPoolSize, poolSize);
+      _configuredPoolSize = poolSize;
 
-    ThreadPoolExecutor executor = new ThreadPoolExecutor(
-        DEFAULT_POOL_SIZE,
-        DEFAULT_POOL_SIZE,
-        THREAD_KEEP_ALIVE_MIN,
-        TimeUnit.MINUTES,
-        new LinkedBlockingQueue<>(),
-        threadFactory,
-        new ThreadPoolExecutor.CallerRunsPolicy());
+      // Shutdown existing pool so it gets recreated with new size on next use
+      ThreadPoolExecutor existing = EXECUTOR_REF.get();
+      if (existing != null && !existing.isShutdown()) {
+        existing.shutdown();
+        EXECUTOR_REF.set(null);
+      }
+    }
+  }
 
-    executor.allowCoreThreadTimeOut(true);
-    EXECUTOR_REF.set(executor);
-    LOG.info("Initialized shared stage parallel executor with {} threads", DEFAULT_POOL_SIZE);
-    return executor;
+  /**
+   * Get the configured pool size.
+   *
+   * @return the configured pool size
+   */
+  public static int getPoolSize() {
+    return _configuredPoolSize;
   }
 
   /**
    * Execute multiple tasks in parallel for a stage and wait for all to complete.
    *
-   * @param stageName Name of the stage for logging/thread naming.
-   * @param tasks     Tasks to execute.
+   * @param stageName name of the stage (used for logging and thread naming)
+   * @param tasks collection of tasks to execute in parallel
+   * @throws InterruptedException if the current thread is interrupted while waiting
    */
   public static void executeAndWait(String stageName, Collection<? extends Callable<?>> tasks)
       throws InterruptedException {
@@ -70,7 +118,7 @@ public class StageThreadPoolHelper {
       return;
     }
 
-    ThreadPoolExecutor executor = getExecutor();
+    ThreadPoolExecutor executor = getOrCreateExecutor();
     List<Future<?>> futures = new ArrayList<>(tasks.size());
 
     for (Callable<?> task : tasks) {
@@ -90,7 +138,10 @@ public class StageThreadPoolHelper {
 
   /**
    * Gracefully shutdown the shared executor.
-   * Should be called once when controller stops.
+   * <p>
+   * Note: This should only be called for testing cleanup. In production, the pool
+   * uses daemon threads and will be automatically cleaned up when the JVM exits.
+   * Controllers should NOT call this on shutdown since the pool is shared.
    */
   public static synchronized void shutdown() {
     ThreadPoolExecutor executor = EXECUTOR_REF.get();
@@ -101,7 +152,7 @@ public class StageThreadPoolHelper {
     LOG.info("Shutting down shared stage parallel executor");
     executor.shutdown();
     try {
-      if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+      if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
         LOG.warn("Executor did not terminate gracefully, forcing shutdown");
         executor.shutdownNow();
       }
@@ -110,6 +161,38 @@ public class StageThreadPoolHelper {
       executor.shutdownNow();
       Thread.currentThread().interrupt();
     }
+    EXECUTOR_REF.set(null);
+  }
+
+  /**
+   * Lazily initialize the shared thread pool.
+   */
+  private static synchronized ThreadPoolExecutor getOrCreateExecutor() {
+    ThreadPoolExecutor existing = EXECUTOR_REF.get();
+    if (existing != null && !existing.isShutdown()) {
+      return existing;
+    }
+
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat(THREAD_NAME_PREFIX + "-%d")
+        .setDaemon(true)
+        .setUncaughtExceptionHandler((t, e) ->
+            LOG.error("Uncaught exception in stage thread {}", t.getName(), e))
+        .build();
+
+    ThreadPoolExecutor executor = new ThreadPoolExecutor(
+        _configuredPoolSize,
+        _configuredPoolSize,
+        THREAD_KEEP_ALIVE_MINUTES,
+        TimeUnit.MINUTES,
+        new LinkedBlockingQueue<>(),
+        threadFactory,
+        new ThreadPoolExecutor.CallerRunsPolicy());
+
+    executor.allowCoreThreadTimeOut(true);
+    EXECUTOR_REF.set(executor);
+    LOG.info("Initialized shared stage parallel executor with {} threads", _configuredPoolSize);
+    return executor;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/util/StageThreadPoolHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StageThreadPoolHelper.java
@@ -29,7 +29,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
@@ -38,14 +37,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Helper class for parallel execution in Helix controller pipeline stages.
- * Uses a shared static thread pool with configurable size.
+ * Each controller instance owns its own thread pool with configurable size.
  * <p>
  * The pool size can be configured via {@link #setPoolSize(int)} which is typically
  * called by the controller based on ClusterConfig.STAGE_PARALLEL_THREAD_POOL_SIZE.
  * <p>
  * Features:
  * <ul>
- *   <li>Single shared thread pool reused by all Helix controller stages</li>
+ *   <li>Per-controller thread pool for isolation between controllers on same node</li>
  *   <li>Configurable pool size via cluster configuration</li>
  *   <li>Per-stage thread name prefixes for better debugging</li>
  *   <li>Ensures all stage tasks complete before returning</li>
@@ -63,12 +62,27 @@ public class StageThreadPoolHelper {
   private static final long SHUTDOWN_TIMEOUT_SECONDS = 30;
   private static final String THREAD_NAME_PREFIX = "HelixStageWorker";
 
-  // Shared executor reused across all stages
-  private static final AtomicReference<ThreadPoolExecutor> EXECUTOR_REF = new AtomicReference<>();
-  private static volatile int _configuredPoolSize = DEFAULT_POOL_SIZE;
+  /**
+   * Queue capacity multiplier relative to pool size.
+   * With CallerRunsPolicy, when queue is full, tasks execute in the caller thread,
+   * providing natural backpressure instead of unbounded queue growth.
+   */
+  private static final int QUEUE_CAPACITY_MULTIPLIER = 2;
 
-  private StageThreadPoolHelper() {
-    // Utility class - prevent instantiation
+  private final String _clusterName;
+  private volatile ThreadPoolExecutor _executor;
+  private volatile int _configuredPoolSize;
+  private final Object _lock = new Object();
+
+  /**
+   * Creates a new StageThreadPoolHelper for a specific controller/cluster.
+   *
+   * @param clusterName the name of the cluster this helper is associated with (may be null for legacy controllers)
+   */
+  public StageThreadPoolHelper(String clusterName) {
+    _clusterName = clusterName != null ? clusterName : "unknown";
+    _configuredPoolSize = DEFAULT_POOL_SIZE;
+    LOG.info("Created StageThreadPoolHelper for cluster {}", _clusterName);
   }
 
   /**
@@ -77,21 +91,25 @@ public class StageThreadPoolHelper {
    *
    * @param poolSize the desired pool size (must be positive, otherwise default is used)
    */
-  public static synchronized void setPoolSize(int poolSize) {
+  public void setPoolSize(int poolSize) {
     if (poolSize <= 0) {
       LOG.warn("Invalid pool size {}, using default {}", poolSize, DEFAULT_POOL_SIZE);
       poolSize = DEFAULT_POOL_SIZE;
     }
 
-    if (poolSize != _configuredPoolSize) {
-      LOG.info("Updating stage thread pool size from {} to {}", _configuredPoolSize, poolSize);
-      _configuredPoolSize = poolSize;
+    synchronized (_lock) {
+      if (poolSize != _configuredPoolSize) {
+        int oldPoolSize = _configuredPoolSize;
+        _configuredPoolSize = poolSize;
 
-      // Shutdown existing pool so it gets recreated with new size on next use
-      ThreadPoolExecutor existing = EXECUTOR_REF.get();
-      if (existing != null && !existing.isShutdown()) {
-        existing.shutdown();
-        EXECUTOR_REF.set(null);
+        // Shutdown existing pool so it gets recreated with new size on next use
+        if (_executor != null && !_executor.isShutdown()) {
+          LOG.info("Shutting down current executor with thread pool size {} for cluster {}, "
+              + "next executor will be started with thread pool size {}",
+              oldPoolSize, _clusterName, poolSize);
+          _executor.shutdown();
+          _executor = null;
+        }
       }
     }
   }
@@ -101,7 +119,7 @@ public class StageThreadPoolHelper {
    *
    * @return the configured pool size
    */
-  public static int getPoolSize() {
+  public int getPoolSize() {
     return _configuredPoolSize;
   }
 
@@ -112,7 +130,7 @@ public class StageThreadPoolHelper {
    * @param tasks collection of tasks to execute in parallel
    * @throws InterruptedException if the current thread is interrupted while waiting
    */
-  public static void executeAndWait(String stageName, Collection<? extends Callable<?>> tasks)
+  public void executeAndWait(String stageName, Collection<? extends Callable<?>> tasks)
       throws InterruptedException {
     if (tasks == null || tasks.isEmpty()) {
       return;
@@ -129,77 +147,87 @@ public class StageThreadPoolHelper {
       try {
         future.get();
       } catch (ExecutionException e) {
-        LOG.warn("Task in stage {} failed: {}", stageName, e.getCause().getMessage(), e);
+        LOG.warn("Task in stage {} failed for cluster {}: {}",
+            stageName, _clusterName, e.getCause().getMessage(), e);
       }
     }
 
-    LOG.debug("Completed parallel execution for stage {}", stageName);
+    LOG.debug("Completed parallel execution for stage {} in cluster {}", stageName, _clusterName);
   }
 
   /**
-   * Gracefully shutdown the shared executor.
-   * <p>
-   * Note: This should only be called for testing cleanup. In production, the pool
-   * uses daemon threads and will be automatically cleaned up when the JVM exits.
-   * Controllers should NOT call this on shutdown since the pool is shared.
+   * Gracefully shutdown the executor for this controller.
+   * This should be called when the controller is shutting down.
    */
-  public static synchronized void shutdown() {
-    ThreadPoolExecutor executor = EXECUTOR_REF.get();
-    if (executor == null || executor.isShutdown()) {
-      return;
-    }
-
-    LOG.info("Shutting down shared stage parallel executor");
-    executor.shutdown();
-    try {
-      if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        LOG.warn("Executor did not terminate gracefully, forcing shutdown");
-        executor.shutdownNow();
+  public void shutdown() {
+    synchronized (_lock) {
+      if (_executor == null || _executor.isShutdown()) {
+        return;
       }
-    } catch (InterruptedException e) {
-      LOG.warn("Interrupted during shutdown", e);
-      executor.shutdownNow();
-      Thread.currentThread().interrupt();
+
+      LOG.info("Shutting down stage parallel executor for cluster {}", _clusterName);
+      _executor.shutdown();
+      try {
+        if (!_executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          LOG.warn("Executor for cluster {} did not terminate gracefully, forcing shutdown",
+              _clusterName);
+          _executor.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        LOG.warn("Interrupted during shutdown for cluster {}", _clusterName, e);
+        _executor.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+      _executor = null;
     }
-    EXECUTOR_REF.set(null);
   }
 
   /**
-   * Lazily initialize the shared thread pool.
+   * Lazily initialize the thread pool for this controller.
    */
-  private static synchronized ThreadPoolExecutor getOrCreateExecutor() {
-    ThreadPoolExecutor existing = EXECUTOR_REF.get();
-    if (existing != null && !existing.isShutdown()) {
-      return existing;
+  private ThreadPoolExecutor getOrCreateExecutor() {
+    if (_executor != null && !_executor.isShutdown()) {
+      return _executor;
     }
 
-    ThreadFactory threadFactory = new ThreadFactoryBuilder()
-        .setNameFormat(THREAD_NAME_PREFIX + "-%d")
-        .setDaemon(true)
-        .setUncaughtExceptionHandler((t, e) ->
-            LOG.error("Uncaught exception in stage thread {}", t.getName(), e))
-        .build();
+    synchronized (_lock) {
+      if (_executor != null && !_executor.isShutdown()) {
+        return _executor;
+      }
 
-    ThreadPoolExecutor executor = new ThreadPoolExecutor(
-        _configuredPoolSize,
-        _configuredPoolSize,
-        THREAD_KEEP_ALIVE_MINUTES,
-        TimeUnit.MINUTES,
-        new LinkedBlockingQueue<>(),
-        threadFactory,
-        new ThreadPoolExecutor.CallerRunsPolicy());
+      ThreadFactory threadFactory = new ThreadFactoryBuilder()
+          .setNameFormat(THREAD_NAME_PREFIX + "-" + _clusterName + "-%d")
+          .setDaemon(true)
+          .setUncaughtExceptionHandler((t, e) ->
+              LOG.error("Uncaught exception in stage thread {} for cluster {}",
+                  t.getName(), _clusterName, e))
+          .build();
 
-    executor.allowCoreThreadTimeOut(true);
-    EXECUTOR_REF.set(executor);
-    LOG.info("Initialized shared stage parallel executor with {} threads", _configuredPoolSize);
-    return executor;
+      // Use bounded queue to prevent unbounded memory growth if tasks pile up.
+      // With CallerRunsPolicy, when queue is full, tasks execute in the caller thread,
+      // providing natural backpressure.
+      int queueCapacity = _configuredPoolSize * QUEUE_CAPACITY_MULTIPLIER;
+      _executor = new ThreadPoolExecutor(
+          _configuredPoolSize,
+          _configuredPoolSize,
+          THREAD_KEEP_ALIVE_MINUTES,
+          TimeUnit.MINUTES,
+          new LinkedBlockingQueue<>(queueCapacity),
+          threadFactory,
+          new ThreadPoolExecutor.CallerRunsPolicy());
+
+      _executor.allowCoreThreadTimeOut(true);
+      LOG.info("Initialized stage parallel executor with {} threads and queue capacity {} for cluster {}",
+          _configuredPoolSize, queueCapacity, _clusterName);
+      return _executor;
+    }
   }
 
   /**
    * Wraps the callable to temporarily rename the current thread
    * with stage-specific prefix during execution (for debugging).
    */
-  private static Callable<?> wrapWithStageContext(Callable<?> task, String stageName) {
+  private Callable<?> wrapWithStageContext(Callable<?> task, String stageName) {
     return () -> {
       Thread current = Thread.currentThread();
       String originalName = current.getName();

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
@@ -32,14 +32,24 @@ import org.apache.helix.model.Resource;
 import org.apache.helix.util.StageThreadPoolHelper;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TestBestPossibleStateCalcStage extends BaseStageTest {
 
+  private StageThreadPoolHelper _stageThreadPoolHelper;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    _stageThreadPoolHelper = new StageThreadPoolHelper("TestCluster");
+  }
+
   @AfterMethod
   public void afterMethod() {
     // Clean up thread pool after each test
-    StageThreadPoolHelper.shutdown();
+    if (_stageThreadPoolHelper != null) {
+      _stageThreadPoolHelper.shutdown();
+    }
   }
 
   @Test
@@ -69,6 +79,7 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
     event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
     event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
     event.addAttribute(AttributeName.ControllerDataProvider.name(), new ResourceControllerDataProvider());
+    event.addAttribute(AttributeName.STAGE_THREAD_POOL_HELPER.name(), _stageThreadPoolHelper);
 
     ReadClusterDataStage stage1 = new ReadClusterDataStage();
     runStage(event, stage1);
@@ -130,6 +141,7 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
     event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
     event.addAttribute(AttributeName.ControllerDataProvider.name(),
         new ResourceControllerDataProvider());
+    event.addAttribute(AttributeName.STAGE_THREAD_POOL_HELPER.name(), _stageThreadPoolHelper);
 
     runStage(event, new ReadClusterDataStage());
     runStage(event, new BestPossibleStateCalcStage());
@@ -187,6 +199,7 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
     event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
     event.addAttribute(AttributeName.ControllerDataProvider.name(),
         new ResourceControllerDataProvider());
+    event.addAttribute(AttributeName.STAGE_THREAD_POOL_HELPER.name(), _stageThreadPoolHelper);
 
     ReadClusterDataStage stage1 = new ReadClusterDataStage();
     runStage(event, stage1);

--- a/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
@@ -29,15 +29,24 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TestStageThreadPoolHelper {
 
+  private StageThreadPoolHelper _helper;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    _helper = new StageThreadPoolHelper("TestCluster");
+  }
+
   @AfterMethod
   public void afterMethod() {
-    // Clean up after each test and reset to default pool size
-    StageThreadPoolHelper.shutdown();
-    StageThreadPoolHelper.setPoolSize(StageThreadPoolHelper.DEFAULT_POOL_SIZE);
+    // Clean up after each test
+    if (_helper != null) {
+      _helper.shutdown();
+    }
   }
 
   @Test
@@ -53,7 +62,7 @@ public class TestStageThreadPoolHelper {
       });
     }
 
-    StageThreadPoolHelper.executeAndWait("TestStage", tasks);
+    _helper.executeAndWait("TestStage", tasks);
 
     // Verify all tasks were executed
     Assert.assertEquals(counter.get(), 5, "All tasks should be executed");
@@ -63,13 +72,13 @@ public class TestStageThreadPoolHelper {
   public void testExecuteAndWaitWithEmptyTasks() throws InterruptedException {
     // Test with empty task collection - should not throw exception
     List<Callable<Void>> emptyTasks = new ArrayList<>();
-    StageThreadPoolHelper.executeAndWait("EmptyStage", emptyTasks);
+    _helper.executeAndWait("EmptyStage", emptyTasks);
   }
 
   @Test
   public void testExecuteAndWaitWithNullTasks() throws InterruptedException {
     // Test with null task collection - should not throw exception
-    StageThreadPoolHelper.executeAndWait("NullStage", null);
+    _helper.executeAndWait("NullStage", null);
   }
 
   @Test
@@ -93,7 +102,7 @@ public class TestStageThreadPoolHelper {
     }
 
     // Should not throw exception even if tasks fail
-    StageThreadPoolHelper.executeAndWait("FailingStage", tasks);
+    _helper.executeAndWait("FailingStage", tasks);
 
     // Verify that tasks were executed (some succeeded, some failed)
     Assert.assertEquals(successCounter.get(), 1, "Successful tasks should complete");
@@ -102,7 +111,7 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testParallelExecution() throws InterruptedException {
-    StageThreadPoolHelper.setPoolSize(4);
+    _helper.setPoolSize(4);
 
     // Test that tasks are actually executed in parallel
     int numTasks = 4;
@@ -122,7 +131,7 @@ public class TestStageThreadPoolHelper {
     }
 
     long startTime = System.currentTimeMillis();
-    StageThreadPoolHelper.executeAndWait("ParallelStage", tasks);
+    _helper.executeAndWait("ParallelStage", tasks);
     long duration = System.currentTimeMillis() - startTime;
 
     // Verify all tasks completed
@@ -136,7 +145,7 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testThreadNaming() throws InterruptedException {
-    // Test that thread names include stage context
+    // Test that thread names include stage context and cluster name
     String stageName = "ThreadNamingStage";
     List<String> threadNames = Collections.synchronizedList(new ArrayList<>());
     List<Callable<Void>> tasks = new ArrayList<>();
@@ -148,13 +157,15 @@ public class TestStageThreadPoolHelper {
       });
     }
 
-    StageThreadPoolHelper.executeAndWait(stageName, tasks);
+    _helper.executeAndWait(stageName, tasks);
 
     // Verify thread names contain the stage name
     Assert.assertEquals(threadNames.size(), 3, "Should capture all thread names");
     for (String threadName : threadNames) {
       Assert.assertTrue(threadName.startsWith(stageName + "-"),
           "Thread name should start with stage name: " + threadName);
+      Assert.assertTrue(threadName.contains("TestCluster"),
+          "Thread name should contain cluster name: " + threadName);
     }
   }
 
@@ -168,15 +179,15 @@ public class TestStageThreadPoolHelper {
       return null;
     });
 
-    StageThreadPoolHelper.executeAndWait("PreShutdownStage", tasks);
+    _helper.executeAndWait("PreShutdownStage", tasks);
     Assert.assertEquals(counter.get(), 1, "Task should execute before shutdown");
 
     // Shutdown the executor
-    StageThreadPoolHelper.shutdown();
+    _helper.shutdown();
 
     // Multiple shutdowns should be safe
-    StageThreadPoolHelper.shutdown();
-    StageThreadPoolHelper.shutdown();
+    _helper.shutdown();
+    _helper.shutdown();
   }
 
   @Test
@@ -190,15 +201,15 @@ public class TestStageThreadPoolHelper {
     });
 
     // Execute before shutdown
-    StageThreadPoolHelper.executeAndWait("BeforeShutdown", tasks);
+    _helper.executeAndWait("BeforeShutdown", tasks);
     Assert.assertEquals(counter.get(), 1);
 
     // Shutdown
-    StageThreadPoolHelper.shutdown();
+    _helper.shutdown();
 
     // Execute after shutdown - should create a new executor
     counter.set(0);
-    StageThreadPoolHelper.executeAndWait("AfterShutdown", tasks);
+    _helper.executeAndWait("AfterShutdown", tasks);
     Assert.assertEquals(counter.get(), 1, "Should work after shutdown with new executor");
   }
 
@@ -213,7 +224,7 @@ public class TestStageThreadPoolHelper {
     }
 
     // executeAndWait should handle tasks with return values
-    StageThreadPoolHelper.executeAndWait("ReturnValueStage", tasks);
+    _helper.executeAndWait("ReturnValueStage", tasks);
   }
 
   @Test
@@ -231,7 +242,7 @@ public class TestStageThreadPoolHelper {
       });
     }
 
-    StageThreadPoolHelper.executeAndWait("LargeStage", tasks);
+    _helper.executeAndWait("LargeStage", tasks);
     Assert.assertEquals(counter.get(), numTasks, "All tasks should complete");
   }
 
@@ -255,7 +266,7 @@ public class TestStageThreadPoolHelper {
       }
     }).start();
 
-    StageThreadPoolHelper.executeAndWait("InterruptedStage", tasks);
+    _helper.executeAndWait("InterruptedStage", tasks);
   }
 
   @Test
@@ -282,7 +293,7 @@ public class TestStageThreadPoolHelper {
       });
     }
 
-    StageThreadPoolHelper.executeAndWait("MixedStage", tasks);
+    _helper.executeAndWait("MixedStage", tasks);
 
     Assert.assertEquals(shortTaskCount.get(), 5, "All short tasks should complete");
     Assert.assertEquals(longTaskCount.get(), 3, "All long tasks should complete");
@@ -291,8 +302,8 @@ public class TestStageThreadPoolHelper {
   @Test
   public void testConfigurablePoolSize() throws InterruptedException {
     // Test that the pool size can be configured
-    StageThreadPoolHelper.setPoolSize(2);
-    Assert.assertEquals(StageThreadPoolHelper.getPoolSize(), 2, "Pool size should be 2");
+    _helper.setPoolSize(2);
+    Assert.assertEquals(_helper.getPoolSize(), 2, "Pool size should be 2");
 
     // Test with tasks that require parallel execution
     int numTasks = 4;
@@ -315,7 +326,7 @@ public class TestStageThreadPoolHelper {
       });
     }
 
-    StageThreadPoolHelper.executeAndWait("ConfiguredPoolStage", tasks);
+    _helper.executeAndWait("ConfiguredPoolStage", tasks);
 
     // With pool size of 2, max concurrent should be 2
     Assert.assertTrue(maxConcurrent.get() <= 2,
@@ -324,19 +335,141 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testDefaultPoolSize() {
-    Assert.assertEquals(StageThreadPoolHelper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
+    Assert.assertEquals(_helper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
         "Pool size should be the default");
   }
 
   @Test
   public void testInvalidPoolSizeFallsBackToDefault() {
     // Test that invalid pool sizes fall back to default
-    StageThreadPoolHelper.setPoolSize(0);
-    Assert.assertEquals(StageThreadPoolHelper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
+    _helper.setPoolSize(0);
+    Assert.assertEquals(_helper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
         "Pool size 0 should fall back to default");
 
-    StageThreadPoolHelper.setPoolSize(-1);
-    Assert.assertEquals(StageThreadPoolHelper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
+    _helper.setPoolSize(-1);
+    Assert.assertEquals(_helper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
         "Negative pool size should fall back to default");
+  }
+
+  @Test
+  public void testMultipleControllersHaveSeparatePools() throws InterruptedException {
+    // Test that each controller instance has its own separate pool
+    StageThreadPoolHelper helper1 = new StageThreadPoolHelper("Cluster1");
+    StageThreadPoolHelper helper2 = new StageThreadPoolHelper("Cluster2");
+
+    try {
+      // Configure different pool sizes
+      helper1.setPoolSize(2);
+      helper2.setPoolSize(4);
+
+      Assert.assertEquals(helper1.getPoolSize(), 2, "Cluster1 pool size should be 2");
+      Assert.assertEquals(helper2.getPoolSize(), 4, "Cluster2 pool size should be 4");
+
+      // Track concurrent executions for each helper
+      AtomicInteger concurrentCount1 = new AtomicInteger(0);
+      AtomicInteger maxConcurrent1 = new AtomicInteger(0);
+      AtomicInteger concurrentCount2 = new AtomicInteger(0);
+      AtomicInteger maxConcurrent2 = new AtomicInteger(0);
+
+      List<Callable<Void>> tasks1 = new ArrayList<>();
+      List<Callable<Void>> tasks2 = new ArrayList<>();
+
+      for (int i = 0; i < 4; i++) {
+        tasks1.add(() -> {
+          int current = concurrentCount1.incrementAndGet();
+          synchronized (maxConcurrent1) {
+            if (current > maxConcurrent1.get()) {
+              maxConcurrent1.set(current);
+            }
+          }
+          TimeUnit.MILLISECONDS.sleep(100);
+          concurrentCount1.decrementAndGet();
+          return null;
+        });
+        tasks2.add(() -> {
+          int current = concurrentCount2.incrementAndGet();
+          synchronized (maxConcurrent2) {
+            if (current > maxConcurrent2.get()) {
+              maxConcurrent2.set(current);
+            }
+          }
+          TimeUnit.MILLISECONDS.sleep(100);
+          concurrentCount2.decrementAndGet();
+          return null;
+        });
+      }
+
+      // Execute on both helpers
+      Thread t1 = new Thread(() -> {
+        try {
+          helper1.executeAndWait("Stage1", tasks1);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      });
+      Thread t2 = new Thread(() -> {
+        try {
+          helper2.executeAndWait("Stage2", tasks2);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      });
+
+      t1.start();
+      t2.start();
+      t1.join();
+      t2.join();
+
+      // Verify each pool respected its own size limit
+      Assert.assertTrue(maxConcurrent1.get() <= 2,
+          "Cluster1 max concurrent should be <= 2, but was: " + maxConcurrent1.get());
+      Assert.assertTrue(maxConcurrent2.get() <= 4,
+          "Cluster2 max concurrent should be <= 4, but was: " + maxConcurrent2.get());
+    } finally {
+      helper1.shutdown();
+      helper2.shutdown();
+    }
+  }
+
+  @Test
+  public void testShutdownDoesNotAffectOtherInstances() throws InterruptedException {
+    // Test that shutting down one helper doesn't affect another
+    StageThreadPoolHelper helper1 = new StageThreadPoolHelper("Cluster1");
+    StageThreadPoolHelper helper2 = new StageThreadPoolHelper("Cluster2");
+
+    try {
+      AtomicInteger counter1 = new AtomicInteger(0);
+      AtomicInteger counter2 = new AtomicInteger(0);
+
+      List<Callable<Void>> tasks1 = new ArrayList<>();
+      tasks1.add(() -> {
+        counter1.incrementAndGet();
+        return null;
+      });
+
+      List<Callable<Void>> tasks2 = new ArrayList<>();
+      tasks2.add(() -> {
+        counter2.incrementAndGet();
+        return null;
+      });
+
+      // Execute on both
+      helper1.executeAndWait("Stage1", tasks1);
+      helper2.executeAndWait("Stage2", tasks2);
+
+      Assert.assertEquals(counter1.get(), 1);
+      Assert.assertEquals(counter2.get(), 1);
+
+      // Shutdown helper1
+      helper1.shutdown();
+
+      // helper2 should still work
+      counter2.set(0);
+      helper2.executeAndWait("Stage2AfterShutdown", tasks2);
+      Assert.assertEquals(counter2.get(), 1, "helper2 should still work after helper1 shutdown");
+    } finally {
+      helper1.shutdown();
+      helper2.shutdown();
+    }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -34,8 +35,9 @@ public class TestStageThreadPoolHelper {
 
   @AfterMethod
   public void afterMethod() {
-    // Clean up after each test
+    // Clean up after each test and reset to default pool size
     StageThreadPoolHelper.shutdown();
+    StageThreadPoolHelper.setPoolSize(StageThreadPoolHelper.DEFAULT_POOL_SIZE);
   }
 
   @Test
@@ -100,6 +102,8 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testParallelExecution() throws InterruptedException {
+    StageThreadPoolHelper.setPoolSize(4);
+
     // Test that tasks are actually executed in parallel
     int numTasks = 4;
     CountDownLatch startLatch = new CountDownLatch(numTasks);
@@ -156,7 +160,6 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testShutdown() throws InterruptedException {
-    // Test shutdown functionality
     AtomicInteger counter = new AtomicInteger(0);
     List<Callable<Void>> tasks = new ArrayList<>();
 
@@ -178,7 +181,6 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testExecutorReinitialization() throws InterruptedException {
-    // Test that executor is reinitialized after shutdown
     AtomicInteger counter = new AtomicInteger(0);
     List<Callable<Void>> tasks = new ArrayList<>();
 
@@ -235,7 +237,6 @@ public class TestStageThreadPoolHelper {
 
   @Test(expectedExceptions = InterruptedException.class)
   public void testInterruptedExecution() throws InterruptedException {
-    // Test behavior when thread is interrupted during execution
     List<Callable<Void>> tasks = new ArrayList<>();
 
     tasks.add(() -> {
@@ -285,5 +286,57 @@ public class TestStageThreadPoolHelper {
 
     Assert.assertEquals(shortTaskCount.get(), 5, "All short tasks should complete");
     Assert.assertEquals(longTaskCount.get(), 3, "All long tasks should complete");
+  }
+
+  @Test
+  public void testConfigurablePoolSize() throws InterruptedException {
+    // Test that the pool size can be configured
+    StageThreadPoolHelper.setPoolSize(2);
+    Assert.assertEquals(StageThreadPoolHelper.getPoolSize(), 2, "Pool size should be 2");
+
+    // Test with tasks that require parallel execution
+    int numTasks = 4;
+    AtomicInteger concurrentCount = new AtomicInteger(0);
+    AtomicInteger maxConcurrent = new AtomicInteger(0);
+    List<Callable<Void>> tasks = new ArrayList<>();
+
+    for (int i = 0; i < numTasks; i++) {
+      tasks.add(() -> {
+        int current = concurrentCount.incrementAndGet();
+        // Track max concurrent execution
+        synchronized (maxConcurrent) {
+          if (current > maxConcurrent.get()) {
+            maxConcurrent.set(current);
+          }
+        }
+        TimeUnit.MILLISECONDS.sleep(100); // Simulate work
+        concurrentCount.decrementAndGet();
+        return null;
+      });
+    }
+
+    StageThreadPoolHelper.executeAndWait("ConfiguredPoolStage", tasks);
+
+    // With pool size of 2, max concurrent should be 2
+    Assert.assertTrue(maxConcurrent.get() <= 2,
+        "Max concurrent tasks should not exceed configured pool size of 2, but was: " + maxConcurrent.get());
+  }
+
+  @Test
+  public void testDefaultPoolSize() {
+    Assert.assertEquals(StageThreadPoolHelper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
+        "Pool size should be the default");
+  }
+
+  @Test
+  public void testInvalidPoolSizeFallsBackToDefault() {
+    // Test that invalid pool sizes fall back to default
+    StageThreadPoolHelper.setPoolSize(0);
+    Assert.assertEquals(StageThreadPoolHelper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
+        "Pool size 0 should fall back to default");
+
+    StageThreadPoolHelper.setPoolSize(-1);
+    Assert.assertEquals(StageThreadPoolHelper.getPoolSize(), StageThreadPoolHelper.DEFAULT_POOL_SIZE,
+        "Negative pool size should fall back to default");
   }
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Make StageThreadPoolHelper thread pool size configurable

### Description

**What**: Makes the parallel stage execution thread pool size configurable via ClusterConfig.
**Why**: Currently the thread pool size in StageThreadPoolHelper is hardcoded. Different clusters may have different parallelism requirements based on their workload and resources.
**How**:

- Added STAGE_PARALLEL_THREAD_POOL_SIZE property to ClusterConfig with getter/setter methods
- Added setPoolSize() method to StageThreadPoolHelper for dynamic pool size updates
- GenericHelixController reads the config on each pipeline run and updates the pool if changed
- Default remains min(4, availableProcessors) when not configured

**Usage**:

> `ClusterConfig clusterConfig = new ClusterConfig(clusterName);
> clusterConfig.setStageParallelThreadPoolSize(8);
> configAccessor.setClusterConfig(clusterName, clusterConfig);`


### Tests
TestStageThreadPoolHelper - tests for setPoolSize(), getPoolSize(), and dynamic pool resizing