### PR TITLE
Fix ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK listField bleeding into IdealState during rebalance

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ResourceConfig.java
@@ -20,6 +20,7 @@ package org.apache.helix.model;
  */
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -280,6 +281,9 @@ public class ResourceConfig extends HelixProperty {
     return _record.getIntField(ResourceConfigProperty.MIN_ACTIVE_REPLICAS.name(), -1);
   }
 
+  // Delimiter used for storing active states as a comma-separated string in simpleField
+  private static final String ACTIVE_STATES_DELIMITER = ",";
+
   /**
    * Get the list of states that should be considered as "active" for min active replica check.
    * If not configured, the default behavior applies (all states except DROPPED, ERROR, and initial state).
@@ -290,7 +294,12 @@ public class ResourceConfig extends HelixProperty {
    * @return List of state names to be considered active, or null if not configured
    */
   public List<String> getActiveStatesForMinActiveReplicaCheck() {
-    return _record.getListField(ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name());
+    String statesStr = _record.getSimpleField(
+        ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name());
+    if (statesStr == null || statesStr.isEmpty()) {
+      return null;
+    }
+    return Arrays.asList(statesStr.split(ACTIVE_STATES_DELIMITER));
   }
 
   /**
@@ -309,10 +318,13 @@ public class ResourceConfig extends HelixProperty {
    * @param activeStates List of state names to be considered active, or null to use default behavior
    */
   public void setActiveStatesForMinActiveReplicaCheck(List<String> activeStates) {
-    if (activeStates == null) {
-      _record.getListFields().remove(ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name());
+    if (activeStates == null || activeStates.isEmpty()) {
+      _record.getSimpleFields().remove(
+          ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name());
     } else {
-      _record.setListField(ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name(), activeStates);
+      _record.setSimpleField(
+          ResourceConfigProperty.ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK.name(),
+          String.join(ACTIVE_STATES_DELIMITER, activeStates));
     }
   }
 


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

This PR fixes a bug where ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK configuration set in ResourceConfig was unintentionally being copied into IdealState during WAGED or any full auto rebalancer during rebalance operations.

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

When setting ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK as a listField in ResourceConfig:
```
{
  "listFields": {
    "ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK": ["LEADER", "STANDBY"]
  }
}
```
After a rebalance, the IdealState would incorrectly contain:
```
{
  "mapFields": {
    "ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK": {}  // empty map, this shouldn't exist
  },
  "listFields": {
    "ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK": ["LEADER", "STANDBY"],  // this shouldn't exist
    "TestDB_0": ["instance1", "instance2"],
    "TestDB_1": ["instance3", "instance4"]
  }
}
```

The bug was in ResourceConfig.getPreferenceLists() which returns all listFields:
```
public Map<String, List<String>> getPreferenceLists() {
    return _record.getListFields();  < - this one
}
```
its calld in two places(The flows I checked as of now):
1. WagedRebalancer.applyUserDefinedPreferenceList() -> applies all returned lists to IdealState
2. DelayedAutoRebalancer.computeNewIdealState() -> adds all to finalMapping

Both rebalancers treat every listField in ResourceConfig as a user-defined preference list, causing non-partition configs like ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK to bleed into IdealState.

As a solution, to avoid touching any rebalancer code, this PR changes the storage of _ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK_ from listField to simpleField (comma-separated string). Since `getPreferenceLists()` only returns listFields, this config is now excluded from preference list processing.
Before (listField):
```
{
  "listFields": {
    "ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK": ["LEADER", "STANDBY"]
  }
}
```
after:
```
{
  "simpleFields": {
    "ACTIVE_STATES_FOR_MIN_ACTIVE_REPLICA_CHECK": "LEADER,STANDBY"
  }
}
```

### Tests
Existing tests (They use the same getter and setter) + Local tests.
- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
