### PR TITLE
Enable SSL for leader forwarded requests

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/common/HttpConstants.java
@@ -28,6 +28,7 @@ public class HttpConstants {
   }
 
   public static final String HTTP_PROTOCOL_PREFIX = "http://";
+  public static final String HTTPS_PROTOCOL_PREFIX = "https://";
   public static final int DEFAULT_HTTP_REQUEST_TIMEOUT = 60 * 1000;
 
   /** REST request categorized as read. Can be used to categorize metric names */

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/ZkMetadataStoreDirectory.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.net.ssl.SSLContext;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.helix.msdcommon.callback.RoutingDataListener;
@@ -79,7 +80,23 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
 
   public static ZkMetadataStoreDirectory getInstance(String namespace, String zkAddress)
       throws InvalidRoutingDataException {
-    getInstance().init(namespace, zkAddress);
+    getInstance().init(namespace, zkAddress, null);
+    return _zkMetadataStoreDirectoryInstance;
+  }
+
+  /**
+   * Gets the singleton instance and initializes it with the given namespace, ZK address, and SSL context.
+   * When sslContext is provided, HTTPS will be used for forwarding requests to the leader.
+   *
+   * @param namespace the namespace
+   * @param zkAddress the ZooKeeper address
+   * @param sslContext the SSL context for HTTPS communication, or null for HTTP
+   * @return the singleton instance
+   * @throws InvalidRoutingDataException if routing data is invalid
+   */
+  public static ZkMetadataStoreDirectory getInstance(String namespace, String zkAddress,
+      SSLContext sslContext) throws InvalidRoutingDataException {
+    getInstance().init(namespace, zkAddress, sslContext);
     return _zkMetadataStoreDirectoryInstance;
   }
 
@@ -95,7 +112,8 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
     _routingDataMap = new ConcurrentHashMap<>();
   }
 
