### PR TITLE
fix for hung future tasks during controller leader switch

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -111,7 +111,6 @@ import org.apache.helix.model.Message;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.monitoring.mbeans.ClusterEventMonitor;
 import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
-import org.apache.helix.util.StageThreadPoolHelper;
 import org.apache.helix.zookeeper.zkclient.exception.ZkInterruptedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1475,8 +1474,8 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     // shutdown async workers
     shutdownAsyncFIFOWorkers();
 
-    // shutdown shared stage thread pool
-    StageThreadPoolHelper.shutdown();
+    // NOTE: StageThreadPoolHelper is a JVM-wide shared pool. Do not shutdown here to avoid
+    // cross-cluster interference when a single controller shuts down.
 
     enableClusterStatusMonitor(false);
 

--- a/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
@@ -286,4 +286,5 @@ public class TestStageThreadPoolHelper {
     Assert.assertEquals(shortTaskCount.get(), 5, "All short tasks should complete");
     Assert.assertEquals(longTaskCount.get(), 3, "All long tasks should complete");
   }
+
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(Fixes hung tasks issue on controller leader change in a multi cluster environment)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- Avoid shutting down the JVM-wide stage thread pool during controller shutdown to prevent cross-cluster interference on leader change.
- Add a brief note in `GenericHelixController.shutdown()` documenting why the shared pool is not shut down here.
- No UI changes.

### Tests

- [ ] The following tests are written for this issue:

(None — change is shutdown behavior only; no new tests added)

- The following is the result of the "mvn test" command on the appropriate module:

- `mvn clean install -Dmaven.test.skip.exec=true` failed at `helix-rest` clean:
  - `Failed to delete /Users/vchekka/working/linoss/helix/helix-rest/target`

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(None)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(None)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)