### PR TITLE
Add MappingCapacityRejectionGauge metric to track capacity rejections per resource and instance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -617,38 +617,22 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   }
 
   /**
-   * Gets the capacity rejection map for all resources.
-   * Outer map key: resource name, Inner map key: instance name, Value: rejection count
+   * Gets and clears all capacity rejection data atomically.
+   * This returns the rejections from the current pipeline run and clears the tracking data
+   * for the next run. The returned data is used to increment the cumulative JMX counters.
    *
-   * @return The capacity rejection map
+   * @return Map of resource name to (instance name to rejection count)
    */
-  public Map<String, Map<String, AtomicLong>> getCapacityRejectionMap() {
-    return _capacityRejectionMap;
-  }
-
-  /**
-   * Gets the capacity rejection counts for a specific resource.
-   *
-   * @param resourceName The resource name
-   * @return Map of instance name to rejection count, or empty map if no rejections
-   */
-  public Map<String, Long> getCapacityRejectionsForResource(String resourceName) {
-    Map<String, AtomicLong> resourceRejections = _capacityRejectionMap.get(resourceName);
-    if (resourceRejections == null) {
-      return Collections.emptyMap();
+  public Map<String, Map<String, Long>> getAndClearCapacityRejections() {
+    Map<String, Map<String, Long>> snapshot = new HashMap<>();
+    for (Map.Entry<String, Map<String, AtomicLong>> resourceEntry : _capacityRejectionMap.entrySet()) {
+      Map<String, Long> instanceRejections = new HashMap<>();
+      for (Map.Entry<String, AtomicLong> instanceEntry : resourceEntry.getValue().entrySet()) {
+        instanceRejections.put(instanceEntry.getKey(), instanceEntry.getValue().get());
+      }
+      snapshot.put(resourceEntry.getKey(), instanceRejections);
     }
-    Map<String, Long> result = new HashMap<>();
-    for (Map.Entry<String, AtomicLong> entry : resourceRejections.entrySet()) {
-      result.put(entry.getKey(), entry.getValue().get());
-    }
-    return result;
-  }
-
-  /**
-   * Clears all capacity rejection tracking data.
-   * Should be called at the start of each pipeline run.
-   */
-  public void clearCapacityRejections() {
     _capacityRejectionMap.clear();
+    return snapshot;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.apache.helix.HelixConstants;
@@ -110,7 +111,8 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
 
   // Tracks capacity rejections per resource per instance during mapping calculation.
   // Outer map key: resource name, Inner map key: instance name, Value: rejection count
-  private final Map<String, Map<String, AtomicLong>> _capacityRejectionMap = new ConcurrentHashMap<>();
+  private final AtomicReference<Map<String, Map<String, AtomicLong>>> _capacityRejectionMapRef =
+      new AtomicReference<>(new ConcurrentHashMap<>());
 
   public ResourceControllerDataProvider() {
     this(AbstractDataCache.UNKNOWN_CLUSTER);
@@ -610,7 +612,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
    * @param instanceName The instance that rejected the partition
    */
   public void recordCapacityRejection(String resourceName, String instanceName) {
-    _capacityRejectionMap
+    _capacityRejectionMapRef.get()
         .computeIfAbsent(resourceName, k -> new ConcurrentHashMap<>())
         .computeIfAbsent(instanceName, k -> new AtomicLong(0))
         .incrementAndGet();
@@ -623,16 +625,7 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
    *
    * @return Map of resource name to (instance name to rejection count)
    */
-  public Map<String, Map<String, Long>> getAndClearCapacityRejections() {
-    Map<String, Map<String, Long>> snapshot = new HashMap<>();
-    for (Map.Entry<String, Map<String, AtomicLong>> resourceEntry : _capacityRejectionMap.entrySet()) {
-      Map<String, Long> instanceRejections = new HashMap<>();
-      for (Map.Entry<String, AtomicLong> instanceEntry : resourceEntry.getValue().entrySet()) {
-        instanceRejections.put(instanceEntry.getKey(), instanceEntry.getValue().get());
-      }
-      snapshot.put(resourceEntry.getKey(), instanceRejections);
-    }
-    _capacityRejectionMap.clear();
-    return snapshot;
+  public Map<String, Map<String, AtomicLong>> getAndClearCapacityRejections() {
+    return _capacityRejectionMapRef.getAndSet(new ConcurrentHashMap<>());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/ResourceControllerDataProvider.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import org.apache.helix.HelixConstants;
@@ -106,6 +107,10 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
   // WAGED specific capacity / weight provider
   WagedInstanceCapacity _wagedInstanceCapacity;
   WagedResourceWeightsProvider _wagedPartitionWeightProvider;
+
+  // Tracks capacity rejections per resource per instance during mapping calculation.
+  // Outer map key: resource name, Inner map key: instance name, Value: rejection count
+  private final Map<String, Map<String, AtomicLong>> _capacityRejectionMap = new ConcurrentHashMap<>();
 
   public ResourceControllerDataProvider() {
     this(AbstractDataCache.UNKNOWN_CLUSTER);
@@ -594,5 +599,56 @@ public class ResourceControllerDataProvider extends BaseControllerDataProvider {
     Set<String> disabledInstances = super.getDisabledInstancesForPartition(resource, partition);
     disabledInstances.addAll(_disabledInstancesForAllPartitionsSet);
     return disabledInstances;
+  }
+
+  /**
+   * Records a capacity rejection for a resource on a specific instance.
+   * This is called when the mapping calculator cannot assign a partition to an instance
+   * due to insufficient capacity.
+   *
+   * @param resourceName The resource whose partition was rejected
+   * @param instanceName The instance that rejected the partition
+   */
+  public void recordCapacityRejection(String resourceName, String instanceName) {
+    _capacityRejectionMap
+        .computeIfAbsent(resourceName, k -> new ConcurrentHashMap<>())
+        .computeIfAbsent(instanceName, k -> new AtomicLong(0))
+        .incrementAndGet();
+  }
+
+  /**
+   * Gets the capacity rejection map for all resources.
+   * Outer map key: resource name, Inner map key: instance name, Value: rejection count
+   *
+   * @return The capacity rejection map
+   */
+  public Map<String, Map<String, AtomicLong>> getCapacityRejectionMap() {
+    return _capacityRejectionMap;
+  }
+
+  /**
+   * Gets the capacity rejection counts for a specific resource.
+   *
+   * @param resourceName The resource name
+   * @return Map of instance name to rejection count, or empty map if no rejections
+   */
+  public Map<String, Long> getCapacityRejectionsForResource(String resourceName) {
+    Map<String, AtomicLong> resourceRejections = _capacityRejectionMap.get(resourceName);
+    if (resourceRejections == null) {
+      return Collections.emptyMap();
+    }
+    Map<String, Long> result = new HashMap<>();
+    for (Map.Entry<String, AtomicLong> entry : resourceRejections.entrySet()) {
+      result.put(entry.getKey(), entry.getValue().get());
+    }
+    return result;
+  }
+
+  /**
+   * Clears all capacity rejection tracking data.
+   * Should be called at the start of each pipeline run.
+   */
+  public void clearCapacityRejections() {
+    _capacityRejectionMap.clear();
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/DelayedAutoRebalancer.java
@@ -383,6 +383,8 @@ public class DelayedAutoRebalancer extends AbstractRebalancer<ResourceController
                 + "it from combinedPreferenceList.", instance, idealState.getResourceName(),
                 partition.getPartitionName());
             combinedPreferenceList.remove(instance);
+            // Record the capacity rejection for metrics
+            cache.recordCapacityRejection(idealState.getResourceName(), instance);
           }
         }
       }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong
 import java.util.stream.Collectors;
 
 import org.apache.helix.HelixDefinedState;
@@ -109,7 +110,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     final Map<String, ResourceConfig> resourceConfigMap = cache.getResourceConfigMap();
     // Capture capacity rejection data before clearing
     final Map<String, Map<String, Long>> capacityRejectionSnapshot = new HashMap<>();
-    for (Map.Entry<String, Map<String, java.util.concurrent.atomic.AtomicLong>> entry
+    for (Map.Entry<String, Map<String, AtomicLong>> entry
         : cache.getCapacityRejectionMap().entrySet()) {
       capacityRejectionSnapshot.put(entry.getKey(), cache.getCapacityRejectionsForResource(entry.getKey()));
     }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -107,6 +107,15 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     final Map<String, IdealState> idealStateMap = cache.getIdealStates();
     final Map<String, ExternalView> externalViewMap = cache.getExternalViews();
     final Map<String, ResourceConfig> resourceConfigMap = cache.getResourceConfigMap();
+    // Capture capacity rejection data before clearing
+    final Map<String, Map<String, Long>> capacityRejectionSnapshot = new HashMap<>();
+    for (Map.Entry<String, Map<String, java.util.concurrent.atomic.AtomicLong>> entry
+        : cache.getCapacityRejectionMap().entrySet()) {
+      capacityRejectionSnapshot.put(entry.getKey(), cache.getCapacityRejectionsForResource(entry.getKey()));
+    }
+    // Clear rejection data for the next pipeline run
+    cache.clearCapacityRejections();
+
     asyncExecute(cache.getAsyncTasksThreadPool(), () -> {
       try {
         if (clusterStatusMonitor != null) {
@@ -126,6 +135,16 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
             IdealState is = idealStateMap.get(resourceName);
             reportResourceState(clusterStatusMonitor, bestPossibleStateOutput, resourceName, is,
                 externalViewMap.get(resourceName), stateModelDefMap.get(is.getStateModelDefRef()));
+          }
+
+          // Report capacity rejection metrics for each resource
+          for (Map.Entry<String, Map<String, Long>> entry : capacityRejectionSnapshot.entrySet()) {
+            String resourceName = entry.getKey();
+            if (resourceConfigMap.containsKey(resourceName) && resourceConfigMap.get(resourceName)
+                .isMonitoringDisabled()) {
+              continue;
+            }
+            clusterStatusMonitor.updateMappingCapacityRejectionStats(resourceName, entry.getValue());
           }
         }
       } catch (Exception e) {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicLong
 import java.util.stream.Collectors;
 
 import org.apache.helix.HelixDefinedState;
@@ -108,14 +107,9 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     final Map<String, IdealState> idealStateMap = cache.getIdealStates();
     final Map<String, ExternalView> externalViewMap = cache.getExternalViews();
     final Map<String, ResourceConfig> resourceConfigMap = cache.getResourceConfigMap();
-    // Capture capacity rejection data before clearing
-    final Map<String, Map<String, Long>> capacityRejectionSnapshot = new HashMap<>();
-    for (Map.Entry<String, Map<String, AtomicLong>> entry
-        : cache.getCapacityRejectionMap().entrySet()) {
-      capacityRejectionSnapshot.put(entry.getKey(), cache.getCapacityRejectionsForResource(entry.getKey()));
-    }
-    // Clear rejection data for the next pipeline run
-    cache.clearCapacityRejections();
+    // Capture capacity rejection data from this pipeline run and clear for next run
+    final Map<String, Map<String, Long>> capacityRejectionSnapshot =
+        cache.getAndClearCapacityRejections();
 
     asyncExecute(cache.getAsyncTasksThreadPool(), () -> {
       try {
@@ -138,14 +132,14 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
                 externalViewMap.get(resourceName), stateModelDefMap.get(is.getStateModelDefRef()));
           }
 
-          // Report capacity rejection metrics for each resource
+          // Increment capacity rejection counters for each resource
           for (Map.Entry<String, Map<String, Long>> entry : capacityRejectionSnapshot.entrySet()) {
             String resourceName = entry.getKey();
             if (resourceConfigMap.containsKey(resourceName) && resourceConfigMap.get(resourceName)
                 .isMonitoringDisabled()) {
               continue;
             }
-            clusterStatusMonitor.updateMappingCapacityRejectionStats(resourceName, entry.getValue());
+            clusterStatusMonitor.incrementMappingCapacityRejectionCounters(resourceName, entry.getValue());
           }
         }
       } catch (Exception e) {

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import org.apache.helix.HelixDefinedState;
@@ -108,7 +109,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     final Map<String, ExternalView> externalViewMap = cache.getExternalViews();
     final Map<String, ResourceConfig> resourceConfigMap = cache.getResourceConfigMap();
     // Capture capacity rejection data from this pipeline run and clear for next run
-    final Map<String, Map<String, Long>> capacityRejectionSnapshot =
+    final Map<String, Map<String, AtomicLong>> capacityRejectionSnapshot =
         cache.getAndClearCapacityRejections();
 
     asyncExecute(cache.getAsyncTasksThreadPool(), () -> {
@@ -133,7 +134,8 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
           }
 
           // Increment capacity rejection counters for each resource
-          for (Map.Entry<String, Map<String, Long>> entry : capacityRejectionSnapshot.entrySet()) {
+          for (Map.Entry<String, Map<String, AtomicLong>> entry
+              : capacityRejectionSnapshot.entrySet()) {
             String resourceName = entry.getKey();
             if (resourceConfigMap.containsKey(resourceName) && resourceConfigMap.get(resourceName)
                 .isMonitoringDisabled()) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -748,23 +748,21 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   /**
-   * Updates the mapping capacity rejection stats for a resource.
+   * Increments the mapping capacity rejection counters for a resource.
    * This tracks how many times partitions of a resource were rejected by each instance
    * due to insufficient capacity during the mapping calculation phase.
+   * Counters are cumulative and always increase.
    *
    * @param resourceName The resource name
-   * @param instanceRejections Map of instance name to rejection count
+   * @param instanceRejections Map of instance name to rejection count to add
    */
-  public void updateMappingCapacityRejectionStats(String resourceName,
+  public void incrementMappingCapacityRejectionCounters(String resourceName,
       Map<String, Long> instanceRejections) {
     ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
 
     if (resourceMonitor != null) {
-      // Reset the stats first to clear old data
-      resourceMonitor.resetCapacityRejectionStats();
-      // Update with new rejection counts
       for (Map.Entry<String, Long> entry : instanceRejections.entrySet()) {
-        resourceMonitor.updateCapacityRejectionStats(entry.getKey(), entry.getValue());
+        resourceMonitor.incrementCapacityRejectionCounter(entry.getKey(), entry.getValue());
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -757,12 +757,12 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
    * @param instanceRejections Map of instance name to rejection count to add
    */
   public void incrementMappingCapacityRejectionCounters(String resourceName,
-      Map<String, Long> instanceRejections) {
+      Map<String, AtomicLong> instanceRejections) {
     ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
 
     if (resourceMonitor != null) {
-      for (Map.Entry<String, Long> entry : instanceRejections.entrySet()) {
-        resourceMonitor.incrementCapacityRejectionCounter(entry.getKey(), entry.getValue());
+      for (Map.Entry<String, AtomicLong> entry : instanceRejections.entrySet()) {
+        resourceMonitor.incrementCapacityRejectionCounter(entry.getKey(), entry.getValue().get());
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -747,6 +747,28 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
   }
 
+  /**
+   * Updates the mapping capacity rejection stats for a resource.
+   * This tracks how many times partitions of a resource were rejected by each instance
+   * due to insufficient capacity during the mapping calculation phase.
+   *
+   * @param resourceName The resource name
+   * @param instanceRejections Map of instance name to rejection count
+   */
+  public void updateMappingCapacityRejectionStats(String resourceName,
+      Map<String, Long> instanceRejections) {
+    ResourceMonitor resourceMonitor = getOrCreateResourceMonitor(resourceName);
+
+    if (resourceMonitor != null) {
+      // Reset the stats first to clear old data
+      resourceMonitor.resetCapacityRejectionStats();
+      // Update with new rejection counts
+      for (Map.Entry<String, Long> entry : instanceRejections.entrySet()) {
+        resourceMonitor.updateCapacityRejectionStats(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
   private ResourceMonitor getOrCreateResourceMonitor(String resourceName) {
     try {
       if (!_resourceMonitorMap.containsKey(resourceName)) {

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -51,7 +51,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   }
 
   private static final String GAUGE_METRIC_SUFFIX = "Gauge";
-  private static final String CAPACITY_REJECTION_METRIC_SUFFIX = "_MappingCapacityRejectionGauge";
+  private static final String CAPACITY_REJECTION_METRIC_SUFFIX = "_MappingCapacityRejectionCounter";
 
   // Gauges
   private SimpleDynamicMetric<Long> _numOfPartitions;
@@ -450,14 +450,18 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   }
 
   /**
-   * Updates the capacity rejection count for a specific instance.
+   * Increments the capacity rejection counter for a specific instance.
    * This tracks how many times partitions of this resource were rejected
    * by the specified instance due to insufficient capacity during mapping calculation.
+   * This is a cumulative counter that always increases.
    *
    * @param instanceName The instance that rejected the partition
-   * @param rejectionCount The number of rejections to record
+   * @param rejectionCount The number of rejections to add to the counter
    */
-  public void updateCapacityRejectionStats(String instanceName, long rejectionCount) {
+  public void incrementCapacityRejectionCounter(String instanceName, long rejectionCount) {
+    if (rejectionCount <= 0) {
+      return;
+    }
     synchronized (_instanceCapacityRejectionMap) {
       SimpleDynamicMetric<Long> metric = _instanceCapacityRejectionMap.get(instanceName);
       if (metric == null) {
@@ -467,19 +471,8 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         updateAttributesInfo(buildAttributeList(),
             "Resource monitor for resource: " + getResourceName());
       } else {
-        metric.updateValue(rejectionCount);
-      }
-    }
-  }
-
-  /**
-   * Resets all capacity rejection stats for this resource.
-   * Called at the start of each pipeline run to reset counters.
-   */
-  public void resetCapacityRejectionStats() {
-    synchronized (_instanceCapacityRejectionMap) {
-      for (SimpleDynamicMetric<Long> metric : _instanceCapacityRejectionMap.values()) {
-        metric.updateValue(0L);
+        // Increment the counter
+        metric.updateValue(metric.getValue() + rejectionCount);
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -471,7 +471,6 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         updateAttributesInfo(buildAttributeList(),
             "Resource monitor for resource: " + getResourceName());
       } else {
-        // Increment the counter
         metric.updateValue(metric.getValue() + rejectionCount);
       }
     }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ResourceMonitor.java
@@ -51,6 +51,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   }
 
   private static final String GAUGE_METRIC_SUFFIX = "Gauge";
+  private static final String CAPACITY_REJECTION_METRIC_SUFFIX = "_MappingCapacityRejectionGauge";
 
   // Gauges
   private SimpleDynamicMetric<Long> _numOfPartitions;
@@ -102,6 +103,10 @@ public class ResourceMonitor extends DynamicMBeanProvider {
   // A map of dynamic capacity Gauges. The map's keys could change.
   private final Map<String, SimpleDynamicMetric<Long>> _dynamicCapacityMetricsMap;
 
+  // A map of instance-level capacity rejection Gauges for this resource.
+  // Key: instance name, Value: rejection count gauge
+  private final Map<String, SimpleDynamicMetric<Long>> _instanceCapacityRejectionMap;
+
   @Override
   public DynamicMBeanProvider register() throws JMException {
     doRegister(buildAttributeList(), _initObjectName);
@@ -120,6 +125,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _resourceName = resourceName;
     _initObjectName = objectName;
     _dynamicCapacityMetricsMap = new ConcurrentHashMap<>();
+    _instanceCapacityRejectionMap = new ConcurrentHashMap<>();
 
     _externalViewIdealStateDiff = new SimpleDynamicMetric("DifferenceWithIdealStateGauge", 0L);
     _numPendingRecoveryRebalanceReplicas =
@@ -443,6 +449,52 @@ public class ResourceMonitor extends DynamicMBeanProvider {
     _rebalanceState.updateValue(state.name());
   }
 
+  /**
+   * Updates the capacity rejection count for a specific instance.
+   * This tracks how many times partitions of this resource were rejected
+   * by the specified instance due to insufficient capacity during mapping calculation.
+   *
+   * @param instanceName The instance that rejected the partition
+   * @param rejectionCount The number of rejections to record
+   */
+  public void updateCapacityRejectionStats(String instanceName, long rejectionCount) {
+    synchronized (_instanceCapacityRejectionMap) {
+      SimpleDynamicMetric<Long> metric = _instanceCapacityRejectionMap.get(instanceName);
+      if (metric == null) {
+        metric = new SimpleDynamicMetric<>(instanceName + CAPACITY_REJECTION_METRIC_SUFFIX, rejectionCount);
+        _instanceCapacityRejectionMap.put(instanceName, metric);
+        // Update MBean attributes since we added a new metric
+        updateAttributesInfo(buildAttributeList(),
+            "Resource monitor for resource: " + getResourceName());
+      } else {
+        metric.updateValue(rejectionCount);
+      }
+    }
+  }
+
+  /**
+   * Resets all capacity rejection stats for this resource.
+   * Called at the start of each pipeline run to reset counters.
+   */
+  public void resetCapacityRejectionStats() {
+    synchronized (_instanceCapacityRejectionMap) {
+      for (SimpleDynamicMetric<Long> metric : _instanceCapacityRejectionMap.values()) {
+        metric.updateValue(0L);
+      }
+    }
+  }
+
+  /**
+   * Gets the capacity rejection count for a specific instance.
+   *
+   * @param instanceName The instance name
+   * @return The rejection count, or 0 if no rejections recorded
+   */
+  public long getCapacityRejectionCount(String instanceName) {
+    SimpleDynamicMetric<Long> metric = _instanceCapacityRejectionMap.get(instanceName);
+    return metric != null ? metric.getValue() : 0L;
+  }
+
   public long getExternalViewPartitionGauge() {
     return _numOfPartitionsInExternalView.getValue();
   }
@@ -552,6 +604,7 @@ public class ResourceMonitor extends DynamicMBeanProvider {
         _rebalanceThrottledByErrorPartitionGauge);
 
     attributeList.addAll(_dynamicCapacityMetricsMap.values());
+    attributeList.addAll(_instanceCapacityRejectionMap.values());
 
     return attributeList;
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestResourceControllerDataProvider.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestResourceControllerDataProvider.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.helix.model.IdealState;
@@ -87,5 +88,27 @@ public class TestResourceControllerDataProvider {
     // Now, since the cache has been cleaned, the get will return different order.
     Assert.assertTrue(
         dataProvider.getStablePartitionList(resourceName) == null);
+  }
+
+  @Test
+  public void testCapacityRejectionTracking() {
+    ResourceControllerDataProvider dataProvider = new ResourceControllerDataProvider();
+
+    dataProvider.recordCapacityRejection("ResourceA", "Instance1");
+    dataProvider.recordCapacityRejection("ResourceA", "Instance1");
+    dataProvider.recordCapacityRejection("ResourceA", "Instance2");
+    dataProvider.recordCapacityRejection("ResourceB", "Instance1");
+
+    Map<String, Map<String, AtomicLong>> snapshot = dataProvider.getAndClearCapacityRejections();
+    Assert.assertEquals(snapshot.get("ResourceA").get("Instance1").get(), 2L);
+    Assert.assertEquals(snapshot.get("ResourceA").get("Instance2").get(), 1L);
+    Assert.assertEquals(snapshot.get("ResourceB").get("Instance1").get(), 1L);
+
+    // After clear, new rejections should not affect the previous snapshot.
+    dataProvider.recordCapacityRejection("ResourceA", "Instance1");
+    Assert.assertEquals(snapshot.get("ResourceA").get("Instance1").get(), 2L);
+
+    Map<String, Map<String, AtomicLong>> nextSnapshot = dataProvider.getAndClearCapacityRejections();
+    Assert.assertEquals(nextSnapshot.get("ResourceA").get("Instance1").get(), 1L);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestResourceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestResourceMonitor.java
@@ -248,6 +248,25 @@ public class TestResourceMonitor {
   }
 
   @Test
+  public void testCapacityRejectionCounter() throws JMException {
+    ResourceMonitor monitor =
+        new ResourceMonitor(_clusterName, _dbName, new ObjectName("testDomain:key=value2"));
+    monitor.register();
+
+    try {
+      monitor.incrementCapacityRejectionCounter("Instance_1", 2);
+      monitor.incrementCapacityRejectionCounter("Instance_1", 3);
+      monitor.incrementCapacityRejectionCounter("Instance_2", 1);
+
+      Assert.assertEquals(monitor.getCapacityRejectionCount("Instance_1"), 5L);
+      Assert.assertEquals(monitor.getCapacityRejectionCount("Instance_2"), 1L);
+      Assert.assertEquals(monitor.getCapacityRejectionCount("Instance_3"), 0L);
+    } finally {
+      monitor.unregister();
+    }
+  }
+
+  @Test
   public void testNoMetricsRecordedForNullOrDisabledIdealState() throws JMException {
     final int n = 5;
     ResourceMonitor monitor =


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

This PR adds a new metric MappingCapacityRejectionGauge to track capacity rejections that occur during the mapping calculation phase in the WAGED rebalancer. The metric provides visibility into which instances are rejecting partitions of specific resources due to insufficient capacity.

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

Currently, when the DelayedAutoRebalancer (MappingCalculator) rejects a partition assignment due to insufficient instance capacity, only an INFO log is printed:

`Instance: {} has no capacity to hold resource: {}, partition: {}, removing it from combinedPreferenceList.`

This makes it difficult to:
- Monitor capacity rejection rates in real-time
- Identify which resources are experiencing placement issues
- Identify which instances are capacity-constrained

hence a new metric to track the rejections.

### Tests
TBA
- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
