### PR TITLE
Custom Thread Pool For ConstraintBasedAlgorithm Computation

### DIFF
--- a/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
+++ b/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
@@ -90,4 +90,8 @@ public class SystemPropertyKeys {
 
   public static final String TASK_CURRENT_STATE_PATH_DISABLED =
       "helix.taskCurrentStatePathDisabled";
+
+  // Constraint-based algorithm ForkJoinPool parallelism
+  public static final String CONSTRAINT_ALGORITHM_PARALLELISM =
+      "helix.constraint.algorithm.parallelism";
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
@@ -127,7 +129,7 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
 
   private Optional<AssignableNode> getNodeWithHighestPoints(AssignableReplica replica,
       List<AssignableNode> assignableNodes, ClusterContext clusterContext, Set<String> busyInstances,
-      OptimalAssignment optimalAssignment) {
+      OptimalAssignment optimalAssignment) throws HelixRebalanceException {
     Map<AssignableNode, List<HardConstraint>> hardConstraintFailures = new ConcurrentHashMap<>(assignableNodes.size());
     
     // Execute first parallelStream within custom ForkJoinPool context
@@ -147,7 +149,16 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
           return isValid;
         }).collect(Collectors.toList())
     );
-    List<AssignableNode> candidateNodes = filterTask.join();
+    
+    List<AssignableNode> candidateNodes;
+    try {
+      candidateNodes = filterTask.join();
+    } catch (CancellationException | CompletionException e) {
+      throw new HelixRebalanceException(
+          String.format("Failed to evaluate hard constraints for replica %s: %s",
+              replica.getPartitionName(), e.getMessage()),
+          HelixRebalanceException.Type.FAILED_TO_CALCULATE, e);
+    }
 
     if (candidateNodes.isEmpty()) {
       LOG.info("Found no eligible candidate nodes. Enabling hard constraint level logging for cluster: {}", clusterContext.getClusterName());
@@ -180,7 +191,15 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
               }
             }).map(Map.Entry::getKey)
     );
