### PR TITLE
Return current Evacuation status of isEvacuateFinished

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -488,8 +488,6 @@ public class ZKHelixAdmin implements HelixAdmin {
   public Map<String, Object> getEvacuationStatus(String clusterName, String instanceName,
       Set<InstanceDrainExclusionType> exclusionTypes) {
     Map<String, Object> result = new HashMap<>();
-    // Provide a stable response shape for clients.
-    result.put("isFinished", false);
     result.put("successful", false);
     result.put("remainingCount", 0);
     result.put("pendingMessageCount", 0);
@@ -503,9 +501,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     boolean hasBlocking = instanceHasCurrentStateOrMessage(
         clusterName, instanceName, exclusionTypes, result);
-    boolean isFinished = !hasBlocking;
-    result.put("isFinished", isFinished);
-    result.put("successful", isFinished); // Backward-compatible alias for older clients/tests.
+    result.put("successful", !hasBlocking);
     return result;
   }
 
@@ -865,19 +861,12 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (sessions.isEmpty()) {
       logger.info("Instance {} in cluster {} does not have any session. The instance can be removed.",
           instanceName, clusterName);
-      if (statusMap != null) {
-        statusMap.put("remainingCount", 0);
-        statusMap.put("pendingMessageCount", 0);
-      }
       return false;
     }
     if (sessions.size() > 1) {
       logger.info("Instance {} in cluster {} is carrying over from prev session.",
           instanceName, clusterName);
       if (statusMap != null) {
-        statusMap.put("isCarryingOverFromPreviousSession", true);
-        statusMap.put("remainingCount", -1);
-        statusMap.put("pendingMessageCount", -1);
         statusMap.put("reason", "Instance has multiple sessions and is carrying over from previous session");
       }
       return true;
@@ -889,10 +878,6 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (currentStates == null || currentStates.isEmpty()) {
       logger.info("Instance {} in cluster {} does not have any current state.",
           instanceName, clusterName);
-      if (statusMap != null) {
-        statusMap.put("remainingCount", 0);
-        statusMap.put("pendingMessageCount", 0);
-      }
       return false;
     }
 
@@ -910,7 +895,6 @@ public class ZKHelixAdmin implements HelixAdmin {
       List<PartitionInfo> partitionsStillOnInstance =
           PartitionExclusionHelper.getCustomizedPartitionsStillOnInstance(
               currentStates, idealStates, instanceName, allowedResources, filters);
-
       boolean hasPartitionsStillOnInstance = !partitionsStillOnInstance.isEmpty();
       logger.info("Instance {} in cluster {} (offline) has {} partitions still on instance after exclusions",
           instanceName, clusterName, partitionsStillOnInstance.size());
@@ -932,15 +916,14 @@ public class ZKHelixAdmin implements HelixAdmin {
           instanceName, clusterName, pendingMessageCount);
     }
 
-    // Step 4: Collect all partitions from current states
+    // Step 4: Collect all partitions from current states (after resource-level exclusions)
     List<PartitionInfo> allPartitions =
         PartitionExclusionHelper.collectPartitions(currentStates, allowedResources);
 
-    // Step 5: Apply exclusions to the collected partitions
+    // Step 5: Apply partition-level exclusions
     List<PartitionInfo> remainingPartitions =
         PartitionExclusionHelper.applyExclusions(allPartitions, filters);
 
-    // Step 6: Check if any partitions remain after exclusions
     boolean hasRemainingPartitions = !remainingPartitions.isEmpty();
     logger.info("Instance {} in cluster {} has {} partitions after applying {} exclusions (from {} total)",
         instanceName, clusterName, remainingPartitions.size(), exclusionTypes.size(), allPartitions.size());

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -29,11 +29,13 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -898,16 +900,12 @@ public class ZKHelixAdmin implements HelixAdmin {
       for (CurrentState cs : currentStates) {
         currentStateKeys.add(keyBuilder.currentState(instanceName, sessionId, cs.getResourceName()));
       }
-      List<HelixProperty.Stat> stats = accessor.getPropertyStats(currentStateKeys);
-      long maxMtime = 0;
-      for (HelixProperty.Stat stat : stats) {
-        if (stat != null && stat.getModifiedTime() > maxMtime) {
-          maxMtime = stat.getModifiedTime();
-        }
-      }
-      if (maxMtime > 0) {
-        evacuationInfo.setLastActivityTimestamp(maxMtime);
-      }
+      accessor.getPropertyStats(currentStateKeys).stream()
+          .filter(Objects::nonNull)
+          .max(Comparator.comparingLong(HelixProperty.Stat::getModifiedTime))
+          .map(HelixProperty.Stat::getModifiedTime)
+          .filter(maxMtime -> maxMtime > 0)
+          .ifPresent(evacuationInfo::setLastActivityTimestamp);
     }
 
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates(), true);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -478,6 +478,37 @@ public class ZKHelixAdmin implements HelixAdmin {
     return !instanceHasCurrentStateOrMessage(clusterName, instanceName, exclusionTypes);
   }
 
+  /**
+   * Returns a detailed evacuation status map for the given instance.
+   *
+   * This is used by the Helix REST {@code isEvacuateFinished} command to return an extendable JSON
+   * response (for example, remaining partition count) without changing the {@link HelixAdmin}
+   * public interface.
+   */
+  public Map<String, Object> getEvacuationStatus(String clusterName, String instanceName,
+      Set<InstanceDrainExclusionType> exclusionTypes) {
+    Map<String, Object> result = new HashMap<>();
+    // Provide a stable response shape for clients.
+    result.put("isFinished", false);
+    result.put("successful", false);
+    result.put("remainingCount", 0);
+    result.put("pendingMessageCount", 0);
+
+    InstanceConfig config = getInstanceConfig(clusterName, instanceName);
+    if (config == null || config.getInstanceOperation().getOperation() !=
+        InstanceConstants.InstanceOperation.EVACUATE) {
+      result.put("reason", "Instance is not in EVACUATE operation");
+      return result;
+    }
+
+    boolean hasBlocking = instanceHasCurrentStateOrMessage(
+        clusterName, instanceName, exclusionTypes, result);
+    boolean isFinished = !hasBlocking;
+    result.put("isFinished", isFinished);
+    result.put("successful", isFinished); // Backward-compatible alias for older clients/tests.
+    return result;
+  }
+
   @Override
   public boolean isInstanceDrained(String clusterName, String instanceName) {
     return !instanceHasCurrentStateOrMessage(clusterName, instanceName, Collections.emptySet());
@@ -811,6 +842,15 @@ public class ZKHelixAdmin implements HelixAdmin {
    */
   private boolean instanceHasCurrentStateOrMessage(String clusterName,
       String instanceName, Set<InstanceDrainExclusionType> exclusionTypes) {
+    return instanceHasCurrentStateOrMessage(clusterName, instanceName, exclusionTypes, null);
+  }
+
+  /**
+   * Same as {@link #instanceHasCurrentStateOrMessage(String, String, Set)} but optionally fills
+   * {@code statusMap} with additional details for REST responses.
+   */
+  private boolean instanceHasCurrentStateOrMessage(String clusterName, String instanceName,
+      Set<InstanceDrainExclusionType> exclusionTypes, @Nullable Map<String, Object> statusMap) {
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, _baseDataAccessor);
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
 
@@ -825,11 +865,21 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (sessions.isEmpty()) {
       logger.info("Instance {} in cluster {} does not have any session. The instance can be removed.",
           instanceName, clusterName);
+      if (statusMap != null) {
+        statusMap.put("remainingCount", 0);
+        statusMap.put("pendingMessageCount", 0);
+      }
       return false;
     }
     if (sessions.size() > 1) {
       logger.info("Instance {} in cluster {} is carrying over from prev session.",
           instanceName, clusterName);
+      if (statusMap != null) {
+        statusMap.put("isCarryingOverFromPreviousSession", true);
+        statusMap.put("remainingCount", -1);
+        statusMap.put("pendingMessageCount", -1);
+        statusMap.put("reason", "Instance has multiple sessions and is carrying over from previous session");
+      }
       return true;
     }
 
@@ -839,6 +889,10 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (currentStates == null || currentStates.isEmpty()) {
       logger.info("Instance {} in cluster {} does not have any current state.",
           instanceName, clusterName);
+      if (statusMap != null) {
+        statusMap.put("remainingCount", 0);
+        statusMap.put("pendingMessageCount", 0);
+      }
       return false;
     }
 
@@ -860,15 +914,22 @@ public class ZKHelixAdmin implements HelixAdmin {
       boolean hasPartitionsStillOnInstance = !partitionsStillOnInstance.isEmpty();
       logger.info("Instance {} in cluster {} (offline) has {} partitions still on instance after exclusions",
           instanceName, clusterName, partitionsStillOnInstance.size());
+      if (statusMap != null) {
+        statusMap.put("remainingCount", partitionsStillOnInstance.size());
+        statusMap.put("pendingMessageCount", 0);
+      }
       return hasPartitionsStillOnInstance;
     }
 
-    // Handle online instances - check for pending messages first
+    // Handle online instances - also report pending messages
     List<String> messages = accessor.getChildNames(keyBuilder.messages(instanceName));
-    if (messages != null && !messages.isEmpty()) {
+    int pendingMessageCount = messages != null ? messages.size() : 0;
+    if (statusMap != null) {
+      statusMap.put("pendingMessageCount", pendingMessageCount);
+    }
+    if (pendingMessageCount > 0) {
       logger.info("Instance {} in cluster {} has {} pending messages.",
-          instanceName, clusterName, messages.size());
-      return true;
+          instanceName, clusterName, pendingMessageCount);
     }
 
     // Step 4: Collect all partitions from current states
@@ -883,8 +944,11 @@ public class ZKHelixAdmin implements HelixAdmin {
     boolean hasRemainingPartitions = !remainingPartitions.isEmpty();
     logger.info("Instance {} in cluster {} has {} partitions after applying {} exclusions (from {} total)",
         instanceName, clusterName, remainingPartitions.size(), exclusionTypes.size(), allPartitions.size());
+    if (statusMap != null) {
+      statusMap.put("remainingCount", remainingPartitions.size());
+    }
 
-    return hasRemainingPartitions;
+    return pendingMessageCount > 0 || hasRemainingPartitions;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -51,6 +51,7 @@ import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixException;
+import org.apache.helix.HelixProperty;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyPathBuilder;
@@ -861,6 +862,10 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (sessions.isEmpty()) {
       logger.info("Instance {} in cluster {} does not have any session. The instance can be removed.",
           instanceName, clusterName);
+      if (evacuationInfo != null) {
+        evacuationInfo.setRemainingPartitionCount(0);
+        evacuationInfo.setPendingMessageCount(0);
+      }
       return false;
     }
     if (sessions.size() > 1) {
@@ -878,7 +883,31 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (currentStates == null || currentStates.isEmpty()) {
       logger.info("Instance {} in cluster {} does not have any current state.",
           instanceName, clusterName);
+      if (evacuationInfo != null) {
+        evacuationInfo.setRemainingPartitionCount(0);
+        evacuationInfo.setPendingMessageCount(0);
+      }
       return false;
+    }
+
+    // Calculate max mtime across all CurrentState ZNodes for lastActivityTimestamp
+    // note: getChildValues() that is used above to fetch currentStates, doesn't populate stat data,
+    // so we need to fetch stats separately, this is not a expensive zk op, as its a batch call.
+    if (evacuationInfo != null) {
+      List<PropertyKey> currentStateKeys = new ArrayList<>();
+      for (CurrentState cs : currentStates) {
+        currentStateKeys.add(keyBuilder.currentState(instanceName, sessionId, cs.getResourceName()));
+      }
+      List<HelixProperty.Stat> stats = accessor.getPropertyStats(currentStateKeys);
+      long maxMtime = 0;
+      for (HelixProperty.Stat stat : stats) {
+        if (stat != null && stat.getModifiedTime() > maxMtime) {
+          maxMtime = stat.getModifiedTime();
+        }
+      }
+      if (maxMtime > 0) {
+        evacuationInfo.setLastActivityTimestamp(maxMtime);
+      }
     }
 
     List<IdealState> idealStates = accessor.getChildValues(keyBuilder.idealStates(), true);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -77,6 +77,7 @@ import org.apache.helix.model.ConstraintItem;
 import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.CustomizedStateConfig;
+import org.apache.helix.model.EvacuationInfo;
 import org.apache.helix.model.CustomizedView;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
@@ -479,29 +480,26 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   /**
-   * Returns a detailed evacuation status map for the given instance.
+   * Returns a detailed evacuation status for the given instance.
    *
    * This is used by the Helix REST {@code isEvacuateFinished} command to return an extendable JSON
    * response (for example, remaining partition count) without changing the {@link HelixAdmin}
    * public interface.
    */
-  public Map<String, Object> getEvacuationStatus(String clusterName, String instanceName,
+  public EvacuationInfo getEvacuationStatus(String clusterName, String instanceName,
       Set<InstanceDrainExclusionType> exclusionTypes) {
-    Map<String, Object> result = new HashMap<>();
-    result.put("successful", false);
-    result.put("remainingCount", 0);
-    result.put("pendingMessageCount", 0);
+    EvacuationInfo result = new EvacuationInfo();
 
     InstanceConfig config = getInstanceConfig(clusterName, instanceName);
     if (config == null || config.getInstanceOperation().getOperation() !=
         InstanceConstants.InstanceOperation.EVACUATE) {
-      result.put("reason", "Instance is not in EVACUATE operation");
+      result.setReason(EvacuationInfo.ReasonCode.NOT_IN_EVACUATE_OPERATION);
       return result;
     }
 
     boolean hasBlocking = instanceHasCurrentStateOrMessage(
         clusterName, instanceName, exclusionTypes, result);
-    result.put("successful", !hasBlocking);
+    result.setSuccessful(!hasBlocking);
     return result;
   }
 
@@ -843,10 +841,10 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   /**
    * Same as {@link #instanceHasCurrentStateOrMessage(String, String, Set)} but optionally fills
-   * {@code statusMap} with additional details for REST responses.
+   * {@code evacuationInfo} with additional details for REST responses.
    */
   private boolean instanceHasCurrentStateOrMessage(String clusterName, String instanceName,
-      Set<InstanceDrainExclusionType> exclusionTypes, @Nullable Map<String, Object> statusMap) {
+      Set<InstanceDrainExclusionType> exclusionTypes, @Nullable EvacuationInfo evacuationInfo) {
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, _baseDataAccessor);
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
 
@@ -866,8 +864,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     if (sessions.size() > 1) {
       logger.info("Instance {} in cluster {} is carrying over from prev session.",
           instanceName, clusterName);
-      if (statusMap != null) {
-        statusMap.put("reason", "Instance has multiple sessions and is carrying over from previous session");
+      if (evacuationInfo != null) {
+        evacuationInfo.setReason(EvacuationInfo.ReasonCode.MULTIPLE_SESSIONS);
       }
       return true;
     }
@@ -898,9 +896,9 @@ public class ZKHelixAdmin implements HelixAdmin {
       boolean hasPartitionsStillOnInstance = !partitionsStillOnInstance.isEmpty();
       logger.info("Instance {} in cluster {} (offline) has {} partitions still on instance after exclusions",
           instanceName, clusterName, partitionsStillOnInstance.size());
-      if (statusMap != null) {
-        statusMap.put("remainingCount", partitionsStillOnInstance.size());
-        statusMap.put("pendingMessageCount", 0);
+      if (evacuationInfo != null) {
+        evacuationInfo.setRemainingCount(partitionsStillOnInstance.size());
+        evacuationInfo.setPendingMessageCount(0);
       }
       return hasPartitionsStillOnInstance;
     }
@@ -908,8 +906,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     // Handle online instances - also report pending messages
     List<String> messages = accessor.getChildNames(keyBuilder.messages(instanceName));
     int pendingMessageCount = messages != null ? messages.size() : 0;
-    if (statusMap != null) {
-      statusMap.put("pendingMessageCount", pendingMessageCount);
+    if (evacuationInfo != null) {
+      evacuationInfo.setPendingMessageCount(pendingMessageCount);
     }
     if (pendingMessageCount > 0) {
       logger.info("Instance {} in cluster {} has {} pending messages.",
@@ -927,8 +925,8 @@ public class ZKHelixAdmin implements HelixAdmin {
     boolean hasRemainingPartitions = !remainingPartitions.isEmpty();
     logger.info("Instance {} in cluster {} has {} partitions after applying {} exclusions (from {} total)",
         instanceName, clusterName, remainingPartitions.size(), exclusionTypes.size(), allPartitions.size());
-    if (statusMap != null) {
-      statusMap.put("remainingCount", remainingPartitions.size());
+    if (evacuationInfo != null) {
+      evacuationInfo.setRemainingCount(remainingPartitions.size());
     }
 
     return pendingMessageCount > 0 || hasRemainingPartitions;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -494,8 +494,12 @@ public class ZKHelixAdmin implements HelixAdmin {
     EvacuationInfo result = new EvacuationInfo();
 
     InstanceConfig config = getInstanceConfig(clusterName, instanceName);
-    if (config == null || config.getInstanceOperation().getOperation() !=
-        InstanceConstants.InstanceOperation.EVACUATE) {
+    if (config == null) {
+      result.setState(EvacuationInfo.EvacuationState.NOT_EVACUATING);
+      result.setReason(EvacuationInfo.ReasonCode.INSTANCE_CONFIG_NOT_FOUND);
+      return result;
+    }
+    if (config.getInstanceOperation().getOperation() != InstanceConstants.InstanceOperation.EVACUATE) {
       result.setState(EvacuationInfo.EvacuationState.NOT_EVACUATING);
       result.setReason(EvacuationInfo.ReasonCode.NOT_IN_EVACUATE_OPERATION);
       return result;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -493,13 +493,15 @@ public class ZKHelixAdmin implements HelixAdmin {
     InstanceConfig config = getInstanceConfig(clusterName, instanceName);
     if (config == null || config.getInstanceOperation().getOperation() !=
         InstanceConstants.InstanceOperation.EVACUATE) {
+      result.setState(EvacuationInfo.EvacuationState.NOT_EVACUATING);
       result.setReason(EvacuationInfo.ReasonCode.NOT_IN_EVACUATE_OPERATION);
       return result;
     }
 
     boolean hasBlocking = instanceHasCurrentStateOrMessage(
         clusterName, instanceName, exclusionTypes, result);
-    result.setSuccessful(!hasBlocking);
+    result.setState(hasBlocking ? EvacuationInfo.EvacuationState.IN_PROGRESS
+        : EvacuationInfo.EvacuationState.COMPLETED);
     return result;
   }
 
@@ -897,7 +899,7 @@ public class ZKHelixAdmin implements HelixAdmin {
       logger.info("Instance {} in cluster {} (offline) has {} partitions still on instance after exclusions",
           instanceName, clusterName, partitionsStillOnInstance.size());
       if (evacuationInfo != null) {
-        evacuationInfo.setRemainingCount(partitionsStillOnInstance.size());
+        evacuationInfo.setRemainingPartitionCount(partitionsStillOnInstance.size());
         evacuationInfo.setPendingMessageCount(0);
       }
       return hasPartitionsStillOnInstance;
@@ -926,7 +928,7 @@ public class ZKHelixAdmin implements HelixAdmin {
     logger.info("Instance {} in cluster {} has {} partitions after applying {} exclusions (from {} total)",
         instanceName, clusterName, remainingPartitions.size(), exclusionTypes.size(), allPartitions.size());
     if (evacuationInfo != null) {
-      evacuationInfo.setRemainingCount(remainingPartitions.size());
+      evacuationInfo.setRemainingPartitionCount(remainingPartitions.size());
     }
 
     return pendingMessageCount > 0 || hasRemainingPartitions;

--- a/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
+++ b/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
@@ -1,0 +1,123 @@
+package org.apache.helix.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Data class representing the evacuation status of an instance.
+ * Used by the isEvacuateFinished REST API to return detailed information
+ * about the evacuation progress.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EvacuationInfo {
+
+  /**
+   * Enum representing reasons why evacuation may be blocked or incomplete.
+   */
+  public enum ReasonCode {
+    NOT_IN_EVACUATE_OPERATION("Instance is not in EVACUATE operation"),
+    MULTIPLE_SESSIONS("Instance has multiple sessions and is carrying over from previous session");
+
+    private final String message;
+
+    ReasonCode(String message) {
+      this.message = message;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
+
+  private boolean successful;
+  private int remainingCount;
+  private int pendingMessageCount;
+  private String reason;
+
+  /**
+   * Default constructor for Jackson deserialization.
+   */
+  public EvacuationInfo() {
+    this.successful = false;
+    this.remainingCount = 0;
+    this.pendingMessageCount = 0;
+  }
+
+  /**
+   * Constructor with all fields.
+   */
+  public EvacuationInfo(boolean successful, int remainingCount, int pendingMessageCount, String reason) {
+    this.successful = successful;
+    this.remainingCount = remainingCount;
+    this.pendingMessageCount = pendingMessageCount;
+    this.reason = reason;
+  }
+
+  public boolean isSuccessful() {
+    return successful;
+  }
+
+  public void setSuccessful(boolean successful) {
+    this.successful = successful;
+  }
+
+  public int getRemainingCount() {
+    return remainingCount;
+  }
+
+  public void setRemainingCount(int remainingCount) {
+    this.remainingCount = remainingCount;
+  }
+
+  public int getPendingMessageCount() {
+    return pendingMessageCount;
+  }
+
+  public void setPendingMessageCount(int pendingMessageCount) {
+    this.pendingMessageCount = pendingMessageCount;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  /**
+   * Sets the reason using a predefined ReasonCode.
+   */
+  public void setReason(ReasonCode reasonCode) {
+    this.reason = reasonCode.getMessage();
+  }
+
+  @Override
+  public String toString() {
+    return "EvacuationInfo{" +
+        "successful=" + successful +
+        ", remainingCount=" + remainingCount +
+        ", pendingMessageCount=" + pendingMessageCount +
+        ", reason='" + reason + '\'' +
+        '}';
+  }
+}
+

--- a/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
+++ b/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
@@ -42,6 +42,7 @@ public class EvacuationInfo {
    * Enum representing reasons why evacuation may be blocked or incomplete.
    */
   public enum ReasonCode {
+    INSTANCE_CONFIG_NOT_FOUND("Instance configuration not found"),
     NOT_IN_EVACUATE_OPERATION("Instance is not in EVACUATE operation"),
     MULTIPLE_SESSIONS("Instance has multiple sessions and is carrying over from previous session");
 

--- a/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
+++ b/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
@@ -30,6 +30,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class EvacuationInfo {
 
   /**
+   * Enum representing the current state of evacuation.
+   */
+  public enum EvacuationState {
+    NOT_EVACUATING,  // Instance is not in EVACUATE operation
+    IN_PROGRESS,     // Evacuation is ongoing
+    COMPLETED        // Evacuation finished successfully
+  }
+
+  /**
    * Enum representing reasons why evacuation may be blocked or incomplete.
    */
   public enum ReasonCode {
@@ -47,8 +56,8 @@ public class EvacuationInfo {
     }
   }
 
-  private boolean successful;
-  private int remainingCount;
+  private EvacuationState state;
+  private int remainingPartitionCount;
   private int pendingMessageCount;
   private String reason;
 
@@ -56,35 +65,35 @@ public class EvacuationInfo {
    * Default constructor for Jackson deserialization.
    */
   public EvacuationInfo() {
-    this.successful = false;
-    this.remainingCount = 0;
+    this.state = EvacuationState.NOT_EVACUATING;
+    this.remainingPartitionCount = 0;
     this.pendingMessageCount = 0;
   }
 
   /**
    * Constructor with all fields.
    */
-  public EvacuationInfo(boolean successful, int remainingCount, int pendingMessageCount, String reason) {
-    this.successful = successful;
-    this.remainingCount = remainingCount;
+  public EvacuationInfo(EvacuationState state, int remainingPartitionCount, int pendingMessageCount, String reason) {
+    this.state = state;
+    this.remainingPartitionCount = remainingPartitionCount;
     this.pendingMessageCount = pendingMessageCount;
     this.reason = reason;
   }
 
-  public boolean isSuccessful() {
-    return successful;
+  public EvacuationState getState() {
+    return state;
   }
 
-  public void setSuccessful(boolean successful) {
-    this.successful = successful;
+  public void setState(EvacuationState state) {
+    this.state = state;
   }
 
-  public int getRemainingCount() {
-    return remainingCount;
+  public int getRemainingPartitionCount() {
+    return remainingPartitionCount;
   }
 
-  public void setRemainingCount(int remainingCount) {
-    this.remainingCount = remainingCount;
+  public void setRemainingPartitionCount(int remainingPartitionCount) {
+    this.remainingPartitionCount = remainingPartitionCount;
   }
 
   public int getPendingMessageCount() {
@@ -113,11 +122,10 @@ public class EvacuationInfo {
   @Override
   public String toString() {
     return "EvacuationInfo{" +
-        "successful=" + successful +
-        ", remainingCount=" + remainingCount +
+        "state=" + state +
+        ", remainingPartitionCount=" + remainingPartitionCount +
         ", pendingMessageCount=" + pendingMessageCount +
         ", reason='" + reason + '\'' +
         '}';
   }
 }
-

--- a/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
+++ b/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
@@ -60,6 +60,7 @@ public class EvacuationInfo {
   private Integer remainingPartitionCount;
   private Integer pendingMessageCount;
   private String reason;
+  private Long lastActivityTimestamp;
 
   /**
    * Default constructor for Jackson deserialization.
@@ -120,6 +121,18 @@ public class EvacuationInfo {
     this.reason = reasonCode.getMessage();
   }
 
+  public Long getLastActivityTimestamp() {
+    return lastActivityTimestamp;
+  }
+
+  /**
+   * Sets the timestamp of the last activity during evacuation.
+   * This is the max modification time across all CurrentState ZNodes for the instance.
+   */
+  public void setLastActivityTimestamp(Long lastActivityTimestamp) {
+    this.lastActivityTimestamp = lastActivityTimestamp;
+  }
+
   @Override
   public String toString() {
     return "EvacuationInfo{" +
@@ -127,6 +140,7 @@ public class EvacuationInfo {
         ", remainingPartitionCount=" + remainingPartitionCount +
         ", pendingMessageCount=" + pendingMessageCount +
         ", reason='" + reason + '\'' +
+        ", lastActivityTimestamp=" + lastActivityTimestamp +
         '}';
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
+++ b/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
@@ -90,6 +90,16 @@ public class EvacuationInfo {
     this.state = state;
   }
 
+  /**
+   * Returns whether evacuation is complete.
+   * This is a derived field for backward compatibility with clients expecting a boolean "successful" field.
+   *
+   * @return true if state is COMPLETED, false otherwise
+   */
+  public boolean isSuccessful() {
+    return state == EvacuationState.COMPLETED;
+  }
+
   public Integer getRemainingPartitionCount() {
     return remainingPartitionCount;
   }
@@ -136,7 +146,8 @@ public class EvacuationInfo {
   @Override
   public String toString() {
     return "EvacuationInfo{" +
-        "state=" + state +
+        "successful=" + isSuccessful() +
+        ", state=" + state +
         ", remainingPartitionCount=" + remainingPartitionCount +
         ", pendingMessageCount=" + pendingMessageCount +
         ", reason='" + reason + '\'' +

--- a/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
+++ b/helix-core/src/main/java/org/apache/helix/model/EvacuationInfo.java
@@ -57,23 +57,24 @@ public class EvacuationInfo {
   }
 
   private EvacuationState state;
-  private int remainingPartitionCount;
-  private int pendingMessageCount;
+  private Integer remainingPartitionCount;
+  private Integer pendingMessageCount;
   private String reason;
 
   /**
    * Default constructor for Jackson deserialization.
+   * Fields are left as null so they won't be serialized when not applicable.
    */
   public EvacuationInfo() {
     this.state = EvacuationState.NOT_EVACUATING;
-    this.remainingPartitionCount = 0;
-    this.pendingMessageCount = 0;
+    // remainingPartitionCount and pendingMessageCount are intentionally left null
+    // so they won't be serialized for NOT_EVACUATING state
   }
 
   /**
    * Constructor with all fields.
    */
-  public EvacuationInfo(EvacuationState state, int remainingPartitionCount, int pendingMessageCount, String reason) {
+  public EvacuationInfo(EvacuationState state, Integer remainingPartitionCount, Integer pendingMessageCount, String reason) {
     this.state = state;
     this.remainingPartitionCount = remainingPartitionCount;
     this.pendingMessageCount = pendingMessageCount;
@@ -88,19 +89,19 @@ public class EvacuationInfo {
     this.state = state;
   }
 
-  public int getRemainingPartitionCount() {
+  public Integer getRemainingPartitionCount() {
     return remainingPartitionCount;
   }
 
-  public void setRemainingPartitionCount(int remainingPartitionCount) {
+  public void setRemainingPartitionCount(Integer remainingPartitionCount) {
     this.remainingPartitionCount = remainingPartitionCount;
   }
 
-  public int getPendingMessageCount() {
+  public Integer getPendingMessageCount() {
     return pendingMessageCount;
   }
 
-  public void setPendingMessageCount(int pendingMessageCount) {
+  public void setPendingMessageCount(Integer pendingMessageCount) {
     this.pendingMessageCount = pendingMessageCount;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
@@ -21,16 +21,13 @@ package org.apache.helix.integration.rebalancer;
 
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.TestHelper;
 import org.apache.helix.constants.InstanceDrainExclusionType;
 import org.apache.helix.constants.InstanceConstants;
-import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.TaskTestBase;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
@@ -405,11 +402,13 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
         "Should return NOT_EVACUATING when instance is not in EVACUATE operation");
     Assert.assertEquals(statusBefore.getReason(),
         EvacuationInfo.ReasonCode.NOT_IN_EVACUATE_OPERATION.getMessage());
-    // When NOT_EVACUATING, counts should be null (won't be serialized in JSON)
+    // When NOT_EVACUATING, counts and timestamp should be null (won't be serialized in JSON)
     Assert.assertNull(statusBefore.getRemainingPartitionCount(),
         "remainingPartitionCount should be null when not evacuating");
     Assert.assertNull(statusBefore.getPendingMessageCount(),
         "pendingMessageCount should be null when not evacuating");
+    Assert.assertNull(statusBefore.getLastActivityTimestamp(),
+        "lastActivityTimestamp should be null when not evacuating");
 
     // Set instance to EVACUATE
     _gSetupTool.getClusterManagementTool()
@@ -419,7 +418,17 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     EvacuationInfo statusDuring = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
     System.out.println("During evacuation - state: " + statusDuring.getState()
         + ", remainingPartitionCount: " + statusDuring.getRemainingPartitionCount()
-        + ", pendingMessageCount: " + statusDuring.getPendingMessageCount());
+        + ", pendingMessageCount: " + statusDuring.getPendingMessageCount()
+        + ", lastActivityTimestamp: " + statusDuring.getLastActivityTimestamp());
+    // During evacuation, lastActivityTimestamp should be populated if there are current states
+    if (statusDuring.getState() == EvacuationInfo.EvacuationState.IN_PROGRESS
+        && statusDuring.getRemainingPartitionCount() != null
+        && statusDuring.getRemainingPartitionCount() > 0) {
+      Assert.assertNotNull(statusDuring.getLastActivityTimestamp(),
+          "lastActivityTimestamp should be populated during evacuation with partitions");
+      Assert.assertTrue(statusDuring.getLastActivityTimestamp() > 0,
+          "lastActivityTimestamp should be a positive Unix timestamp");
+    }
 
     // Wait for evacuation to complete
     boolean evacuated = TestHelper.verify(
@@ -433,10 +442,12 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
         "Should return COMPLETED after evacuation completes");
     Assert.assertEquals(statusAfter.getRemainingPartitionCount(), Integer.valueOf(0), "remainingPartitionCount should be 0 after evacuation");
     Assert.assertEquals(statusAfter.getPendingMessageCount(), Integer.valueOf(0), "pendingMessageCount should be 0 after evacuation");
-
+    // After evacuation, lastActivityTimestamp may or may not be set depending on whether CurrentState ZNodes exist
+    // If the instance still has a session with CurrentState ZNodes (even if empty), timestamp should be present
     System.out.println("After evacuation - state: " + statusAfter.getState()
         + ", remainingPartitionCount: " + statusAfter.getRemainingPartitionCount()
-        + ", pendingMessageCount: " + statusAfter.getPendingMessageCount());
+        + ", pendingMessageCount: " + statusAfter.getPendingMessageCount()
+        + ", lastActivityTimestamp: " + statusAfter.getLastActivityTimestamp());
 
     // Cleanup
     _gSetupTool.getClusterManagementTool()

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
@@ -383,7 +383,7 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
   }
 
   /**
-   * Test getEvacuationStatus returns remainingCount and pendingMessageCount
+   * Test getEvacuationStatus returns remainingPartitionCount and pendingMessageCount
    */
   @Test
   public void testGetEvacuationStatusReturnsDetailedInfo() throws Exception {
@@ -398,11 +398,11 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
 
     String instanceToEvacuate = _participants[0].getInstanceName();
 
-    // Before setting EVACUATE, getEvacuationStatus should return successful=false
+    // Before setting EVACUATE, getEvacuationStatus should return NOT_EVACUATING state
     ZKHelixAdmin zkAdmin = (ZKHelixAdmin) _admin;
     EvacuationInfo statusBefore = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
-    Assert.assertFalse(statusBefore.isSuccessful(),
-        "Should return successful=false when instance is not in EVACUATE operation");
+    Assert.assertEquals(statusBefore.getState(), EvacuationInfo.EvacuationState.NOT_EVACUATING,
+        "Should return NOT_EVACUATING when instance is not in EVACUATE operation");
     Assert.assertEquals(statusBefore.getReason(),
         EvacuationInfo.ReasonCode.NOT_IN_EVACUATE_OPERATION.getMessage());
 
@@ -410,9 +410,10 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     _gSetupTool.getClusterManagementTool()
         .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
 
-    // Immediately check status - should have remainingCount > 0 (partitions still being evacuated)
+    // Immediately check status - should have remainingPartitionCount > 0 (partitions still being evacuated)
     EvacuationInfo statusDuring = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
-    System.out.println("During evacuation - remainingCount: " + statusDuring.getRemainingCount()
+    System.out.println("During evacuation - state: " + statusDuring.getState()
+        + ", remainingPartitionCount: " + statusDuring.getRemainingPartitionCount()
         + ", pendingMessageCount: " + statusDuring.getPendingMessageCount());
 
     // Wait for evacuation to complete
@@ -423,12 +424,13 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
 
     // After evacuation completes, verify final status
     EvacuationInfo statusAfter = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
-    Assert.assertTrue(statusAfter.isSuccessful(), "Should return successful=true after evacuation completes");
-    Assert.assertEquals(statusAfter.getRemainingCount(), 0, "remainingCount should be 0 after evacuation");
+    Assert.assertEquals(statusAfter.getState(), EvacuationInfo.EvacuationState.COMPLETED,
+        "Should return COMPLETED after evacuation completes");
+    Assert.assertEquals(statusAfter.getRemainingPartitionCount(), 0, "remainingPartitionCount should be 0 after evacuation");
     Assert.assertEquals(statusAfter.getPendingMessageCount(), 0, "pendingMessageCount should be 0 after evacuation");
 
-    System.out.println("After evacuation - successful: " + statusAfter.isSuccessful()
-        + ", remainingCount: " + statusAfter.getRemainingCount()
+    System.out.println("After evacuation - state: " + statusAfter.getState()
+        + ", remainingPartitionCount: " + statusAfter.getRemainingPartitionCount()
         + ", pendingMessageCount: " + statusAfter.getPendingMessageCount());
 
     // Cleanup
@@ -484,28 +486,30 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
 
     ZKHelixAdmin zkAdmin = (ZKHelixAdmin) _admin;
 
-    // Without exclusions - should NOT be finished (disabled CUSTOMIZED resource blocks)
+    // Without exclusions - should be IN_PROGRESS (disabled CUSTOMIZED resource blocks)
     EvacuationInfo statusNoExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
-    Assert.assertFalse(statusNoExclusions.isSuccessful(),
-        "Without exclusions, evacuation should be blocked by disabled resource");
-    int remainingWithoutExclusions = statusNoExclusions.getRemainingCount();
+    Assert.assertEquals(statusNoExclusions.getState(), EvacuationInfo.EvacuationState.IN_PROGRESS,
+        "Without exclusions, evacuation should be IN_PROGRESS (blocked by disabled resource)");
+    int remainingWithoutExclusions = statusNoExclusions.getRemainingPartitionCount();
     Assert.assertTrue(remainingWithoutExclusions > 0, "Should have remaining partitions without exclusions");
-    System.out.println("Without exclusions - remainingCount: " + remainingWithoutExclusions);
+    System.out.println("Without exclusions - state: " + statusNoExclusions.getState()
+        + ", remainingPartitionCount: " + remainingWithoutExclusions);
 
-    // With DISABLED_RESOURCE exclusion - SHOULD be finished
+    // With DISABLED_RESOURCE exclusion - SHOULD be COMPLETED
     Set<InstanceDrainExclusionType> exclusions = new HashSet<>();
     exclusions.add(InstanceDrainExclusionType.DISABLED_RESOURCE);
 
     EvacuationInfo statusWithExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, exclusions);
-    Assert.assertTrue(statusWithExclusions.isSuccessful(),
-        "With DISABLED_RESOURCE exclusion, evacuation should be finished");
-    int remainingWithExclusions = statusWithExclusions.getRemainingCount();
-    Assert.assertEquals(remainingWithExclusions, 0, "remainingCount should be 0 with exclusions");
-    System.out.println("With DISABLED_RESOURCE exclusion - remainingCount: " + remainingWithExclusions);
+    Assert.assertEquals(statusWithExclusions.getState(), EvacuationInfo.EvacuationState.COMPLETED,
+        "With DISABLED_RESOURCE exclusion, evacuation should be COMPLETED");
+    int remainingWithExclusions = statusWithExclusions.getRemainingPartitionCount();
+    Assert.assertEquals(remainingWithExclusions, 0, "remainingPartitionCount should be 0 with exclusions");
+    System.out.println("With DISABLED_RESOURCE exclusion - state: " + statusWithExclusions.getState()
+        + ", remainingPartitionCount: " + remainingWithExclusions);
 
-    // Verify that remainingCount differs based on exclusions
+    // Verify that remainingPartitionCount differs based on exclusions
     Assert.assertTrue(remainingWithoutExclusions > remainingWithExclusions,
-        "remainingCount should be higher without exclusions than with exclusions");
+        "remainingPartitionCount should be higher without exclusions than with exclusions");
 
     // Cleanup
     _gSetupTool.getClusterManagementTool()

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
@@ -35,6 +35,7 @@ import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.TaskTestBase;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.EvacuationInfo;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.testng.Assert;
@@ -399,21 +400,20 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
 
     // Before setting EVACUATE, getEvacuationStatus should return successful=false
     ZKHelixAdmin zkAdmin = (ZKHelixAdmin) _admin;
-    Map<String, Object> statusBefore = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
-    Assert.assertFalse((Boolean) statusBefore.get("successful"),
+    EvacuationInfo statusBefore = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
+    Assert.assertFalse(statusBefore.isSuccessful(),
         "Should return successful=false when instance is not in EVACUATE operation");
-    Assert.assertEquals(statusBefore.get("reason"), "Instance is not in EVACUATE operation");
+    Assert.assertEquals(statusBefore.getReason(),
+        EvacuationInfo.ReasonCode.NOT_IN_EVACUATE_OPERATION.getMessage());
 
     // Set instance to EVACUATE
     _gSetupTool.getClusterManagementTool()
         .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
 
     // Immediately check status - should have remainingCount > 0 (partitions still being evacuated)
-    Map<String, Object> statusDuring = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
-    Assert.assertNotNull(statusDuring.get("remainingCount"), "Should have remainingCount field");
-    Assert.assertNotNull(statusDuring.get("pendingMessageCount"), "Should have pendingMessageCount field");
-    System.out.println("During evacuation - remainingCount: " + statusDuring.get("remainingCount")
-        + ", pendingMessageCount: " + statusDuring.get("pendingMessageCount"));
+    EvacuationInfo statusDuring = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
+    System.out.println("During evacuation - remainingCount: " + statusDuring.getRemainingCount()
+        + ", pendingMessageCount: " + statusDuring.getPendingMessageCount());
 
     // Wait for evacuation to complete
     boolean evacuated = TestHelper.verify(
@@ -422,14 +422,14 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     Assert.assertTrue(evacuated, "Evacuation should complete");
 
     // After evacuation completes, verify final status
-    Map<String, Object> statusAfter = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
-    Assert.assertTrue((Boolean) statusAfter.get("successful"), "Should return successful=true after evacuation completes");
-    Assert.assertEquals(statusAfter.get("remainingCount"), 0, "remainingCount should be 0 after evacuation");
-    Assert.assertEquals(statusAfter.get("pendingMessageCount"), 0, "pendingMessageCount should be 0 after evacuation");
+    EvacuationInfo statusAfter = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
+    Assert.assertTrue(statusAfter.isSuccessful(), "Should return successful=true after evacuation completes");
+    Assert.assertEquals(statusAfter.getRemainingCount(), 0, "remainingCount should be 0 after evacuation");
+    Assert.assertEquals(statusAfter.getPendingMessageCount(), 0, "pendingMessageCount should be 0 after evacuation");
 
-    System.out.println("After evacuation - successful: " + statusAfter.get("successful")
-        + ", remainingCount: " + statusAfter.get("remainingCount")
-        + ", pendingMessageCount: " + statusAfter.get("pendingMessageCount"));
+    System.out.println("After evacuation - successful: " + statusAfter.isSuccessful()
+        + ", remainingCount: " + statusAfter.getRemainingCount()
+        + ", pendingMessageCount: " + statusAfter.getPendingMessageCount());
 
     // Cleanup
     _gSetupTool.getClusterManagementTool()
@@ -485,10 +485,10 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     ZKHelixAdmin zkAdmin = (ZKHelixAdmin) _admin;
 
     // Without exclusions - should NOT be finished (disabled CUSTOMIZED resource blocks)
-    Map<String, Object> statusNoExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
-    Assert.assertFalse((Boolean) statusNoExclusions.get("successful"),
+    EvacuationInfo statusNoExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
+    Assert.assertFalse(statusNoExclusions.isSuccessful(),
         "Without exclusions, evacuation should be blocked by disabled resource");
-    int remainingWithoutExclusions = (Integer) statusNoExclusions.get("remainingCount");
+    int remainingWithoutExclusions = statusNoExclusions.getRemainingCount();
     Assert.assertTrue(remainingWithoutExclusions > 0, "Should have remaining partitions without exclusions");
     System.out.println("Without exclusions - remainingCount: " + remainingWithoutExclusions);
 
@@ -496,10 +496,10 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     Set<InstanceDrainExclusionType> exclusions = new HashSet<>();
     exclusions.add(InstanceDrainExclusionType.DISABLED_RESOURCE);
 
-    Map<String, Object> statusWithExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, exclusions);
-    Assert.assertTrue((Boolean) statusWithExclusions.get("successful"),
+    EvacuationInfo statusWithExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, exclusions);
+    Assert.assertTrue(statusWithExclusions.isSuccessful(),
         "With DISABLED_RESOURCE exclusion, evacuation should be finished");
-    int remainingWithExclusions = (Integer) statusWithExclusions.get("remainingCount");
+    int remainingWithExclusions = statusWithExclusions.getRemainingCount();
     Assert.assertEquals(remainingWithExclusions, 0, "remainingCount should be 0 with exclusions");
     System.out.println("With DISABLED_RESOURCE exclusion - remainingCount: " + remainingWithExclusions);
 

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
@@ -382,6 +382,140 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
   }
 
   /**
+   * Test getEvacuationStatus returns remainingCount and pendingMessageCount
+   */
+  @Test
+  public void testGetEvacuationStatusReturnsDetailedInfo() throws Exception {
+    System.out.println("START testGetEvacuationStatusReturnsDetailedInfo at " + new Date(System.currentTimeMillis()));
+
+    String db = "TestDB_EvacuationStatus";
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, db, _numPartitions,
+        BuiltInStateModelDefinitions.MasterSlave.name(), IdealState.RebalanceMode.FULL_AUTO.name());
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, db, _numReplicas);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    String instanceToEvacuate = _participants[0].getInstanceName();
+
+    // Before setting EVACUATE, getEvacuationStatus should return successful=false
+    ZKHelixAdmin zkAdmin = (ZKHelixAdmin) _admin;
+    Map<String, Object> statusBefore = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
+    Assert.assertFalse((Boolean) statusBefore.get("successful"),
+        "Should return successful=false when instance is not in EVACUATE operation");
+    Assert.assertEquals(statusBefore.get("reason"), "Instance is not in EVACUATE operation");
+
+    // Set instance to EVACUATE
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+
+    // Immediately check status - should have remainingCount > 0 (partitions still being evacuated)
+    Map<String, Object> statusDuring = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
+    Assert.assertNotNull(statusDuring.get("remainingCount"), "Should have remainingCount field");
+    Assert.assertNotNull(statusDuring.get("pendingMessageCount"), "Should have pendingMessageCount field");
+    System.out.println("During evacuation - remainingCount: " + statusDuring.get("remainingCount")
+        + ", pendingMessageCount: " + statusDuring.get("pendingMessageCount"));
+
+    // Wait for evacuation to complete
+    boolean evacuated = TestHelper.verify(
+        () -> _admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate),
+        TestHelper.WAIT_DURATION);
+    Assert.assertTrue(evacuated, "Evacuation should complete");
+
+    // After evacuation completes, verify final status
+    Map<String, Object> statusAfter = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
+    Assert.assertTrue((Boolean) statusAfter.get("successful"), "Should return successful=true after evacuation completes");
+    Assert.assertEquals(statusAfter.get("remainingCount"), 0, "remainingCount should be 0 after evacuation");
+    Assert.assertEquals(statusAfter.get("pendingMessageCount"), 0, "pendingMessageCount should be 0 after evacuation");
+
+    System.out.println("After evacuation - successful: " + statusAfter.get("successful")
+        + ", remainingCount: " + statusAfter.get("remainingCount")
+        + ", pendingMessageCount: " + statusAfter.get("pendingMessageCount"));
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, db);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  /**
+   * Test getEvacuationStatus with exclusions
+   */
+  @Test
+  public void testGetEvacuationStatusWithExclusions() throws Exception {
+    System.out.println("START testGetEvacuationStatusWithExclusions at " + new Date(System.currentTimeMillis()));
+
+    String enabledDB = "TestDB_Status_Enabled";
+    String disabledDB = "TestDB_Status_Disabled";
+
+    // Create enabled FULL_AUTO resource
+    _gSetupTool.addResourceToCluster(CLUSTER_NAME, enabledDB, _numPartitions,
+        BuiltInStateModelDefinitions.MasterSlave.name(), IdealState.RebalanceMode.FULL_AUTO.name());
+    _gSetupTool.rebalanceStorageCluster(CLUSTER_NAME, enabledDB, _numReplicas);
+
+    // Create CUSTOMIZED resource that will be disabled
+    IdealState customizedIS = new IdealState(disabledDB);
+    customizedIS.setStateModelDefRef(BuiltInStateModelDefinitions.MasterSlave.name());
+    customizedIS.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+    customizedIS.setReplicas(String.valueOf(_numReplicas));
+    customizedIS.setNumPartitions(2);
+
+    String instanceToEvacuate = _participants[0].getInstanceName();
+    String otherInstance = _participants[1].getInstanceName();
+
+    customizedIS.setPartitionState(disabledDB + "_0", instanceToEvacuate, "MASTER");
+    customizedIS.setPartitionState(disabledDB + "_0", otherInstance, "SLAVE");
+    customizedIS.setPartitionState(disabledDB + "_1", instanceToEvacuate, "SLAVE");
+    customizedIS.setPartitionState(disabledDB + "_1", otherInstance, "MASTER");
+
+    _gSetupTool.getClusterManagementTool().addResource(CLUSTER_NAME, disabledDB, customizedIS);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Disable the CUSTOMIZED resource
+    _gSetupTool.getClusterManagementTool().enableResource(CLUSTER_NAME, disabledDB, false);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // Set instance to EVACUATE
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.EVACUATE);
+
+    // Wait for enabled resource to evacuate
+    Thread.sleep(5000);
+
+    ZKHelixAdmin zkAdmin = (ZKHelixAdmin) _admin;
+
+    // Without exclusions - should NOT be finished (disabled CUSTOMIZED resource blocks)
+    Map<String, Object> statusNoExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
+    Assert.assertFalse((Boolean) statusNoExclusions.get("successful"),
+        "Without exclusions, evacuation should be blocked by disabled resource");
+    int remainingWithoutExclusions = (Integer) statusNoExclusions.get("remainingCount");
+    Assert.assertTrue(remainingWithoutExclusions > 0, "Should have remaining partitions without exclusions");
+    System.out.println("Without exclusions - remainingCount: " + remainingWithoutExclusions);
+
+    // With DISABLED_RESOURCE exclusion - SHOULD be finished
+    Set<InstanceDrainExclusionType> exclusions = new HashSet<>();
+    exclusions.add(InstanceDrainExclusionType.DISABLED_RESOURCE);
+
+    Map<String, Object> statusWithExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, exclusions);
+    Assert.assertTrue((Boolean) statusWithExclusions.get("successful"),
+        "With DISABLED_RESOURCE exclusion, evacuation should be finished");
+    int remainingWithExclusions = (Integer) statusWithExclusions.get("remainingCount");
+    Assert.assertEquals(remainingWithExclusions, 0, "remainingCount should be 0 with exclusions");
+    System.out.println("With DISABLED_RESOURCE exclusion - remainingCount: " + remainingWithExclusions);
+
+    // Verify that remainingCount differs based on exclusions
+    Assert.assertTrue(remainingWithoutExclusions > remainingWithExclusions,
+        "remainingCount should be higher without exclusions than with exclusions");
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate, InstanceConstants.InstanceOperation.ENABLE);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, enabledDB);
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, disabledDB);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  /**
    * Test combined exclusions
    */
   @Test

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
@@ -405,6 +405,11 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
         "Should return NOT_EVACUATING when instance is not in EVACUATE operation");
     Assert.assertEquals(statusBefore.getReason(),
         EvacuationInfo.ReasonCode.NOT_IN_EVACUATE_OPERATION.getMessage());
+    // When NOT_EVACUATING, counts should be null (won't be serialized in JSON)
+    Assert.assertNull(statusBefore.getRemainingPartitionCount(),
+        "remainingPartitionCount should be null when not evacuating");
+    Assert.assertNull(statusBefore.getPendingMessageCount(),
+        "pendingMessageCount should be null when not evacuating");
 
     // Set instance to EVACUATE
     _gSetupTool.getClusterManagementTool()
@@ -426,8 +431,8 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     EvacuationInfo statusAfter = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
     Assert.assertEquals(statusAfter.getState(), EvacuationInfo.EvacuationState.COMPLETED,
         "Should return COMPLETED after evacuation completes");
-    Assert.assertEquals(statusAfter.getRemainingPartitionCount(), 0, "remainingPartitionCount should be 0 after evacuation");
-    Assert.assertEquals(statusAfter.getPendingMessageCount(), 0, "pendingMessageCount should be 0 after evacuation");
+    Assert.assertEquals(statusAfter.getRemainingPartitionCount(), Integer.valueOf(0), "remainingPartitionCount should be 0 after evacuation");
+    Assert.assertEquals(statusAfter.getPendingMessageCount(), Integer.valueOf(0), "pendingMessageCount should be 0 after evacuation");
 
     System.out.println("After evacuation - state: " + statusAfter.getState()
         + ", remainingPartitionCount: " + statusAfter.getRemainingPartitionCount()
@@ -490,7 +495,7 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     EvacuationInfo statusNoExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet());
     Assert.assertEquals(statusNoExclusions.getState(), EvacuationInfo.EvacuationState.IN_PROGRESS,
         "Without exclusions, evacuation should be IN_PROGRESS (blocked by disabled resource)");
-    int remainingWithoutExclusions = statusNoExclusions.getRemainingPartitionCount();
+    Integer remainingWithoutExclusions = statusNoExclusions.getRemainingPartitionCount();
     Assert.assertTrue(remainingWithoutExclusions > 0, "Should have remaining partitions without exclusions");
     System.out.println("Without exclusions - state: " + statusNoExclusions.getState()
         + ", remainingPartitionCount: " + remainingWithoutExclusions);
@@ -502,8 +507,8 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     EvacuationInfo statusWithExclusions = zkAdmin.getEvacuationStatus(CLUSTER_NAME, instanceToEvacuate, exclusions);
     Assert.assertEquals(statusWithExclusions.getState(), EvacuationInfo.EvacuationState.COMPLETED,
         "With DISABLED_RESOURCE exclusion, evacuation should be COMPLETED");
-    int remainingWithExclusions = statusWithExclusions.getRemainingPartitionCount();
-    Assert.assertEquals(remainingWithExclusions, 0, "remainingPartitionCount should be 0 with exclusions");
+    Integer remainingWithExclusions = statusWithExclusions.getRemainingPartitionCount();
+    Assert.assertEquals(remainingWithExclusions, Integer.valueOf(0), "remainingPartitionCount should be 0 with exclusions");
     System.out.println("With DISABLED_RESOURCE exclusion - state: " + statusWithExclusions.getState()
         + ", remainingPartitionCount: " + remainingWithExclusions);
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -516,7 +516,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
             } else {
               // Fallback for non-ZK HelixAdmin implementations (should not happen in Helix REST runtime).
               boolean finished = admin.isEvacuateFinished(clusterId, instanceName, exclusionTypes);
-              evacuationStatus = ImmutableMap.of("successful", finished, "isFinished", finished);
+              evacuationStatus = ImmutableMap.of("successful", finished);
             }
           } catch (IllegalArgumentException e) {
             LOG.error(String.format("Invalid exclusion type for cluster: {}, instance: {}, exclusions: {}",

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -517,7 +517,10 @@ public class PerInstanceAccessor extends AbstractHelixResource {
             } else {
               // Fallback for non-ZK HelixAdmin implementations (should not happen in Helix REST runtime).
               boolean finished = admin.isEvacuateFinished(clusterId, instanceName, exclusionTypes);
-              evacuationInfo = new EvacuationInfo(finished, 0, 0, null);
+              EvacuationInfo.EvacuationState state = finished
+                  ? EvacuationInfo.EvacuationState.COMPLETED
+                  : EvacuationInfo.EvacuationState.IN_PROGRESS;
+              evacuationInfo = new EvacuationInfo(state, 0, 0, null);
             }
           } catch (IllegalArgumentException e) {
             LOG.error(String.format("Invalid exclusion type for cluster: {}, instance: {}, exclusions: {}",

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -56,6 +56,7 @@ import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.Error;
+import org.apache.helix.model.EvacuationInfo;
 import org.apache.helix.model.HealthStat;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.InstanceConfig;
@@ -504,19 +505,19 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                       .constructCollectionType(List.class, String.class)));
           break;
         case isEvacuateFinished:
-          Map<String, Object> evacuationStatus;
+          EvacuationInfo evacuationInfo;
           try {
             Set<InstanceDrainExclusionType> exclusionTypes = Collections.emptySet();
             if (exclusions != null && !exclusions.trim().isEmpty()) {
               exclusionTypes = InstanceDrainExclusionType.parseExclusionTypes(exclusions);
             }
             if (admin instanceof ZKHelixAdmin) {
-              evacuationStatus =
+              evacuationInfo =
                   ((ZKHelixAdmin) admin).getEvacuationStatus(clusterId, instanceName, exclusionTypes);
             } else {
               // Fallback for non-ZK HelixAdmin implementations (should not happen in Helix REST runtime).
               boolean finished = admin.isEvacuateFinished(clusterId, instanceName, exclusionTypes);
-              evacuationStatus = ImmutableMap.of("successful", finished);
+              evacuationInfo = new EvacuationInfo(finished, 0, 0, null);
             }
           } catch (IllegalArgumentException e) {
             LOG.error(String.format("Invalid exclusion type for cluster: {}, instance: {}, exclusions: {}",
@@ -527,7 +528,7 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                 + "{}, instance: {}", clusterId, instanceName), e);
             return serverError(e);
           }
-          return OK(OBJECT_MAPPER.writeValueAsString(evacuationStatus));
+          return OK(OBJECT_MAPPER.writeValueAsString(evacuationInfo));
         case isInstanceDrained:
           boolean instanceDrained;
           try {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -51,6 +51,7 @@ import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
 import org.apache.helix.constants.InstanceDrainExclusionType;
 import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.CurrentState;
@@ -503,25 +504,30 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                       .constructCollectionType(List.class, String.class)));
           break;
         case isEvacuateFinished:
-          boolean evacuateFinished;
+          Map<String, Object> evacuationStatus;
           try {
+            Set<InstanceDrainExclusionType> exclusionTypes = Collections.emptySet();
             if (exclusions != null && !exclusions.trim().isEmpty()) {
-              Set<InstanceDrainExclusionType> exclusionTypes =
-                  InstanceDrainExclusionType.parseExclusionTypes(exclusions);
-              evacuateFinished = admin.isEvacuateFinished(clusterId, instanceName, exclusionTypes);
+              exclusionTypes = InstanceDrainExclusionType.parseExclusionTypes(exclusions);
+            }
+            if (admin instanceof ZKHelixAdmin) {
+              evacuationStatus =
+                  ((ZKHelixAdmin) admin).getEvacuationStatus(clusterId, instanceName, exclusionTypes);
             } else {
-              evacuateFinished = admin.isEvacuateFinished(clusterId, instanceName);
+              // Fallback for non-ZK HelixAdmin implementations (should not happen in Helix REST runtime).
+              boolean finished = admin.isEvacuateFinished(clusterId, instanceName, exclusionTypes);
+              evacuationStatus = ImmutableMap.of("successful", finished, "isFinished", finished);
             }
           } catch (IllegalArgumentException e) {
             LOG.error(String.format("Invalid exclusion type for cluster: {}, instance: {}, exclusions: {}",
                 clusterId, instanceName, exclusions), e);
             return badRequest("Invalid exclusion type: " + exclusions);
           } catch (HelixException e) {
-            LOG.error(String.format("Encountered error when checking if evacuation finished for cluster: "
+            LOG.error(String.format("Encountered error when checking evacuation status for cluster: "
                 + "{}, instance: {}", clusterId, instanceName), e);
             return serverError(e);
           }
-          return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of("successful", evacuateFinished)));
+          return OK(OBJECT_MAPPER.writeValueAsString(evacuationStatus));
         case isInstanceDrained:
           boolean instanceDrained;
           try {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -523,12 +523,12 @@ public class PerInstanceAccessor extends AbstractHelixResource {
               evacuationInfo = new EvacuationInfo(state, 0, 0, null);
             }
           } catch (IllegalArgumentException e) {
-            LOG.error(String.format("Invalid exclusion type for cluster: {}, instance: {}, exclusions: {}",
-                clusterId, instanceName, exclusions), e);
+            LOG.error("Invalid exclusion type for cluster: {}, instance: {}, exclusions: {}",
+                clusterId, instanceName, exclusions, e);
             return badRequest("Invalid exclusion type: " + exclusions);
           } catch (HelixException e) {
-            LOG.error(String.format("Encountered error when checking evacuation status for cluster: "
-                + "{}, instance: {}", clusterId, instanceName), e);
+            LOG.error("Encountered error when checking evacuation status for cluster: {}, instance: {}",
+                clusterId, instanceName, e);
             return serverError(e);
           }
           return OK(OBJECT_MAPPER.writeValueAsString(evacuationInfo));

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestCanSwapCompleteAPI.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestCanSwapCompleteAPI.java
@@ -303,8 +303,8 @@ public class TestCanSwapCompleteAPI extends AbstractTestClass {
         .format(CLUSTER_NAME, instanceName).post(this, empty);
     Assert.assertEquals(evac.getStatus(), Response.Status.OK.getStatusCode());
 
-    Map<String, Boolean> evacMap = (Map<String, Boolean>) OBJECT_MAPPER.readValue(evac.readEntity(String.class), Map.class);
-    Assert.assertTrue(evacMap.get("successful"), "Evacuation should have finished successfully");
+    Map<String, Object> evacMap = (Map<String, Object>) OBJECT_MAPPER.readValue(evac.readEntity(String.class), Map.class);
+    Assert.assertEquals(evacMap.get("state"), "COMPLETED", "Evacuation should have finished successfully");
   }
 
   /**

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -741,22 +741,22 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     Map<String, Object> evacuateFinishedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-    // Returns true because the node only contains semi-auto resources
-    Assert.assertTrue((Boolean) evacuateFinishedResult.get("successful"));
+    // Returns COMPLETED because the node only contains semi-auto resources
+    Assert.assertEquals(evacuateFinishedResult.get("state"), "COMPLETED");
     // Verify new fields are present in the response
-    Assert.assertTrue(evacuateFinishedResult.containsKey("remainingCount"),
-        "Response should contain remainingCount field");
+    Assert.assertTrue(evacuateFinishedResult.containsKey("remainingPartitionCount"),
+        "Response should contain remainingPartitionCount field");
     Assert.assertTrue(evacuateFinishedResult.containsKey("pendingMessageCount"),
         "Response should contain pendingMessageCount field");
-    Assert.assertEquals(evacuateFinishedResult.get("remainingCount"), 0,
-        "remainingCount should be 0 for successful evacuation");
+    Assert.assertEquals(evacuateFinishedResult.get("remainingPartitionCount"), 0,
+        "remainingPartitionCount should be 0 for completed evacuation");
 
-    // Because the resources are now all semi-auto, is EvacuateFinished should return true
+    // Because the resources are now all semi-auto, is EvacuateFinished should return COMPLETED
     response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=isEvacuateFinished")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     evacuateFinishedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-    Assert.assertTrue((Boolean) evacuateFinishedResult.get("successful"));
+    Assert.assertEquals(evacuateFinishedResult.get("state"), "COMPLETED");
 
     response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=isInstanceDrained")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
@@ -783,10 +783,10 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         .format(CLUSTER_NAME, test_instance_name).post(this, entity);
     evacuateFinishedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-    Assert.assertTrue((Boolean) evacuateFinishedResult.get("successful"));
+    Assert.assertEquals(evacuateFinishedResult.get("state"), "COMPLETED");
     // Verify new fields for instance with no currentState
-    Assert.assertEquals(evacuateFinishedResult.get("remainingCount"), 0,
-        "remainingCount should be 0 for instance with no currentState");
+    Assert.assertEquals(evacuateFinishedResult.get("remainingPartitionCount"), 0,
+        "remainingPartitionCount should be 0 for instance with no currentState");
 
     // Remove instance created for evacuate test
     delete("clusters/" + CLUSTER_NAME + "/instances/" + test_instance_name, Response.Status.OK.getStatusCode());

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -739,17 +739,24 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
 
     Response response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=isEvacuateFinished")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
-    Map<String, Boolean> evacuateFinishedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
+    Map<String, Object> evacuateFinishedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     // Returns true because the node only contains semi-auto resources
-    Assert.assertTrue(evacuateFinishedResult.get("successful"));
+    Assert.assertTrue((Boolean) evacuateFinishedResult.get("successful"));
+    // Verify new fields are present in the response
+    Assert.assertTrue(evacuateFinishedResult.containsKey("remainingCount"),
+        "Response should contain remainingCount field");
+    Assert.assertTrue(evacuateFinishedResult.containsKey("pendingMessageCount"),
+        "Response should contain pendingMessageCount field");
+    Assert.assertEquals(evacuateFinishedResult.get("remainingCount"), 0,
+        "remainingCount should be 0 for successful evacuation");
 
     // Because the resources are now all semi-auto, is EvacuateFinished should return true
     response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=isEvacuateFinished")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
     evacuateFinishedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-    Assert.assertTrue(evacuateFinishedResult.get("successful"));
+    Assert.assertTrue((Boolean) evacuateFinishedResult.get("successful"));
 
     response = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=isInstanceDrained")
         .format(CLUSTER_NAME, INSTANCE_NAME).post(this, entity);
@@ -776,7 +783,10 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
         .format(CLUSTER_NAME, test_instance_name).post(this, entity);
     evacuateFinishedResult = OBJECT_MAPPER.readValue(response.readEntity(String.class), Map.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-    Assert.assertTrue(evacuateFinishedResult.get("successful"));
+    Assert.assertTrue((Boolean) evacuateFinishedResult.get("successful"));
+    // Verify new fields for instance with no currentState
+    Assert.assertEquals(evacuateFinishedResult.get("remainingCount"), 0,
+        "remainingCount should be 0 for instance with no currentState");
 
     // Remove instance created for evacuate test
     delete("clusters/" + CLUSTER_NAME + "/instances/" + test_instance_name, Response.Status.OK.getStatusCode());


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Return remaining paritition count during isEvacuateFinished

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description
Currently isEvacuateFinished API just returns a boolean response, users have no visibility into why the evacuation is blocked. This PR adds a remainingPartitionCounter, which returns the client remaining count and failure reason as well.


- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

Before:
```
{
  "successful": true
}

```
New respons e structure examples:
1. IN_PROGRESS
```
{
  "successful": true,
  "state": "COMPLETED",
  "remainingPartitionCount": 0,
  "pendingMessageCount": 0,
  "lastActivityTimestamp": 1736812345678
}
```
2. NOT_EVACUATING
```
{
  "successful": false,
  "state": "NOT_EVACUATING",
  "reason": "Instance is not in EVACUATE operation"
}
```

New tests added.

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
