### PR TITLE
Fix TestConfigAccessor and TestHelixConfigAccessor to reflect removal of INSTANCE_OPERATION_STATE auto-initialization

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestConfigAccessor.java
@@ -116,7 +116,7 @@ public class TestConfigAccessor extends ZkUnitTestBase {
 
     keys = configAccessor.getKeys(ConfigScopeProperty.PARTICIPANT, clusterName, "localhost_12918");
     System.out.println((keys));
-    Assert.assertEquals(keys.size(), 4, "should be [HELIX_HOST, HELIX_PORT, INSTANCE_OPERATION_STATE, participantConfigKey]");
+    Assert.assertEquals(keys.size(), 3, "should be [HELIX_HOST, HELIX_PORT, participantConfigKey]");
     Assert.assertTrue(keys.contains("participantConfigKey"));
 
     keys = configAccessor.getKeys(ConfigScopeProperty.PARTITION, clusterName, "testResource",

--- a/helix-core/src/test/java/org/apache/helix/TestHelixConfigAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelixConfigAccessor.java
@@ -119,7 +119,7 @@ public class TestHelixConfigAccessor extends ZkUnitTestBase {
     keys = configAccessor.getKeys(
         new HelixConfigScopeBuilder(ConfigScopeProperty.PARTICIPANT).forCluster(clusterName)
             .forParticipant("localhost_12918").build());
-    Assert.assertEquals(keys.size(), 4, "should be [HELIX_PORT, HELIX_HOST, INSTANCE_OPERATION_STATE, participantConfigKey]");
+    Assert.assertEquals(keys.size(), 3, "should be [HELIX_PORT, HELIX_HOST, participantConfigKey]");
     Assert.assertTrue(keys.contains("participantConfigKey"));
 
     keys = configAccessor.getKeys(


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fix TestConfigAccessor and TestHelixConfigAccessor to reflect removal of INSTANCE_OPERATION_STATE auto-initialization

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

The `INSTANCE_OPERATION_STATE` field is no longer automatically initialized in the `InstanceConfig(String instanceId)` constructor. This was an intentional change(see https://github.com/linkedin/helix/pull/97).
Updated both test files to expect 3 configuration keys instead of 4

### Tests
Updated the tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
