### PR TITLE
Add participant message send performance test & bug fix

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/messaging/CriteriaEvaluator.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/CriteriaEvaluator.java
@@ -41,14 +41,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Evaluates {@link Criteria} against persisted Helix data to determine message recipients.
- * 
- * <p><b>PERFORMANCE WARNING:</b> When using {@link DataSource#EXTERNALVIEW}, this evaluator 
+ *
+ * <p><b>PERFORMANCE WARNING:</b> When using {@link DataSource#EXTERNALVIEW}, this evaluator
  * will scan <b>all</b> ExternalView znodes in the cluster if the resource name is unspecified or uses wildcards
  * (e.g., "%" or "*"). This scanning happens <b>even when targeting specific instances</b>, and is
  * NOT automatically optimized based on other criteria fields (like instanceName).
- * 
+ *
  * <p>At high ExternalView cardinality, this can cause severe performance degradation.
- * 
+ *
  * <p><b>Safer Patterns:</b>
  * <ul>
  *   <li><b>Use {@link DataSource#LIVEINSTANCES}:</b> When you only need to target live instances
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  *   <li><b>Specify exact resource names:</b> If ExternalView is required, provide specific resource
  *       names in {@link Criteria#setResource(String)} instead of wildcards to limit the scan scope.</li>
  * </ul>
- * 
+ *
  * <p><b>Example - Targeting a specific instance:</b>
  * <pre>
  * // BAD: Scans all ExternalViews even though instance is specified
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  * criteria.setInstanceName("instance123");
  * criteria.setDataSource(DataSource.EXTERNALVIEW);
  * criteria.setResource("%"); // wildcard triggers full scan
- * 
+ *
  * // GOOD: Uses LIVEINSTANCES, avoids ExternalView scan
  * Criteria criteria = new Criteria();
  * criteria.setInstanceName("instance123");
@@ -78,12 +78,12 @@ public class CriteriaEvaluator {
 
   /**
    * Examine persisted data to match wildcards in {@link Criteria}
-   * 
+   *
    * <p><b>PERFORMANCE WARNING:</b> Using {@link DataSource#EXTERNALVIEW} with wildcard resource
    * names (or unspecified resource) will scan ALL ExternalView znodes, even when targeting specific
-   * instances. At high cardinality, this can cause severe performance degradation. Prefer 
+   * instances. At high cardinality, this can cause severe performance degradation. Prefer
    * {@link DataSource#LIVEINSTANCES} when resource/partition filtering is not needed.
-   * 
+   *
    * @param recipientCriteria Criteria specifying the message destinations
    * @param manager connection to the persisted data
    * @return map of evaluated criteria
@@ -95,12 +95,12 @@ public class CriteriaEvaluator {
 
   /**
    * Examine persisted data to match wildcards in {@link Criteria}
-   * 
+   *
    * <p><b>PERFORMANCE WARNING:</b> Using {@link DataSource#EXTERNALVIEW} with wildcard resource
    * names (or unspecified resource) will scan ALL ExternalView znodes, even when targeting specific
-   * instances. At high cardinality, this can cause severe performance degradation. Prefer 
+   * instances. At high cardinality, this can cause severe performance degradation. Prefer
    * {@link DataSource#LIVEINSTANCES} when resource/partition filtering is not needed.
-   * 
+   *
    * @param recipientCriteria Criteria specifying the message destinations
    * @param accessor connection to the persisted data
    * @return map of evaluated criteria
@@ -129,8 +129,8 @@ public class CriteriaEvaluator {
           keyBuilder.liveInstance(instanceName), DataSource.LIVEINSTANCES.name());
       break;
     case INSTANCES:
-      properties = getProperty(accessor, instanceName, keyBuilder.instances(),
-          keyBuilder.instance(instanceName), DataSource.INSTANCES.name());
+      properties = getProperty(accessor, instanceName, keyBuilder.instanceConfigs(),
+          keyBuilder.instanceConfig(instanceName), DataSource.INSTANCES.name());
       break;
     default:
       return Lists.newArrayList();

--- a/helix-core/src/main/java/org/apache/helix/messaging/CriteriaEvaluator.java
+++ b/helix-core/src/main/java/org/apache/helix/messaging/CriteriaEvaluator.java
@@ -116,24 +116,24 @@ public class CriteriaEvaluator {
     String instanceName = recipientCriteria.getInstanceName();
 
     switch (dataSource) {
-    case EXTERNALVIEW:
-      properties = getProperty(accessor, resourceName, keyBuilder.externalViews(),
-          keyBuilder.externalView(resourceName), DataSource.EXTERNALVIEW.name());
-      break;
-    case IDEALSTATES:
-      properties = getProperty(accessor, resourceName, keyBuilder.idealStates(),
-          keyBuilder.idealStates(resourceName), DataSource.IDEALSTATES.name());
-      break;
-    case LIVEINSTANCES:
-      properties = getProperty(accessor, instanceName, keyBuilder.liveInstances(),
-          keyBuilder.liveInstance(instanceName), DataSource.LIVEINSTANCES.name());
-      break;
-    case INSTANCES:
-      properties = getProperty(accessor, instanceName, keyBuilder.instanceConfigs(),
-          keyBuilder.instanceConfig(instanceName), DataSource.INSTANCES.name());
-      break;
-    default:
-      return Lists.newArrayList();
+      case EXTERNALVIEW:
+        properties = getProperty(accessor, resourceName, keyBuilder.externalViews(),
+            keyBuilder.externalView(resourceName), DataSource.EXTERNALVIEW.name());
+        break;
+      case IDEALSTATES:
+        properties = getProperty(accessor, resourceName, keyBuilder.idealStates(),
+            keyBuilder.idealStates(resourceName), DataSource.IDEALSTATES.name());
+        break;
+      case LIVEINSTANCES:
+        properties = getProperty(accessor, instanceName, keyBuilder.liveInstances(),
+            keyBuilder.liveInstance(instanceName), DataSource.LIVEINSTANCES.name());
+        break;
+      case INSTANCES:
+        properties = getProperty(accessor, instanceName, keyBuilder.instanceConfigs(),
+            keyBuilder.instanceConfig(instanceName), DataSource.INSTANCES.name());
+        break;
+      default:
+        return Lists.newArrayList();
     }
     // flatten the data
     List<ZNRecordRow> allRows = ZNRecordRow.flatten(HelixProperty.convertToList(properties));

--- a/helix-core/src/test/java/org/apache/helix/integration/messaging/TestMessagingService.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/messaging/TestMessagingService.java
@@ -40,6 +40,8 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
 public class TestMessagingService extends ZkStandAloneCMTestBase {
+  // Nanoseconds to milliseconds conversion factor
+  private static final long NANOS_TO_MILLIS = 1_000_000;
   public static class TestMessagingHandlerFactory implements MultiTypeMessageHandlerFactory {
     public static HashSet<String> _processedMsgIds = new HashSet<String>();
 
@@ -70,7 +72,6 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
         HelixTaskResult result = new HelixTaskResult();
         result.setSuccess(true);
         Thread.sleep(1000);
-        //System.out.println("TestMessagingHandler " + _message.getMsgId());
         _processedMsgIds.add(_message.getRecord().getSimpleField("TestMessagingPara"));
         result.getTaskResultMap().put("ReplyMessage", "TestReplyMessage");
         return result;
@@ -129,7 +130,9 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
 
   }
 
-  @Test()
+  // Performance test - excluded from CI to reduce test execution time
+  // Enable test in local to fetch performance numbers before and after your change
+  @Test(enabled = false)
   public void TestMessageSendPerformance() throws Exception {
     String hostSrc = "localhost_" + START_PORT;
     String hostDest = "localhost_" + (START_PORT + 1);
@@ -158,8 +161,8 @@ public class TestMessagingService extends ZkStandAloneCMTestBase {
         totalTime += (endTime - startTime);
       }
 
-      long avgTimeMs = (totalTime / iterations) / 1_000_000;
-      long totalTimeMs = totalTime / 1_000_000;
+      long avgTimeMs = (totalTime / iterations) / NANOS_TO_MILLIS;
+      long totalTimeMs = totalTime / NANOS_TO_MILLIS;
       System.out.println("DataSource: " + dataSource);
       System.out.println("  Total time for " + iterations + " sends: " + totalTimeMs + " ms");
       System.out.println("  Average time per send: " + avgTimeMs + " ms\n");


### PR DESCRIPTION
### Description
1. Add participant message send performance test
2. Fix bug in send message where source is Instances. in case of instance getProperty throws exception, reason being instance/instance_120919 is not a leaf znode like LiveInstances/instance_120919 and instead its a folder. If it reads instanceconfig, then it serves same purpose and doesn't throw error. It indicates no customer is using instance as source today, else they would get exception.

### Tests
NA