-    return scoreTask.join();
+    
+    try {
+      return scoreTask.join();
+    } catch (CancellationException | CompletionException e) {
+      throw new HelixRebalanceException(
+          String.format("Failed to evaluate soft constraints for replica %s: %s",
+              replica.getPartitionName(), e.getMessage()),
+          HelixRebalanceException.Type.FAILED_TO_CALCULATE, e);
+    }
   }
 
   private double getAssignmentNormalizedScore(AssignableNode node, AssignableReplica replica,

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.ForkJoinTask;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Maps;
@@ -131,34 +131,27 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
       List<AssignableNode> assignableNodes, ClusterContext clusterContext, Set<String> busyInstances,
       OptimalAssignment optimalAssignment) throws HelixRebalanceException {
     Map<AssignableNode, List<HardConstraint>> hardConstraintFailures = new ConcurrentHashMap<>(assignableNodes.size());
-    
+
     // Execute first parallelStream within custom ForkJoinPool context
-    ForkJoinTask<List<AssignableNode>> filterTask = _constraintEvaluationPool.submit(() ->
-        assignableNodes.parallelStream().filter(candidateNode -> {
-          boolean isValid = true;
-          for (HardConstraint hardConstraint : _hardConstraints) {
-            if (!hardConstraint.isAssignmentValid(candidateNode, replica, clusterContext)) {
-              if (!hardConstraintFailures.containsKey(candidateNode)) {
-                hardConstraintFailures.put(candidateNode, new ArrayList<>());
+    List<AssignableNode> candidateNodes = executeInPool(
+        () -> assignableNodes.parallelStream()
+            .filter(candidateNode -> {
+              boolean isValid = true;
+              for (HardConstraint hardConstraint : _hardConstraints) {
+                if (!hardConstraint.isAssignmentValid(candidateNode, replica, clusterContext)) {
+                  if (!hardConstraintFailures.containsKey(candidateNode)) {
+                    hardConstraintFailures.put(candidateNode, new ArrayList<>());
+                  }
+                  hardConstraintFailures.get(candidateNode).add(hardConstraint);
+                  isValid = false;
+                  break;
+                }
               }
-              hardConstraintFailures.get(candidateNode).add(hardConstraint);
-              isValid = false;
-              break;
-            }
-          }
-          return isValid;
-        }).collect(Collectors.toList())
+              return isValid;
+            })
+            .collect(Collectors.toList()),
+        "hard constraint filtering"
     );
-    
-    List<AssignableNode> candidateNodes;
-    try {
-      candidateNodes = filterTask.join();
-    } catch (CancellationException | CompletionException e) {
-      throw new HelixRebalanceException(
-          String.format("Failed to evaluate hard constraints for replica %s: %s",
-              replica.getPartitionName(), e.getMessage()),
-          HelixRebalanceException.Type.FAILED_TO_CALCULATE, e);
-    }
 
     if (candidateNodes.isEmpty()) {
       LOG.info("Found no eligible candidate nodes. Enabling hard constraint level logging for cluster: {}", clusterContext.getClusterName());
@@ -172,14 +165,13 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
     removeFullLoggingForCluster();
 
     // Execute second parallelStream within custom ForkJoinPool context
-    ForkJoinTask<Optional<AssignableNode>> scoreTask = _constraintEvaluationPool.submit(() ->
-        candidateNodes.parallelStream().map(node -> new HashMap.SimpleEntry<>(node,
-            getAssignmentNormalizedScore(node, replica, clusterContext)))
+    return executeInPool(
+        () -> candidateNodes.parallelStream()
+            .map(node -> new HashMap.SimpleEntry<>(node,
+                getAssignmentNormalizedScore(node, replica, clusterContext)))
             .max((nodeEntry1, nodeEntry2) -> {
               int scoreCompareResult = nodeEntry1.getValue().compareTo(nodeEntry2.getValue());
               if (scoreCompareResult == 0) {
-                // If the evaluation scores of 2 nodes are the same, the algorithm assigns the replica
-                // to the idle node first.
                 String logicalId1 = nodeEntry1.getKey().getLogicalId();
                 String logicalId2 = nodeEntry2.getKey().getLogicalId();
                 int idleScore1 = busyInstances.contains(logicalId1) ? 0 : 1;
@@ -189,17 +181,10 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
               } else {
                 return scoreCompareResult;
               }
-            }).map(Map.Entry::getKey)
+            })
+            .map(Map.Entry::getKey),
+        "node scoring and selection"
     );
-    
-    try {
-      return scoreTask.join();
-    } catch (CancellationException | CompletionException e) {
-      throw new HelixRebalanceException(
-          String.format("Failed to evaluate soft constraints for replica %s: %s",
-              replica.getPartitionName(), e.getMessage()),
-          HelixRebalanceException.Type.FAILED_TO_CALCULATE, e);
-    }
   }
 
   private double getAssignmentNormalizedScore(AssignableNode node, AssignableReplica replica,
@@ -344,5 +329,27 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
         resourceAssignment -> resourceAssignment.getRecord().getMapFields().values().stream()
             .flatMap(instanceStateMap -> instanceStateMap.keySet().stream())
             .collect(Collectors.toSet()).stream()).collect(Collectors.toSet());
+  }
+
+  /**
+   * Executes the given operation in the constraint evaluation pool, handling exceptions and
+   * wrapping them in HelixRebalanceException.
+   *
+   * @param operation The operation to execute.
+   * @param errorContext A description of the context for error reporting.
+   * @param <T> The return type of the operation.
+   * @return The result of the operation.
+   * @throws HelixRebalanceException If the operation fails.
+   */
+  private <T> T executeInPool(Supplier<T> operation, String errorContext)
+      throws HelixRebalanceException {
+    try {
+      return _constraintEvaluationPool.submit(operation::get).join();
+    } catch (CancellationException | CompletionException e) {
+      LOG.error("Constraint evaluation failed during {}: {}", errorContext, e.getMessage(), e);
+      throw new HelixRebalanceException(
+          String.format("Failed during %s: %s", errorContext, e.getMessage()),
+          HelixRebalanceException.Type.FAILED_TO_CALCULATE, e);
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -28,6 +28,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Maps;
@@ -57,11 +59,13 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
   private static final Logger LOG = LoggerFactory.getLogger(ConstraintBasedAlgorithm.class);
   private final List<HardConstraint> _hardConstraints;
   private final Map<SoftConstraint, Float> _softConstraints;
+  private final ForkJoinPool _constraintEvaluationPool;
 
   ConstraintBasedAlgorithm(List<HardConstraint> hardConstraints,
-      Map<SoftConstraint, Float> softConstraints) {
+      Map<SoftConstraint, Float> softConstraints, ForkJoinPool constraintEvaluationPool) {
     _hardConstraints = hardConstraints;
     _softConstraints = softConstraints;
+    _constraintEvaluationPool = constraintEvaluationPool;
   }
 
   @Override
@@ -125,20 +129,25 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
       List<AssignableNode> assignableNodes, ClusterContext clusterContext, Set<String> busyInstances,
       OptimalAssignment optimalAssignment) {
     Map<AssignableNode, List<HardConstraint>> hardConstraintFailures = new ConcurrentHashMap<>(assignableNodes.size());
-    List<AssignableNode> candidateNodes = assignableNodes.parallelStream().filter(candidateNode -> {
-      boolean isValid = true;
-      for (HardConstraint hardConstraint : _hardConstraints) {
-        if (!hardConstraint.isAssignmentValid(candidateNode, replica, clusterContext)) {
-          if (!hardConstraintFailures.containsKey(candidateNode)) {
-            hardConstraintFailures.put(candidateNode, new ArrayList<>());
+    
+    // Execute first parallelStream within custom ForkJoinPool context
+    ForkJoinTask<List<AssignableNode>> filterTask = _constraintEvaluationPool.submit(() ->
+        assignableNodes.parallelStream().filter(candidateNode -> {
+          boolean isValid = true;
+          for (HardConstraint hardConstraint : _hardConstraints) {
+            if (!hardConstraint.isAssignmentValid(candidateNode, replica, clusterContext)) {
+              if (!hardConstraintFailures.containsKey(candidateNode)) {
+                hardConstraintFailures.put(candidateNode, new ArrayList<>());
+              }
+              hardConstraintFailures.get(candidateNode).add(hardConstraint);
+              isValid = false;
+              break;
+            }
           }
-          hardConstraintFailures.get(candidateNode).add(hardConstraint);
-          isValid = false;
-          break;
-        }
-      }
-      return isValid;
-    }).collect(Collectors.toList());
+          return isValid;
+        }).collect(Collectors.toList())
+    );
+    List<AssignableNode> candidateNodes = filterTask.join();
 
     if (candidateNodes.isEmpty()) {
       LOG.info("Found no eligible candidate nodes. Enabling hard constraint level logging for cluster: {}", clusterContext.getClusterName());
@@ -151,23 +160,27 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
     LOG.debug("Disabling hard constraint level logging for cluster: {}", clusterContext.getClusterName());
     removeFullLoggingForCluster();
 
-    return candidateNodes.parallelStream().map(node -> new HashMap.SimpleEntry<>(node,
-        getAssignmentNormalizedScore(node, replica, clusterContext)))
-        .max((nodeEntry1, nodeEntry2) -> {
-          int scoreCompareResult = nodeEntry1.getValue().compareTo(nodeEntry2.getValue());
-          if (scoreCompareResult == 0) {
-            // If the evaluation scores of 2 nodes are the same, the algorithm assigns the replica
-            // to the idle node first.
-            String logicalId1 = nodeEntry1.getKey().getLogicalId();
-            String logicalId2 = nodeEntry2.getKey().getLogicalId();
-            int idleScore1 = busyInstances.contains(logicalId1) ? 0 : 1;
-            int idleScore2 = busyInstances.contains(logicalId2) ? 0 : 1;
-            return idleScore1 != idleScore2 ? (idleScore1 - idleScore2)
-                : -nodeEntry1.getKey().compareTo(nodeEntry2.getKey());
-          } else {
-            return scoreCompareResult;
-          }
-        }).map(Map.Entry::getKey);
+    // Execute second parallelStream within custom ForkJoinPool context
+    ForkJoinTask<Optional<AssignableNode>> scoreTask = _constraintEvaluationPool.submit(() ->
+        candidateNodes.parallelStream().map(node -> new HashMap.SimpleEntry<>(node,
+            getAssignmentNormalizedScore(node, replica, clusterContext)))
+            .max((nodeEntry1, nodeEntry2) -> {
+              int scoreCompareResult = nodeEntry1.getValue().compareTo(nodeEntry2.getValue());
+              if (scoreCompareResult == 0) {
+                // If the evaluation scores of 2 nodes are the same, the algorithm assigns the replica
+                // to the idle node first.
+                String logicalId1 = nodeEntry1.getKey().getLogicalId();
+                String logicalId2 = nodeEntry2.getKey().getLogicalId();
+                int idleScore1 = busyInstances.contains(logicalId1) ? 0 : 1;
+                int idleScore2 = busyInstances.contains(logicalId2) ? 0 : 1;
+                return idleScore1 != idleScore2 ? (idleScore1 - idleScore2)
+                    : -nodeEntry1.getKey().compareTo(nodeEntry2.getKey());
+              } else {
+                return scoreCompareResult;
+              }
+            }).map(Map.Entry::getKey)
+    );
+    return scoreTask.join();
   }
 
   private double getAssignmentNormalizedScore(AssignableNode node, AssignableReplica replica,

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ConstraintBasedAlgorithmFactory {
   private static final Logger LOG = LoggerFactory.getLogger(ConstraintBasedAlgorithmFactory.class);
-  private static final int DEFAULT_CONSTRAINT_ALGORITHM_PARALLELISM = 4;
+  private static final int DEFAULT_CONSTRAINT_ALGORITHM_PARALLELISM = 8;
 
   // Shared ForkJoinPool reused across all ConstraintBasedAlgorithm instances
   private static final AtomicReference<ForkJoinPool> SHARED_POOL_REF = new AtomicReference<>();

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.collect.ImmutableList;
@@ -41,10 +44,26 @@ import org.slf4j.LoggerFactory;
  */
 public class ConstraintBasedAlgorithmFactory {
   private static final Logger LOG = LoggerFactory.getLogger(ConstraintBasedAlgorithmFactory.class);
-  private static final int DEFAULT_CONSTRAINT_ALGORITHM_PARALLELISM = 8;
+  private static final String CONSTRAINT_EVAL_THREAD_PREFIX = "Helix-ConstraintEval-worker-";
+  private static final int MIN_PARALLELISM = 2;
 
   // Shared ForkJoinPool reused across all ConstraintBasedAlgorithm instances
   private static final AtomicReference<ForkJoinPool> SHARED_POOL_REF = new AtomicReference<>();
+
+  /**
+   * Custom ForkJoinWorkerThreadFactory that creates threads with meaningful names
+   * for better debugging and monitoring.
+   */
+  private static class NamedForkJoinWorkerThreadFactory implements ForkJoinWorkerThreadFactory {
+    private final AtomicInteger threadCounter = new AtomicInteger(0);
+
+    @Override
+    public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+      ForkJoinWorkerThread thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+      thread.setName(CONSTRAINT_EVAL_THREAD_PREFIX + threadCounter.getAndIncrement());
+      return thread;
+    }
+  }
 
   private static final Map<String, Float> MODEL = new HashMap<String, Float>() {
     {
@@ -114,7 +133,8 @@ public class ConstraintBasedAlgorithmFactory {
   /**
    * Gets or creates a shared ForkJoinPool for constraint evaluation with controlled parallelism.
    * The parallelism can be configured via system property {@link SystemPropertyKeys#CONSTRAINT_ALGORITHM_PARALLELISM}.
-   * Defaults to 8 threads to avoid contention on systems with many CPU cores.
+   * The parallelism is capped between {@link #MIN_PARALLELISM} and half of available CPU cores
+   * to prevent CPU exhaustion. Default parallelism is set to 1/4 of available cores.
    * The pool is shared across all ConstraintBasedAlgorithm instances to avoid resource waste.
    *
    * @return Shared ForkJoinPool instance for constraint evaluation
@@ -132,15 +152,24 @@ public class ConstraintBasedAlgorithmFactory {
         return existing;
       }
 
-      int parallelism = HelixUtil.getSystemPropertyAsInt(
-          SystemPropertyKeys.CONSTRAINT_ALGORITHM_PARALLELISM,
-          DEFAULT_CONSTRAINT_ALGORITHM_PARALLELISM);
+      // Calculate bounds based on available CPU cores to prevent CPU exhaustion
+      int availableCores = Runtime.getRuntime().availableProcessors();
+      int maxParallelism = Math.max(MIN_PARALLELISM, availableCores / 2);
+      int defaultParallelism = Math.min(maxParallelism, Math.max(MIN_PARALLELISM, availableCores / 4));
 
-      LOG.info("Creating shared constraint evaluation ForkJoinPool with parallelism: {}", parallelism);
+      // Read configured value and clamp it within bounds
+      int configuredParallelism = HelixUtil.getSystemPropertyAsInt(
+          SystemPropertyKeys.CONSTRAINT_ALGORITHM_PARALLELISM,
+          defaultParallelism);
+      int finalParallelism = Math.min(maxParallelism, Math.max(MIN_PARALLELISM, configuredParallelism));
+
+      LOG.info("Creating shared constraint evaluation ForkJoinPool. "
+              + "Available cores: {}, configured parallelism: {}, final parallelism: {} (min: {}, max: {})",
+          availableCores, configuredParallelism, finalParallelism, MIN_PARALLELISM, maxParallelism);
 
       ForkJoinPool pool = new ForkJoinPool(
-          parallelism,
-          ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+          finalParallelism,
+          new NamedForkJoinWorkerThreadFactory(),
           null,
           false
       );

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -30,11 +32,20 @@ import org.apache.helix.HelixManagerProperties;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.helix.controller.rebalancer.waged.RebalanceAlgorithm;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.util.HelixUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The factory class to create an instance of {@link ConstraintBasedAlgorithm}
  */
 public class ConstraintBasedAlgorithmFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(ConstraintBasedAlgorithmFactory.class);
+  private static final int DEFAULT_CONSTRAINT_ALGORITHM_PARALLELISM = 4;
+
+  // Shared ForkJoinPool reused across all ConstraintBasedAlgorithm instances
+  private static final AtomicReference<ForkJoinPool> SHARED_POOL_REF = new AtomicReference<>();
+
   private static final Map<String, Float> MODEL = new HashMap<String, Float>() {
     {
       // The default setting
@@ -96,7 +107,45 @@ public class ConstraintBasedAlgorithmFactory {
           : evennessPreference * weight;
     });
 
+    ForkJoinPool constraintEvaluationPool = getSharedConstraintEvaluationPool();
+    return new ConstraintBasedAlgorithm(hardConstraints, softConstraintsWithWeight, constraintEvaluationPool);
+  }
 
-    return new ConstraintBasedAlgorithm(hardConstraints, softConstraintsWithWeight);
+  /**
+   * Gets or creates a shared ForkJoinPool for constraint evaluation with controlled parallelism.
+   * The parallelism can be configured via system property {@link SystemPropertyKeys#CONSTRAINT_ALGORITHM_PARALLELISM}.
+   * Defaults to 8 threads to avoid contention on systems with many CPU cores.
+   * The pool is shared across all ConstraintBasedAlgorithm instances to avoid resource waste.
+   *
+   * @return Shared ForkJoinPool instance for constraint evaluation
+   */
+  private static ForkJoinPool getSharedConstraintEvaluationPool() {
+    ForkJoinPool existing = SHARED_POOL_REF.get();
+    if (existing != null && !existing.isShutdown()) {
+      return existing;
+    }
+
+    synchronized (ConstraintBasedAlgorithmFactory.class) {
+      // Double-check after acquiring lock
+      existing = SHARED_POOL_REF.get();
+      if (existing != null && !existing.isShutdown()) {
+        return existing;
+      }
+
+      int parallelism = HelixUtil.getSystemPropertyAsInt(
+          SystemPropertyKeys.CONSTRAINT_ALGORITHM_PARALLELISM,
+          DEFAULT_CONSTRAINT_ALGORITHM_PARALLELISM);
+
+      LOG.info("Creating shared constraint evaluation ForkJoinPool with parallelism: {}", parallelism);
+
+      ForkJoinPool pool = new ForkJoinPool(
+          parallelism,
+          ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+          null,
+          true
+      );
+      SHARED_POOL_REF.set(pool);
+      return pool;
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithmFactory.java
@@ -142,7 +142,7 @@ public class ConstraintBasedAlgorithmFactory {
           parallelism,
           ForkJoinPool.defaultForkJoinWorkerThreadFactory,
           null,
-          true
+          false
       );
       SHARED_POOL_REF.set(pool);
       return pool;

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -45,6 +46,7 @@ import static org.mockito.Mockito.when;
 
 
 public class TestConstraintBasedAlgorithm {
+  private static final ForkJoinPool TEST_FORK_JOIN_POOL = new ForkJoinPool(4);
 
   @Test
   public void testCalculateNoValidAssignment() throws IOException {
@@ -54,7 +56,7 @@ public class TestConstraintBasedAlgorithm {
     when(mockSoftConstraint.getAssignmentNormalizedScore(any(), any(), any())).thenReturn(1.0);
     ConstraintBasedAlgorithm algorithm =
         new ConstraintBasedAlgorithm(ImmutableList.of(mockHardConstraint),
-            ImmutableMap.of(mockSoftConstraint, 1f));
+            ImmutableMap.of(mockSoftConstraint, 1f), TEST_FORK_JOIN_POOL);
     ClusterModel clusterModel = new ClusterModelTestHelper().getDefaultClusterModel();
     try {
       algorithm.calculate(clusterModel);
@@ -76,7 +78,7 @@ public class TestConstraintBasedAlgorithm {
     when(mockSoftConstraint.getAssignmentNormalizedScore(any(), any(), any())).thenReturn(1.0);
     ConstraintBasedAlgorithm algorithm =
         new ConstraintBasedAlgorithm(ImmutableList.of(mockHardConstraint),
-            ImmutableMap.of(mockSoftConstraint, 1f));
+            ImmutableMap.of(mockSoftConstraint, 1f), TEST_FORK_JOIN_POOL);
     ClusterModel clusterModel = new ClusterModelTestHelper().getDefaultClusterModel();
     try {
       algorithm.calculate(clusterModel);
@@ -100,7 +102,7 @@ public class TestConstraintBasedAlgorithm {
     when(mockSoftConstraint.getAssignmentNormalizedScore(any(), any(), any())).thenReturn(1.0);
     ConstraintBasedAlgorithm algorithm =
         new ConstraintBasedAlgorithm(ImmutableList.of(mockHardConstraint),
-            ImmutableMap.of(mockSoftConstraint, 1f));
+            ImmutableMap.of(mockSoftConstraint, 1f), TEST_FORK_JOIN_POOL);
     ClusterModel clusterModel = new ClusterModelTestHelper().getDefaultClusterModel();
     OptimalAssignment optimalAssignment = algorithm.calculate(clusterModel);
 
@@ -115,7 +117,7 @@ public class TestConstraintBasedAlgorithm {
     when(mockSoftConstraint.getAssignmentNormalizedScore(any(), any(), any())).thenReturn(1.0);
     ConstraintBasedAlgorithm algorithm =
         new ConstraintBasedAlgorithm(ImmutableList.of(mockHardConstraint),
-            ImmutableMap.of(mockSoftConstraint, 1f));
+            ImmutableMap.of(mockSoftConstraint, 1f), TEST_FORK_JOIN_POOL);
     ClusterModel clusterModel = new ClusterModelTestHelper().getMultiNodeClusterModel();
     OptimalAssignment optimalAssignment = algorithm.calculate(clusterModel);
 
@@ -135,7 +137,7 @@ public class TestConstraintBasedAlgorithm {
     SoftConstraint soft2 = new InstancePartitionsCountConstraint();
     ConstraintBasedAlgorithm algorithm =
         new ConstraintBasedAlgorithm(ImmutableList.of(nodeCapacityConstraint),
-            ImmutableMap.of(soft1, 1f, soft2, 1f));
+            ImmutableMap.of(soft1, 1f, soft2, 1f), TEST_FORK_JOIN_POOL);
     ClusterModel clusterModel = new ClusterModelTestHelper().getMultiNodeClusterModel();
     OptimalAssignment optimalAssignment = algorithm.calculate(clusterModel);
 
@@ -150,7 +152,7 @@ public class TestConstraintBasedAlgorithm {
     SoftConstraint soft2 = new InstancePartitionsCountConstraint();
     ConstraintBasedAlgorithm algorithm =
         new ConstraintBasedAlgorithm(ImmutableList.of(nodeCapacityConstraint),
-            ImmutableMap.of(soft1, 1f, soft2, 1f));
+            ImmutableMap.of(soft1, 1f, soft2, 1f), TEST_FORK_JOIN_POOL);
     ClusterModel clusterModel =
         new ClusterModelTestHelper().getMultiNodeClusterModelNegativeSetup();
     try {
@@ -171,7 +173,7 @@ public class TestConstraintBasedAlgorithm {
     SoftConstraint soft2 = new InstancePartitionsCountConstraint();
     ConstraintBasedAlgorithm algorithm =
         new ConstraintBasedAlgorithm(ImmutableList.of(nodeCapacityConstraint),
-            ImmutableMap.of(soft1, 1f, soft2, 1f));
+            ImmutableMap.of(soft1, 1f, soft2, 1f), TEST_FORK_JOIN_POOL);
     ClusterModel clusterModel = new ClusterModelTestHelper().getMultiNodeClusterModel();
     // increase the ask capacity of item 3, which will trigger the capacity constraint to fail.
     Map<String, Set<AssignableReplica>> assignableReplicaMap = new HashMap<>(clusterModel.getAssignableReplicaMap());


### PR DESCRIPTION
### Issues
**High CPU Usage observed during rebalance**
- ConstraintBasedAlgorithm.getNodeWithHighestPoints() uses parallelStream() twice over potentially large collections (assignableNodes, candidateNodes).
- parallelStream() relies on the JVM common ForkJoinPool, whose size defaults to Runtime.getRuntime().availableProcessors().
- This method is invoked once per replica during rebalancing, leading to 1000+ invocations in large clusters.
- Multiple concurrent parallel streams contend for the same ForkJoinPool, causing thread starvation and contention.
-  Constraint evaluation is CPU-intensive, amplifying CPU saturation under contention.
- There is no backpressure or concurrency control, allowing unbounded parallel execution and excessive CPU usage.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)


**What**

- Executes constraint evaluation using a dedicated ForkJoinPool instead of the JVM common pool.

- Caps parallelism to a configurable level to prevent CPU oversubscription during rebalancing.

**Why**

- parallelStream() defaults to the JVM common ForkJoinPool, which scales to the number of available cores 
- This method is invoked per replica and uses multiple parallel streams, leading to excessive contention and CPU saturation when many rebalances run concurrently.

- Using the common pool provides no isolation or backpressure, allowing unrelated parallel workloads to interfere with rebalancing.

**How**

- Introduces a custom ForkJoinPool and submits the parallel stream computation through it.

- Retains ForkJoin semantics, which are well-suited for constraint evaluation due to task splitting and work-stealing behavior.


### Tests
Existing ConstraintBasedAlgorithm tests are modified and passing
