### PR TITLE
Fix NullPointerException in ZkCallbackCache when oldStat is null

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCallbackCache.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCallbackCache.java
@@ -86,11 +86,8 @@ public class ZkCallbackCache<T> extends Cache<T> implements IZkChildListener, IZ
       znode.setStat(stat);
       // System.out.println("\t\t--setData. path: " + path + ", data: " + data);
 
-      // Null oldStat means first time seeing proper stat - fire Create only
-      if (oldStat == null) {
-        fireEvents(path, EventType.NodeCreated);
-      } else if (oldStat.getCzxid() != stat.getCzxid()) {
-        // Node was recreated (different czxid) - fire Delete + Create
+      // Null oldStat or czxid change indicates node recreation - fire Delete + Create
+      if (oldStat == null || oldStat.getCzxid() != stat.getCzxid()) {
         fireEvents(path, EventType.NodeDeleted);
         fireEvents(path, EventType.NodeCreated);
       } else if (oldStat.getVersion() != stat.getVersion()) {
@@ -179,11 +176,8 @@ public class ZkCallbackCache<T> extends Cache<T> implements IZkChildListener, IZ
         // if create right after delete, and zkCallback comes after create
         // no DataDelete() will be fired, instead will fire 2 DataChange()
         // see ZkClient.fireDataChangedEvents()
-        // Null oldStat means first time seeing proper stat - fire Create only
-        if (oldStat == null) {
-          fireEvents(dataPath, EventType.NodeCreated);
-        } else if (oldStat.getCzxid() != stat.getCzxid()) {
-          // Node was recreated (different czxid) - fire Delete + Create
+        // Null oldStat or czxid change indicates node recreation - fire Delete + Create
+        if (oldStat == null || oldStat.getCzxid() != stat.getCzxid()) {
           fireEvents(dataPath, EventType.NodeDeleted);
           fireEvents(dataPath, EventType.NodeCreated);
         } else if (oldStat.getVersion() != stat.getVersion()) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCallbackCache.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCallbackCache.java
@@ -86,8 +86,11 @@ public class ZkCallbackCache<T> extends Cache<T> implements IZkChildListener, IZ
       znode.setStat(stat);
       // System.out.println("\t\t--setData. path: " + path + ", data: " + data);
 
-      // If we don't know the previous czxid (oldState is null), that means node was recreated and listeners need to resync their state
-      if (oldStat == null || oldStat.getCzxid() != stat.getCzxid()) {
+      // Null oldStat means first time seeing proper stat - fire Create only
+      if (oldStat == null) {
+        fireEvents(path, EventType.NodeCreated);
+      } else if (oldStat.getCzxid() != stat.getCzxid()) {
+        // Node was recreated (different czxid) - fire Delete + Create
         fireEvents(path, EventType.NodeDeleted);
         fireEvents(path, EventType.NodeCreated);
       } else if (oldStat.getVersion() != stat.getVersion()) {
@@ -176,8 +179,11 @@ public class ZkCallbackCache<T> extends Cache<T> implements IZkChildListener, IZ
         // if create right after delete, and zkCallback comes after create
         // no DataDelete() will be fired, instead will fire 2 DataChange()
         // see ZkClient.fireDataChangedEvents()
-        // If we don't know the previous czxid (oldState is null), that means node was recreated and listeners need to resync their state
-        if (oldStat == null || oldStat.getCzxid() != stat.getCzxid()) {
+        // Null oldStat means first time seeing proper stat - fire Create only
+        if (oldStat == null) {
+          fireEvents(dataPath, EventType.NodeCreated);
+        } else if (oldStat.getCzxid() != stat.getCzxid()) {
+          // Node was recreated (different czxid) - fire Delete + Create
           fireEvents(dataPath, EventType.NodeDeleted);
           fireEvents(dataPath, EventType.NodeCreated);
         } else if (oldStat.getVersion() != stat.getVersion()) {

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCallbackCache.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkCallbackCache.java
@@ -86,7 +86,8 @@ public class ZkCallbackCache<T> extends Cache<T> implements IZkChildListener, IZ
       znode.setStat(stat);
       // System.out.println("\t\t--setData. path: " + path + ", data: " + data);
 
-      if (oldStat.getCzxid() != stat.getCzxid()) {
+      // If we don't know the previous czxid (oldState is null), that means node was recreated and listeners need to resync their state
+      if (oldStat == null || oldStat.getCzxid() != stat.getCzxid()) {
         fireEvents(path, EventType.NodeDeleted);
         fireEvents(path, EventType.NodeCreated);
       } else if (oldStat.getVersion() != stat.getVersion()) {
@@ -175,7 +176,8 @@ public class ZkCallbackCache<T> extends Cache<T> implements IZkChildListener, IZ
         // if create right after delete, and zkCallback comes after create
         // no DataDelete() will be fired, instead will fire 2 DataChange()
         // see ZkClient.fireDataChangedEvents()
-        if (oldStat.getCzxid() != stat.getCzxid()) {
+        // If we don't know the previous czxid (oldState is null), that means node was recreated and listeners need to resync their state
+        if (oldStat == null || oldStat.getCzxid() != stat.getCzxid()) {
           fireEvents(dataPath, EventType.NodeDeleted);
           fireEvents(dataPath, EventType.NodeCreated);
         } else if (oldStat.getVersion() != stat.getVersion()) {

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheSyncOpSingleThread.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheSyncOpSingleThread.java
@@ -37,6 +37,8 @@ import org.apache.helix.ZkUnitTestBase;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.impl.factory.SharedZkClientFactory;
 import org.apache.helix.store.HelixPropertyListener;
+import org.apache.helix.store.zk.ZNode;
+import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -347,25 +349,24 @@ public class TestZkCacheSyncOpSingleThread extends ZkUnitTestBase {
     accessor.subscribe(testPath, listener);
     String nodePath = testPath + "/testNode";
 
-    // Case 1: Null oldStat should fire Delete+Create (not NPE)
-    org.apache.helix.store.zk.ZNode znodeNullStat =
-        new org.apache.helix.store.zk.ZNode(nodePath, new ZNRecord("test"), null);
+    // Case 1: Null oldStat should fire Create only (not NPE, not Delete)
+    ZNode znodeNullStat = new ZNode(nodePath, new ZNRecord("test"), null);
     accessor._zkCache._cache.put(nodePath, znodeNullStat);
     listener.reset();
 
-    org.apache.zookeeper.data.Stat newStat = new org.apache.zookeeper.data.Stat();
+    Stat newStat = new Stat();
     newStat.setCzxid(100L);
     newStat.setVersion(1);
     accessor._zkCache.update(nodePath, new ZNRecord("updated"), newStat);
     Thread.sleep(100);
 
-    Assert.assertTrue(listener._deletePathQueue.size() >= 1, "Null oldStat should fire onDelete");
-    Assert.assertTrue(listener._createPathQueue.size() >= 1, "Null oldStat should fire onCreate");
+    Assert.assertEquals(listener._deletePathQueue.size(), 0, "Null oldStat should NOT fire onDelete");
+    Assert.assertEquals(listener._createPathQueue.size(), 1, "Null oldStat should fire onCreate");
     Assert.assertNotNull(accessor._zkCache._cache.get(nodePath).getStat(), "Stat should be set");
 
     // Case 2: Valid oldStat with version change -> DataChanged only
     listener.reset();
-    org.apache.zookeeper.data.Stat versionChange = new org.apache.zookeeper.data.Stat();
+    Stat versionChange = new Stat();
     versionChange.setCzxid(100L);
     versionChange.setVersion(2);
     accessor._zkCache.update(nodePath, new ZNRecord("v2"), versionChange);
@@ -376,7 +377,7 @@ public class TestZkCacheSyncOpSingleThread extends ZkUnitTestBase {
 
     // Case 3: Valid oldStat with czxid change -> Delete+Create
     listener.reset();
-    org.apache.zookeeper.data.Stat czxidChange = new org.apache.zookeeper.data.Stat();
+    Stat czxidChange = new Stat();
     czxidChange.setCzxid(200L);
     czxidChange.setVersion(0);
     accessor._zkCache.update(nodePath, new ZNRecord("recreated"), czxidChange);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheSyncOpSingleThread.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheSyncOpSingleThread.java
@@ -320,4 +320,72 @@ public class TestZkCacheSyncOpSingleThread extends ZkUnitTestBase {
     deleteCluster(clusterName);
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
   }
+
+  /**
+   * Test that ZkCallbackCache.update() handles null oldStat gracefully.
+   *
+   * Verifies:
+   * 1. No NPE when oldStat is null
+   * 2. Delete+Create events fire when oldStat is null
+   * 3. Normal behavior preserved when oldStat is valid
+   */
+  @Test
+  public void testUpdateHandlesNullOldStat() throws Exception {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String clusterName = className + "_" + methodName;
+
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+
+    String testPath = PropertyPathBuilder.instanceCurrentState(clusterName, "localhost_8901");
+    ZkBaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<>(_gZkClient);
+    List<String> cachePaths = Arrays.asList(testPath);
+    ZkCacheBaseDataAccessor<ZNRecord> accessor =
+        new ZkCacheBaseDataAccessor<>(baseAccessor, null, null, cachePaths);
+
+    TestListener listener = new TestListener();
+    accessor.subscribe(testPath, listener);
+    String nodePath = testPath + "/testNode";
+
+    // Case 1: Null oldStat should fire Delete+Create (not NPE)
+    org.apache.helix.store.zk.ZNode znodeNullStat =
+        new org.apache.helix.store.zk.ZNode(nodePath, new ZNRecord("test"), null);
+    accessor._zkCache._cache.put(nodePath, znodeNullStat);
+    listener.reset();
+
+    org.apache.zookeeper.data.Stat newStat = new org.apache.zookeeper.data.Stat();
+    newStat.setCzxid(100L);
+    newStat.setVersion(1);
+    accessor._zkCache.update(nodePath, new ZNRecord("updated"), newStat);
+    Thread.sleep(100);
+
+    Assert.assertTrue(listener._deletePathQueue.size() >= 1, "Null oldStat should fire onDelete");
+    Assert.assertTrue(listener._createPathQueue.size() >= 1, "Null oldStat should fire onCreate");
+    Assert.assertNotNull(accessor._zkCache._cache.get(nodePath).getStat(), "Stat should be set");
+
+    // Case 2: Valid oldStat with version change -> DataChanged only
+    listener.reset();
+    org.apache.zookeeper.data.Stat versionChange = new org.apache.zookeeper.data.Stat();
+    versionChange.setCzxid(100L);
+    versionChange.setVersion(2);
+    accessor._zkCache.update(nodePath, new ZNRecord("v2"), versionChange);
+    Thread.sleep(100);
+
+    Assert.assertEquals(listener._changePathQueue.size(), 1, "Version change should fire onChange");
+    Assert.assertEquals(listener._deletePathQueue.size(), 0, "Version change should not fire onDelete");
+
+    // Case 3: Valid oldStat with czxid change -> Delete+Create
+    listener.reset();
+    org.apache.zookeeper.data.Stat czxidChange = new org.apache.zookeeper.data.Stat();
+    czxidChange.setCzxid(200L);
+    czxidChange.setVersion(0);
+    accessor._zkCache.update(nodePath, new ZNRecord("recreated"), czxidChange);
+    Thread.sleep(100);
+
+    Assert.assertEquals(listener._deletePathQueue.size(), 1, "Czxid change should fire onDelete");
+    Assert.assertEquals(listener._createPathQueue.size(), 1, "Czxid change should fire onCreate");
+
+    deleteCluster(clusterName);
+    System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheSyncOpSingleThread.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkCacheSyncOpSingleThread.java
@@ -349,7 +349,7 @@ public class TestZkCacheSyncOpSingleThread extends ZkUnitTestBase {
     accessor.subscribe(testPath, listener);
     String nodePath = testPath + "/testNode";
 
-    // Case 1: Null oldStat should fire Create only (not NPE, not Delete)
+    // Case 1: Null oldStat should fire Delete + Create (not NPE)
     ZNode znodeNullStat = new ZNode(nodePath, new ZNRecord("test"), null);
     accessor._zkCache._cache.put(nodePath, znodeNullStat);
     listener.reset();
@@ -360,7 +360,7 @@ public class TestZkCacheSyncOpSingleThread extends ZkUnitTestBase {
     accessor._zkCache.update(nodePath, new ZNRecord("updated"), newStat);
     Thread.sleep(100);
 
-    Assert.assertEquals(listener._deletePathQueue.size(), 0, "Null oldStat should NOT fire onDelete");
+    Assert.assertEquals(listener._deletePathQueue.size(), 1, "Null oldStat should fire onDelete");
     Assert.assertEquals(listener._createPathQueue.size(), 1, "Null oldStat should fire onCreate");
     Assert.assertNotNull(accessor._zkCache._cache.get(nodePath).getStat(), "Stat should be set");
 


### PR DESCRIPTION
### Issues

Espresso storage nodes are encountering `NullPointerException` in Helix's `ZkCallbackCache` during ZooKeeper callback processing:

```
java.lang.NullPointerException: Cannot invoke "org.apache.zookeeper.data.Stat.getCzxid()" because "oldStat" is null
at org.apache.helix.manager.zk.ZkCallbackCache.update(ZkCallbackCache.java:89)
at org.apache.helix.manager.zk.ZkCallbackCache.updateRecursive(ZkCallbackCache.java:117)
at org.apache.helix.manager.zk.ZkCallbackCache.handleChildChange(ZkCallbackCache.java:150
```


This is a transient error during schema operations, caused by a race condition where `oldStat` is null when comparing `czxid` values.
The `oldStat` can be null in two scenarios:
1. ZNode created with null stat: When `cache.update(path, data, null)` is called in `ZkCacheBaseDataAccessor.java`
2. Stat set to null: When `znode.setStat(stat)` is called with stat=null in `ZkCallbackCache.java`

Both scenarios lead to `znode.getStat()` returning null on subsequent calls. ZNode ctor does not stop null stat.


- [x] My PR addresses the following Helix issues and references them in the PR description: CICP-3092, CICP-2712

### Description

- [x] Here are some details about my PR:

**Root Cause:** In `ZkCallbackCache.update()` and `handleDataChange()`, the code retrieves `oldStat` from a cached `ZNode` and uses it without null check:

```
Stat oldStat = znode.getStat();
if (oldStat.getCzxid() != stat.getCzxid()) { // NPE when oldStat is null
```

**The Fix:** Add null check to handle the race condition gracefully:

```
if (oldStat == null || oldStat.getCzxid() != stat.getCzxid()) {
    fireEvents(path, EventType.NodeDeleted);
    fireEvents(path, EventType.NodeCreated);
}
```

- When `oldStat` is null, we cannot determine if the node was recreated
- fire Delete+Create events to ensure listeners resync
- This matches the existing behavior when `czxid` changes
- File `HierarchicalDataHolder.java` already handles null oldStat.
- Espresso's [InFlightSchemaStore](https://jarvis.corp.linkedin.com/codesearch/result/?name=InFlightSchemaStore.java&path=espresso-pub%2Fschema%2Fespresso-schema-impl%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fespresso%2Fschema&reponame=linkedin-multiproduct%2Fespresso-pub#430) listener handles these events 
<img width="621" height="142" alt="Screenshot 2026-01-07 at 6 26 07 PM" src="https://github.com/user-attachments/assets/c3eee98e-7ef2-49de-bd70-e49eb5e3a023" />
<img width="1037" height="265" alt="Screenshot 2026-01-07 at 6 26 21 PM" src="https://github.com/user-attachments/assets/c1a20a4e-d2a2-4566-895e-8537075aae00" />

### Tests

- [x] The following tests are written for this issue:

`TestZkCacheSyncOpSingleThread.testUpdateHandlesNullOldStat`

Covers:
1. No NPE when `oldStat` is null
4. Delete+Create events fire when `oldStat` is null
5. Normal behavior preserved when `oldStat` is valid (version change → DataChanged, czxid change → Delete+Create)

`mvn test -pl helix-core -Dtest=TestZkCacheSyncOpSingleThread 2>&1 `

<img width="1132" height="646" alt="Screenshot 2026-01-07 at 6 12 18 PM" src="https://github.com/user-attachments/assets/abcf5ac7-06f8-43ca-ab75-089f495d0c83" />
