### PR TITLE
Reduce log volume in evacuation check methods

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -858,8 +858,11 @@ public class ZKHelixAdmin implements HelixAdmin {
               currentStates, idealStates, instanceName, allowedResources, filters);
 
       boolean hasPartitionsStillOnInstance = !partitionsStillOnInstance.isEmpty();
-      logger.info("Instance {} in cluster {} (offline) has {} partitions still on instance after exclusions",
-          instanceName, clusterName, partitionsStillOnInstance.size());
+      if (hasPartitionsStillOnInstance) {
+        // Partitions are still blocking evacuation
+        logger.info("Instance {} in cluster {} (offline) has {} partitions still on instance after exclusions",
+            instanceName, clusterName, partitionsStillOnInstance.size());
+      }
       return hasPartitionsStillOnInstance;
     }
 
@@ -881,8 +884,11 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     // Step 6: Check if any partitions remain after exclusions
     boolean hasRemainingPartitions = !remainingPartitions.isEmpty();
-    logger.info("Instance {} in cluster {} has {} partitions after applying {} exclusions (from {} total)",
-        instanceName, clusterName, remainingPartitions.size(), exclusionTypes.size(), allPartitions.size());
+    if (hasRemainingPartitions) {
+      // Partitions are still blocking evacuation
+      logger.info("Instance {} in cluster {} has {} partitions after applying {} exclusions (from {} total)",
+          instanceName, clusterName, remainingPartitions.size(), exclusionTypes.size(), allPartitions.size());
+    }
 
     return hasRemainingPartitions;
   }


### PR DESCRIPTION
## Problem

EKG log volume check is failing for `helix.ambry` and `helix.espresso2` during canary deployments in EI cluster:
> "Total log volume should not change by more than 100% when experiment host produces log volume more than 1 MB/min"

**Observation:** The rule is flaky (failing mostly but sometimes passing). Started failing from version **11.3.0.31** (Dec 12).

**Jira:** [CICP-3460](https://linkedin.atlassian.net/browse/CICP-3460)

## Root Cause Analysis

After analyzing logging changes in past ~45 days, identified culprit: Commit `99b5c158e` introduced 6 new INFO logs in `ZKHelixAdmin.java`'s `instanceHasCurrentStateOrMessage()` method.

**The problem:** This method is called on every REST API poll to `isEvacuateFinished()`, `isInstanceDrained()`, and `isReadyForPreparingJoiningCluster()`. The partition-counting log was firing on **every successful call**, even when evacuation was complete.

**Why only Ambry & Espresso2 in EI?**
- Storage systems with frequent node maintenance (evacuations/swaps)
- Many instances being monitored simultaneously
- High polling frequency from ACM automation

## Solution

Made partition-counting logs **conditional** - only fire when partitions are actually blocking evacuation:

```java
if (hasRemainingPartitions) {
    logger.info("Instance {} in cluster {} has {} partitions after applying {} exclusions...");
}
```