### PR TITLE
BestPossibleStateCalc Stage : Fixes race condition in parallel resource computation

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateOutput.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateOutput.java
@@ -34,7 +34,8 @@ import org.apache.helix.model.Partition;
  */
 public class BestPossibleStateOutput extends ResourcesStateMap {
   /* resource -> partition -> preference list */
-  private Map<String, Map<String, List<String>>> _preferenceLists;
+  // Initialize eagerly to avoid race condition during parallel resource computation
+  private final Map<String, Map<String, List<String>>> _preferenceLists = new ConcurrentHashMap<>();
   /**
    * Deprecated, use getResourceStatesMap instead.
    *
@@ -72,38 +73,27 @@ public class BestPossibleStateOutput extends ResourcesStateMap {
   }
 
   public Map<String, List<String>> getPreferenceLists(String resource) {
-    if (_preferenceLists != null && _preferenceLists.containsKey(resource)) {
-      return _preferenceLists.get(resource);
-    }
-
-    return null;
+    return _preferenceLists.get(resource);
   }
 
   public List<String> getPreferenceList(String resource, String partition) {
-    if (_preferenceLists != null && _preferenceLists.containsKey(resource) && _preferenceLists
-        .get(resource).containsKey(partition)) {
-      return _preferenceLists.get(resource).get(partition);
+    Map<String, List<String>> resourcePrefs = _preferenceLists.get(resource);
+    if (resourcePrefs != null) {
+      return resourcePrefs.get(partition);
     }
-
     return null;
   }
 
   public void setPreferenceList(String resource, String partition, List<String> list) {
-    if (_preferenceLists == null) {
-      _preferenceLists = new ConcurrentHashMap<>();
-    }
     _preferenceLists.computeIfAbsent(resource, k -> new ConcurrentHashMap<>()).put(partition, list);
   }
 
   public void setPreferenceLists(String resource,
       Map<String, List<String>> resourcePreferenceLists) {
-    if (_preferenceLists == null) {
-      _preferenceLists = new ConcurrentHashMap<>();
-    }
     _preferenceLists.put(resource, resourcePreferenceLists);
   }
 
   protected boolean containsResource(String resource) {
-    return _preferenceLists != null && _preferenceLists.containsKey(resource);
+    return _preferenceLists.containsKey(resource);
   }
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fixes race condition in parallel resource computation introduced by BestPossibleState calc parallelization

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
**What:**
Fix thread-safety issue in BestPossibleStateOutput class that caused intermittent test failures when resources are computed in parallel.
**Why:**
The _preferenceLists field in BestPossibleStateOutput used lazy initialization with a check-then-act pattern that was not thread-safe:

> `// BEFORE: Race condition - multiple threads could pass the null check// and overwrite each other's ConcurrentHashMap instanceif (_preferenceLists == null) {    _preferenceLists = new ConcurrentHashMap<>();}_preferenceLists.put(resource, resourcePreferenceLists);`

When BestPossibleStateCalcStage computes resources in parallel using StageThreadPoolHelper, multiple threads could simultaneously:

- Check _preferenceLists == null → both return true
- Create new ConcurrentHashMap instances
- One thread's map overwrites the other's, losing resource data

**How**:
Changed _preferenceLists from lazy initialization to eager initialization:
`

> // AFTER: Thread-safe - field is initialized once at declarationprivate final Map<String, Map<String, List<String>>> _preferenceLists = new ConcurrentHashMap<>();

`
Key changes:

- Initialize _preferenceLists eagerly at field declaration
- Make the field final to prevent reassignment
- Remove all null checks from getter/setter methods
- Simplify method implementations

### Tests
No new tests added. This fix resolves existing intermittent failing tests:

<img width="1531" height="168" alt="image" src="https://github.com/user-attachments/assets/d2e67e66-a001-425b-8107-bf28d8b3f29a" />


TestBestPossibleStateCalcStage.testBestPossibleComputationWithMultipleResources

Fixing unrelated test failure here - https://github.com/linkedin/helix/pull/95