-  private void init(String namespace, String zkAddress) throws InvalidRoutingDataException {
+  private void init(String namespace, String zkAddress, SSLContext sslContext)
+      throws InvalidRoutingDataException {
     if (!_routingZkAddressMap.containsKey(namespace)) {
       synchronized (_routingZkAddressMap) {
         if (!_routingZkAddressMap.containsKey(namespace)) {
@@ -115,7 +133,8 @@ public class ZkMetadataStoreDirectory implements MetadataStoreDirectory, Routing
             _routingZkAddressMap.put(namespace, zkAddress);
             _routingDataReaderMap
                 .put(namespace, new ZkRoutingDataReader(namespace, zkAddress, this));
-            _routingDataWriterMap.put(namespace, new ZkRoutingDataWriter(namespace, zkAddress));
+            _routingDataWriterMap.put(namespace,
+                new ZkRoutingDataWriter(namespace, zkAddress, sslContext));
           } catch (IllegalArgumentException | IllegalStateException e) {
             LOG.error("ZkMetadataStoreDirectory: initializing ZkRoutingDataReader/Writer failed!",
                 e);

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -167,7 +167,7 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
   public static String buildEndpointFromLeaderElectionNode(ZNRecord znRecord) {
     // Read protocol from ZNRecord, default to HTTP for backward compatibility
     String protocol = znRecord.getSimpleField(SIMPLE_FIELD_KEY_PROTOCOL);
-    if (protocol == null || protocol.isEmpty()) {
+    if (!HttpConstants.HTTPS_PROTOCOL_PREFIX.equals(protocol)) {
       protocol = HttpConstants.HTTP_PROTOCOL_PREFIX;
     }
     List<String> urlComponents = new ArrayList<>(Collections.singletonList(protocol));

--- a/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/metadatastore/accessor/ZkRoutingDataWriter.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
@@ -62,14 +63,36 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
   private static final String SIMPLE_FIELD_KEY_HOSTNAME = "hostname";
   private static final String SIMPLE_FIELD_KEY_PORT = "port";
   private static final String SIMPLE_FIELD_KEY_CONTEXT_URL_PREFIX = "contextUrlPrefix";
+  private static final String SIMPLE_FIELD_KEY_PROTOCOL = "protocol";
 
   private final String _namespace;
   private final HelixZkClient _zkClient;
   private final ZkDistributedLeaderElection _leaderElection;
   private final CloseableHttpClient _forwardHttpClient;
   private final String _myHostName;
+  private final String _protocolPrefix;
 
+  /**
+   * Creates a ZkRoutingDataWriter with HTTP protocol (no SSL).
+   * This constructor is kept for backward compatibility.
+   *
+   * @param namespace the namespace
+   * @param zkAddress the ZooKeeper address
+   */
   public ZkRoutingDataWriter(String namespace, String zkAddress) {
+    this(namespace, zkAddress, null);
+  }
+
+  /**
+   * Creates a ZkRoutingDataWriter with optional SSL support.
+   * When sslContext is provided, HTTPS will be used for forwarding requests to the leader.
+   * When sslContext is null, HTTP will be used (backward compatible behavior).
+   *
+   * @param namespace the namespace
+   * @param zkAddress the ZooKeeper address
+   * @param sslContext the SSL context for HTTPS communication, or null for HTTP
+   */
+  public ZkRoutingDataWriter(String namespace, String zkAddress, SSLContext sslContext) {
     if (namespace == null || namespace.isEmpty()) {
       throw new IllegalArgumentException("namespace cannot be null or empty!");
     }
@@ -92,10 +115,19 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
       LOG.error(errMsg);
       throw new IllegalStateException(errMsg);
     }
-    _myHostName = HttpConstants.HTTP_PROTOCOL_PREFIX + hostName;
+
+    // Determine protocol based on whether SSL context is provided
+    if (sslContext != null) {
+      _protocolPrefix = HttpConstants.HTTPS_PROTOCOL_PREFIX;
+    } else {
+      _protocolPrefix = HttpConstants.HTTP_PROTOCOL_PREFIX;
+    }
+    _myHostName = _protocolPrefix + hostName;
 
     ZNRecord myServerInfo = new ZNRecord(hostName);
     myServerInfo.setSimpleField(SIMPLE_FIELD_KEY_HOSTNAME, hostName);
+    // Store the protocol so other servers know how to reach this server
+    myServerInfo.setSimpleField(SIMPLE_FIELD_KEY_PROTOCOL, _protocolPrefix);
 
     String port = System.getProperty(MetadataStoreRoutingConstants.MSDS_SERVER_PORT_KEY);
     if (port != null && !port.isEmpty()) {
@@ -114,15 +146,31 @@ public class ZkRoutingDataWriter implements MetadataStoreRoutingDataWriter {
     _leaderElection = new ZkDistributedLeaderElection(_zkClient,
         MetadataStoreRoutingConstants.LEADER_ELECTION_ZNODE, myServerInfo);
 
+    // Build HTTP client with or without SSL
     RequestConfig config = RequestConfig.custom().setConnectTimeout(HTTP_REQUEST_FORWARDING_TIMEOUT)
         .setConnectionRequestTimeout(HTTP_REQUEST_FORWARDING_TIMEOUT)
         .setSocketTimeout(HTTP_REQUEST_FORWARDING_TIMEOUT).build();
-    _forwardHttpClient = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+    if (sslContext != null) {
+      _forwardHttpClient = HttpClientBuilder.create()
+          .setDefaultRequestConfig(config)
+          .setSSLContext(sslContext)
+          .build();
+      LOG.info("ZkRoutingDataWriter initialized with SSL enabled for namespace: {}", namespace);
+    } else {
+      _forwardHttpClient = HttpClientBuilder.create()
+          .setDefaultRequestConfig(config)
+          .build();
+      LOG.info("ZkRoutingDataWriter initialized with HTTP (no SSL) for namespace: {}", namespace);
+    }
   }
 
   public static String buildEndpointFromLeaderElectionNode(ZNRecord znRecord) {
-    List<String> urlComponents =
-        new ArrayList<>(Collections.singletonList(HttpConstants.HTTP_PROTOCOL_PREFIX));
+    // Read protocol from ZNRecord, default to HTTP for backward compatibility
+    String protocol = znRecord.getSimpleField(SIMPLE_FIELD_KEY_PROTOCOL);
+    if (protocol == null || protocol.isEmpty()) {
+      protocol = HttpConstants.HTTP_PROTOCOL_PREFIX;
+    }
+    List<String> urlComponents = new ArrayList<>(Collections.singletonList(protocol));
     urlComponents.add(znRecord.getSimpleField(SIMPLE_FIELD_KEY_HOSTNAME));
     String port = znRecord.getSimpleField(SIMPLE_FIELD_KEY_PORT);
     if (port != null && !port.isEmpty()) {

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
@@ -53,6 +53,7 @@ import org.apache.helix.rest.common.HelixRestUtils;
 import org.apache.helix.rest.common.HttpConstants;
 import org.apache.helix.rest.metadatastore.MetadataStoreDirectory;
 import org.apache.helix.rest.metadatastore.ZkMetadataStoreDirectory;
+import org.apache.helix.rest.server.HelixRestServer;
 import org.apache.helix.rest.metadatastore.datamodel.MetadataStoreShardingKey;
 import org.apache.helix.rest.metadatastore.datamodel.MetadataStoreShardingKeysByRealm;
 import org.apache.helix.rest.server.filters.NamespaceAuth;
@@ -369,7 +370,10 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
 
   protected void buildMetadataStoreDirectory(String namespace, String address) {
     try {
-      _metadataStoreDirectory = ZkMetadataStoreDirectory.getInstance(namespace, address);
+      // Use the SSL context registered with HelixRestServer for secure internal communication
+      // When SSL context is set, HTTPS will be used for forwarding requests to the leader
+      _metadataStoreDirectory = ZkMetadataStoreDirectory.getInstance(namespace, address,
+          HelixRestServer.REST_SERVER_SSL_CONTEXT);
     } catch (InvalidRoutingDataException ex) {
       LOG.warn("Unable to create metadata store directory for namespace: {}, ZK address: {}",
           namespace, address, ex);

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/metadatastore/MetadataStoreDirectoryAccessor.java
@@ -372,6 +372,12 @@ public class MetadataStoreDirectoryAccessor extends AbstractResource {
     try {
       // Use the SSL context registered with HelixRestServer for secure internal communication
       // When SSL context is set, HTTPS will be used for forwarding requests to the leader
+      if (HelixRestServer.REST_SERVER_SSL_CONTEXT == null) {
+        LOG.warn(
+            "SSL context is not set on HelixRestServer; leader forwarding will use HTTP (not HTTPS). "
+                + "Ensure registerServerSSLContext() is called before buildMetadataStoreDirectory() "
+                + "if secure forwarding is required. Namespace: {}", namespace);
+      }
       _metadataStoreDirectory = ZkMetadataStoreDirectory.getInstance(namespace, address,
           HelixRestServer.REST_SERVER_SSL_CONTEXT);
     } catch (InvalidRoutingDataException ex) {

--- a/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/metadatastore/accessor/TestZkRoutingDataWriter.java
@@ -19,10 +19,12 @@ package org.apache.helix.rest.metadatastore.accessor;
  * under the License.
  */
 
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.TestHelper;
@@ -49,6 +51,10 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
 
     MockWriter(String namespace, String zkAddress) {
       super(namespace, zkAddress);
+    }
+
+    MockWriter(String namespace, String zkAddress, SSLContext sslContext) {
+      super(namespace, zkAddress, sslContext);
     }
 
     // This method does not call super() because the http call should not be actually made
@@ -217,5 +223,101 @@ public class TestZkRoutingDataWriter extends AbstractTestClass {
       return _gZkClientTestNS.getChildren(MetadataStoreRoutingConstants.ROUTING_DATA_PATH)
           .isEmpty();
     }, TestHelper.WAIT_DURATION), "Routing data path should be deleted after the tests.");
+  }
+
+  @Test(dependsOnMethods = "testSetRoutingDataNonLeader")
+  public void testBuildEndpointWithHttpProtocol() {
+    // Test that HTTP protocol is used when no protocol is stored (backward compatibility)
+    ZNRecord znRecord = new ZNRecord("test");
+    znRecord.setSimpleField("hostname", "localhost");
+    znRecord.setSimpleField("port", "8080");
+
+    String endpoint = ZkRoutingDataWriter.buildEndpointFromLeaderElectionNode(znRecord);
+    Assert.assertTrue(endpoint.startsWith(HttpConstants.HTTP_PROTOCOL_PREFIX),
+        "Should default to HTTP protocol when protocol field is not set");
+    Assert.assertEquals(endpoint, "http://localhost:8080");
+  }
+
+  @Test(dependsOnMethods = "testBuildEndpointWithHttpProtocol")
+  public void testBuildEndpointWithHttpsProtocol() {
+    // Test that HTTPS protocol is used when stored in ZNRecord
+    ZNRecord znRecord = new ZNRecord("test");
+    znRecord.setSimpleField("hostname", "localhost");
+    znRecord.setSimpleField("port", "8443");
+    znRecord.setSimpleField("protocol", HttpConstants.HTTPS_PROTOCOL_PREFIX);
+
+    String endpoint = ZkRoutingDataWriter.buildEndpointFromLeaderElectionNode(znRecord);
+    Assert.assertTrue(endpoint.startsWith(HttpConstants.HTTPS_PROTOCOL_PREFIX),
+        "Should use HTTPS protocol when protocol field is set to https://");
+    Assert.assertEquals(endpoint, "https://localhost:8443");
+  }
+
+  @Test(dependsOnMethods = "testBuildEndpointWithHttpsProtocol")
+  public void testBuildEndpointWithContextUrlPrefix() {
+    // Test that context URL prefix is appended correctly with HTTPS
+    ZNRecord znRecord = new ZNRecord("test");
+    znRecord.setSimpleField("hostname", "localhost");
+    znRecord.setSimpleField("port", "8443");
+    znRecord.setSimpleField("protocol", HttpConstants.HTTPS_PROTOCOL_PREFIX);
+    znRecord.setSimpleField("contextUrlPrefix", "/admin/v2");
+
+    String endpoint = ZkRoutingDataWriter.buildEndpointFromLeaderElectionNode(znRecord);
+    Assert.assertEquals(endpoint, "https://localhost:8443/admin/v2");
+  }
+
+  @Test(dependsOnMethods = "testBuildEndpointWithContextUrlPrefix")
+  public void testSslWriterRegistersWithHttpsProtocol() throws NoSuchAlgorithmException {
+    // Test that when SSL is enabled, the server registers itself with HTTPS protocol
+    // This means other servers will use HTTPS to reach this server when it becomes leader
+    SSLContext sslContext = SSLContext.getDefault();
+
+    // Create a writer with SSL - this will register with HTTPS protocol in ZK
+    ZkRoutingDataWriter sslWriter = new ZkRoutingDataWriter(TEST_NAMESPACE, _zkAddrTestNS, sslContext);
+
+    // The SSL writer is not the leader (the one from beforeClass is), but we can verify
+    // that a ZNRecord with HTTPS protocol would build an HTTPS endpoint
+    ZNRecord httpsRecord = new ZNRecord("ssl-server");
+    httpsRecord.setSimpleField("hostname", "ssl-host.example.com");
+    httpsRecord.setSimpleField("port", "8443");
+    httpsRecord.setSimpleField("protocol", HttpConstants.HTTPS_PROTOCOL_PREFIX);
+
+    String endpoint = ZkRoutingDataWriter.buildEndpointFromLeaderElectionNode(httpsRecord);
+    Assert.assertTrue(endpoint.startsWith(HttpConstants.HTTPS_PROTOCOL_PREFIX),
+        "Endpoint should use HTTPS when protocol field is set. Actual: " + endpoint);
+    Assert.assertEquals(endpoint, "https://ssl-host.example.com:8443");
+
+    sslWriter.close();
+  }
+
+  @Test(dependsOnMethods = "testSslWriterRegistersWithHttpsProtocol")
+  public void testForwardingUsesLeaderProtocol() {
+    // Test that forwarding uses the leader's protocol from ZK, not the forwarder's
+    // The existing leader (_zkRoutingDataWriter from beforeClass) uses HTTP
+
+    MockWriter mockWriter = new MockWriter(TEST_NAMESPACE, _zkAddrTestNS, null);
+
+    mockWriter.addMetadataStoreRealm(DUMMY_REALM);
+    Assert.assertEquals(mockWriter.calledRequest.getMethod(), HttpConstants.RestVerbs.PUT.name());
+
+    // The URL should start with http:// because the leader registered with HTTP
+    String requestUrl = mockWriter.calledRequest.getURI().toString();
+    Assert.assertTrue(requestUrl.startsWith(HttpConstants.HTTP_PROTOCOL_PREFIX),
+        "Request URL should use leader's protocol (HTTP). Actual URL: " + requestUrl);
+
+    mockWriter.close();
+  }
+
+  @Test(dependsOnMethods = "testForwardingUsesLeaderProtocol")
+  public void testBackwardCompatibilityNoProtocolField() {
+    // Test backward compatibility: when protocol field is missing, default to HTTP
+    ZNRecord legacyRecord = new ZNRecord("legacy-server");
+    legacyRecord.setSimpleField("hostname", "legacy-host.example.com");
+    legacyRecord.setSimpleField("port", "8080");
+    // Note: no protocol field set (simulating old servers)
+
+    String endpoint = ZkRoutingDataWriter.buildEndpointFromLeaderElectionNode(legacyRecord);
+    Assert.assertTrue(endpoint.startsWith(HttpConstants.HTTP_PROTOCOL_PREFIX),
+        "Endpoint should default to HTTP when protocol field is missing. Actual: " + endpoint);
+    Assert.assertEquals(endpoint, "http://legacy-host.example.com:8080");
   }
 }

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -92,4 +92,8 @@ public class MetadataStoreRoutingConstants {
   // "localhost:9998"; with this value, the url will be "localhost:9998/admin/v2" if this
   // value is "/admin/v2".
   public static final String MSDS_CONTEXT_URL_PREFIX_KEY = "msds_context_url_prefix";
+
+  // SSL/TLS configuration for MSDS server-to-server communication (request forwarding)
+  // When set to "true", HTTPS will be used for forwarding requests to the leader
+  public static final String MSDS_SSL_ENABLED_KEY = "msds_ssl_enabled";
 }

--- a/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
+++ b/metadata-store-directory-common/src/main/java/org/apache/helix/msdcommon/constant/MetadataStoreRoutingConstants.java
@@ -92,8 +92,4 @@ public class MetadataStoreRoutingConstants {
   // "localhost:9998"; with this value, the url will be "localhost:9998/admin/v2" if this
   // value is "/admin/v2".
   public static final String MSDS_CONTEXT_URL_PREFIX_KEY = "msds_context_url_prefix";
-
-  // SSL/TLS configuration for MSDS server-to-server communication (request forwarding)
-  // When set to "true", HTTPS will be used for forwarding requests to the leader
-  public static final String MSDS_SSL_ENABLED_KEY = "msds_ssl_enabled";
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

This PR fixes an issue where MSDS (Metadata Store Directory Service) leader forwarding fails when SSL is enabled. Previously, the MSDS server always advertised the HTTP port (12954) for internal server-to-server communication, causing forwarding requests from followers to leaders to fail with "No cert found" errors when client certificate authentication is required.


### Description

Current Flow
`Client ──HTTPS+cert──► Server A ──HTTP (no cert)──► Server B (Leader)` // Failure at forwarded leader with "No cert found"

New Flow 
`Client ──HTTPS+cert──► Server A ──HTTPS+cert──► Server B (Leader)`

<img width="605" height="412" alt="533748904-7b7c913b-e1c6-4528-a73b-f56ced4ed1fe" src="https://github.com/user-attachments/assets/4db4c09b-82d6-43e8-945c-13201daa0e58" />



### Tests
Unit Tests added'
Verified msds curl on local ZK setup.
