### PR TITLE
Configurable Stage Thread Pool 

### DIFF
--- a/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
+++ b/helix-common/src/main/java/org/apache/helix/SystemPropertyKeys.java
@@ -94,4 +94,7 @@ public class SystemPropertyKeys {
   // Constraint-based algorithm ForkJoinPool parallelism
   public static final String CONSTRAINT_ALGORITHM_PARALLELISM =
       "helix.constraint.algorithm.parallelism";
+
+  // Stage thread pool size for parallel stage execution
+  public static final String STAGE_THREAD_POOL_SIZE = "helix.stage.threadpool.size";
 }

--- a/helix-core/src/main/java/org/apache/helix/util/StageThreadPoolHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StageThreadPoolHelper.java
@@ -17,18 +17,30 @@ import org.slf4j.LoggerFactory;
 public class StageThreadPoolHelper {
   private static final Logger LOG = LoggerFactory.getLogger(StageThreadPoolHelper.class);
 
+  private static final int MIN_POOL_SIZE = 1;
   private static final int DEFAULT_POOL_SIZE =
       Math.min(4, Runtime.getRuntime().availableProcessors());
   private static final long THREAD_KEEP_ALIVE_MIN = 3;
   private static final String THREAD_NAME_PREFIX = "HelixStageWorker";
 
   /**
-   * Get the configured pool size from system property, or fall back to default.
+   * Get the configured pool size from system property, bounded between MIN_POOL_SIZE
+   * and availableProcessors().
    * @return the pool size to use for the shared stage thread pool
    */
   private static int getPoolSize() {
-    return HelixUtil.getSystemPropertyAsInt(
+    int maxPoolSize = Runtime.getRuntime().availableProcessors();
+    int configuredSize = HelixUtil.getSystemPropertyAsInt(
         SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, DEFAULT_POOL_SIZE);
+
+    int boundedSize = Math.max(MIN_POOL_SIZE, Math.min(maxPoolSize, configuredSize));
+
+    if (boundedSize != configuredSize) {
+      LOG.warn("Configured pool size {} is out of bounds [{}, {}], using {}",
+          configuredSize, MIN_POOL_SIZE, maxPoolSize, boundedSize);
+    }
+
+    return boundedSize;
   }
 
   // Shared executor reused across all stages

--- a/helix-core/src/main/java/org/apache/helix/util/StageThreadPoolHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/util/StageThreadPoolHelper.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.helix.SystemPropertyKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +22,15 @@ public class StageThreadPoolHelper {
   private static final long THREAD_KEEP_ALIVE_MIN = 3;
   private static final String THREAD_NAME_PREFIX = "HelixStageWorker";
 
+  /**
+   * Get the configured pool size from system property, or fall back to default.
+   * @return the pool size to use for the shared stage thread pool
+   */
+  private static int getPoolSize() {
+    return HelixUtil.getSystemPropertyAsInt(
+        SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, DEFAULT_POOL_SIZE);
+  }
+
   // Shared executor reused across all stages
   private static final AtomicReference<ThreadPoolExecutor> EXECUTOR_REF = new AtomicReference<>();
 
@@ -36,6 +46,8 @@ public class StageThreadPoolHelper {
       return existing;
     }
 
+    int poolSize = getPoolSize();
+
     ThreadFactory threadFactory = new ThreadFactoryBuilder()
         .setNameFormat(THREAD_NAME_PREFIX + "-%d")
         .setDaemon(true)
@@ -44,8 +56,8 @@ public class StageThreadPoolHelper {
         .build();
 
     ThreadPoolExecutor executor = new ThreadPoolExecutor(
-        DEFAULT_POOL_SIZE,
-        DEFAULT_POOL_SIZE,
+        poolSize,
+        poolSize,
         THREAD_KEEP_ALIVE_MIN,
         TimeUnit.MINUTES,
         new LinkedBlockingQueue<>(),
@@ -54,7 +66,7 @@ public class StageThreadPoolHelper {
 
     executor.allowCoreThreadTimeOut(true);
     EXECUTOR_REF.set(executor);
-    LOG.info("Initialized shared stage parallel executor with {} threads", DEFAULT_POOL_SIZE);
+    LOG.info("Initialized shared stage parallel executor with {} threads", poolSize);
     return executor;
   }
 

--- a/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
@@ -292,7 +292,6 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testConfigurablePoolSize() throws InterruptedException {
-    // First ensure any existing pool is shut down
     StageThreadPoolHelper.shutdown();
 
     // Configure a custom pool size via system property
@@ -342,6 +341,47 @@ public class TestStageThreadPoolHelper {
           "Should use at most " + configuredPoolSize + " threads, but used " + uniqueThreadNames.size());
     } finally {
       // Clean up the system property
+      System.clearProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE);
+      StageThreadPoolHelper.shutdown();
+    }
+  }
+
+  @Test
+  public void testPoolSizeBounds() throws InterruptedException {
+    StageThreadPoolHelper.shutdown();
+
+    int availableProcessors = Runtime.getRuntime().availableProcessors();
+
+    // Test 1: Excessive pool size should be capped
+    System.setProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, String.valueOf(availableProcessors + 100));
+    try {
+      AtomicInteger counter = new AtomicInteger(0);
+      List<Callable<Void>> tasks = new ArrayList<>();
+      for (int i = 0; i < 5; i++) {
+        tasks.add(() -> {
+          counter.incrementAndGet();
+          return null;
+        });
+      }
+      StageThreadPoolHelper.executeAndWait("MaxBoundTest", tasks);
+      Assert.assertEquals(counter.get(), 5, "All tasks should execute even with excessive pool size config");
+    } finally {
+      System.clearProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE);
+      StageThreadPoolHelper.shutdown();
+    }
+
+    // Test 2: Zero pool size should fall back to default
+    System.setProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, "0");
+    try {
+      AtomicInteger counter = new AtomicInteger(0);
+      List<Callable<Void>> tasks = new ArrayList<>();
+      tasks.add(() -> {
+        counter.incrementAndGet();
+        return null;
+      });
+      StageThreadPoolHelper.executeAndWait("MinBoundTest", tasks);
+      Assert.assertEquals(counter.get(), 1, "Task should execute even with zero pool size config");
+    } finally {
       System.clearProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE);
       StageThreadPoolHelper.shutdown();
     }

--- a/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
@@ -22,10 +22,13 @@ package org.apache.helix.util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.helix.SystemPropertyKeys;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -285,6 +288,63 @@ public class TestStageThreadPoolHelper {
 
     Assert.assertEquals(shortTaskCount.get(), 5, "All short tasks should complete");
     Assert.assertEquals(longTaskCount.get(), 3, "All long tasks should complete");
+  }
+
+  @Test
+  public void testConfigurablePoolSize() throws InterruptedException {
+    // First ensure any existing pool is shut down
+    StageThreadPoolHelper.shutdown();
+
+    // Configure a custom pool size via system property
+    int configuredPoolSize = 2;
+    System.setProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, String.valueOf(configuredPoolSize));
+
+    try {
+      // Track unique thread names to verify pool size
+      Set<String> uniqueThreadNames = ConcurrentHashMap.newKeySet();
+      CountDownLatch allTasksStarted = new CountDownLatch(configuredPoolSize + 2);
+      CountDownLatch releaseTasksLatch = new CountDownLatch(1);
+      List<Callable<Void>> tasks = new ArrayList<>();
+
+      // Create more tasks than pool size to test that pool size limits concurrent execution
+      for (int i = 0; i < configuredPoolSize + 2; i++) {
+        tasks.add(() -> {
+          uniqueThreadNames.add(Thread.currentThread().getName());
+          allTasksStarted.countDown();
+          // Hold the thread to observe concurrency
+          releaseTasksLatch.await(5, TimeUnit.SECONDS);
+          return null;
+        });
+      }
+
+      // Execute in a separate thread so we can check concurrency
+      Thread executorThread = new Thread(() -> {
+        try {
+          StageThreadPoolHelper.executeAndWait("ConfigPoolTest", tasks);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      });
+      executorThread.start();
+
+      // Wait a bit for tasks to start
+      TimeUnit.MILLISECONDS.sleep(200);
+
+      // With pool size of 2, at most 2 threads should be executing concurrently
+      // The remaining tasks should be queued
+      // Release all tasks
+      releaseTasksLatch.countDown();
+      executorThread.join(5000);
+
+      // Verify that the configured pool size was used
+      // The number of unique threads should be at most the configured pool size
+      Assert.assertTrue(uniqueThreadNames.size() <= configuredPoolSize,
+          "Should use at most " + configuredPoolSize + " threads, but used " + uniqueThreadNames.size());
+    } finally {
+      // Clean up the system property
+      System.clearProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE);
+      StageThreadPoolHelper.shutdown();
+    }
   }
 
 }

--- a/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
@@ -292,8 +292,6 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testConfigurablePoolSize() throws InterruptedException {
-    StageThreadPoolHelper.shutdown();
-
     // Configure a custom pool size via system property
     int configuredPoolSize = 2;
     System.setProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, String.valueOf(configuredPoolSize));
@@ -348,8 +346,6 @@ public class TestStageThreadPoolHelper {
 
   @Test
   public void testPoolSizeBounds() throws InterruptedException {
-    StageThreadPoolHelper.shutdown();
-
     int availableProcessors = Runtime.getRuntime().availableProcessors();
 
     // Test 1: Excessive pool size should be capped

--- a/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestStageThreadPoolHelper.java
@@ -38,6 +38,7 @@ public class TestStageThreadPoolHelper {
   @AfterMethod
   public void afterMethod() {
     // Clean up after each test
+    System.clearProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE);
     StageThreadPoolHelper.shutdown();
   }
 
@@ -296,91 +297,79 @@ public class TestStageThreadPoolHelper {
     int configuredPoolSize = 2;
     System.setProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, String.valueOf(configuredPoolSize));
 
-    try {
-      // Track unique thread names to verify pool size
-      Set<String> uniqueThreadNames = ConcurrentHashMap.newKeySet();
-      CountDownLatch allTasksStarted = new CountDownLatch(configuredPoolSize + 2);
-      CountDownLatch releaseTasksLatch = new CountDownLatch(1);
-      List<Callable<Void>> tasks = new ArrayList<>();
+    // Track unique thread names to verify pool size
+    Set<String> uniqueThreadNames = ConcurrentHashMap.newKeySet();
+    CountDownLatch allTasksStarted = new CountDownLatch(configuredPoolSize + 2);
+    CountDownLatch releaseTasksLatch = new CountDownLatch(1);
+    List<Callable<Void>> tasks = new ArrayList<>();
 
-      // Create more tasks than pool size to test that pool size limits concurrent execution
-      for (int i = 0; i < configuredPoolSize + 2; i++) {
-        tasks.add(() -> {
-          uniqueThreadNames.add(Thread.currentThread().getName());
-          allTasksStarted.countDown();
-          // Hold the thread to observe concurrency
-          releaseTasksLatch.await(5, TimeUnit.SECONDS);
-          return null;
-        });
-      }
-
-      // Execute in a separate thread so we can check concurrency
-      Thread executorThread = new Thread(() -> {
-        try {
-          StageThreadPoolHelper.executeAndWait("ConfigPoolTest", tasks);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
+    // Create more tasks than pool size to test that pool size limits concurrent execution
+    for (int i = 0; i < configuredPoolSize + 2; i++) {
+      tasks.add(() -> {
+        uniqueThreadNames.add(Thread.currentThread().getName());
+        allTasksStarted.countDown();
+        // Hold the thread to observe concurrency
+        releaseTasksLatch.await(5, TimeUnit.SECONDS);
+        return null;
       });
-      executorThread.start();
-
-      // Wait a bit for tasks to start
-      TimeUnit.MILLISECONDS.sleep(200);
-
-      // With pool size of 2, at most 2 threads should be executing concurrently
-      // The remaining tasks should be queued
-      // Release all tasks
-      releaseTasksLatch.countDown();
-      executorThread.join(5000);
-
-      // Verify that the configured pool size was used
-      // The number of unique threads should be at most the configured pool size
-      Assert.assertTrue(uniqueThreadNames.size() <= configuredPoolSize,
-          "Should use at most " + configuredPoolSize + " threads, but used " + uniqueThreadNames.size());
-    } finally {
-      // Clean up the system property
-      System.clearProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE);
-      StageThreadPoolHelper.shutdown();
     }
+
+    // Execute in a separate thread so we can check concurrency
+    Thread executorThread = new Thread(() -> {
+      try {
+        StageThreadPoolHelper.executeAndWait("ConfigPoolTest", tasks);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    executorThread.start();
+
+    // Wait a bit for tasks to start
+    TimeUnit.MILLISECONDS.sleep(200);
+
+    // With pool size of 2, at most 2 threads should be executing concurrently
+    // The remaining tasks should be queued
+    // Release all tasks
+    releaseTasksLatch.countDown();
+    executorThread.join(5000);
+
+    // Verify that the configured pool size was used
+    // The number of unique threads should be at most the configured pool size
+    Assert.assertTrue(uniqueThreadNames.size() <= configuredPoolSize,
+        "Should use at most " + configuredPoolSize + " threads, but used " + uniqueThreadNames.size());
   }
 
   @Test
-  public void testPoolSizeBounds() throws InterruptedException {
+  public void testExcessivePoolSizeCapped() throws InterruptedException {
+    // Excessive pool size should be capped
     int availableProcessors = Runtime.getRuntime().availableProcessors();
-
-    // Test 1: Excessive pool size should be capped
     System.setProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, String.valueOf(availableProcessors + 100));
-    try {
-      AtomicInteger counter = new AtomicInteger(0);
-      List<Callable<Void>> tasks = new ArrayList<>();
-      for (int i = 0; i < 5; i++) {
-        tasks.add(() -> {
-          counter.incrementAndGet();
-          return null;
-        });
-      }
-      StageThreadPoolHelper.executeAndWait("MaxBoundTest", tasks);
-      Assert.assertEquals(counter.get(), 5, "All tasks should execute even with excessive pool size config");
-    } finally {
-      System.clearProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE);
-      StageThreadPoolHelper.shutdown();
-    }
 
-    // Test 2: Zero pool size should fall back to default
-    System.setProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, "0");
-    try {
-      AtomicInteger counter = new AtomicInteger(0);
-      List<Callable<Void>> tasks = new ArrayList<>();
+    AtomicInteger counter = new AtomicInteger(0);
+    List<Callable<Void>> tasks = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
       tasks.add(() -> {
         counter.incrementAndGet();
         return null;
       });
-      StageThreadPoolHelper.executeAndWait("MinBoundTest", tasks);
-      Assert.assertEquals(counter.get(), 1, "Task should execute even with zero pool size config");
-    } finally {
-      System.clearProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE);
-      StageThreadPoolHelper.shutdown();
     }
+    StageThreadPoolHelper.executeAndWait("MaxBoundTest", tasks);
+    Assert.assertEquals(counter.get(), 5, "All tasks should execute even with excessive pool size config");
+  }
+
+  @Test
+  public void testZeroPoolSizeFallback() throws InterruptedException {
+    // Zero pool size should fall back to default
+    System.setProperty(SystemPropertyKeys.STAGE_THREAD_POOL_SIZE, "0");
+
+    AtomicInteger counter = new AtomicInteger(0);
+    List<Callable<Void>> tasks = new ArrayList<>();
+    tasks.add(() -> {
+      counter.incrementAndGet();
+      return null;
+    });
+    StageThreadPoolHelper.executeAndWait("MinBoundTest", tasks);
+    Assert.assertEquals(counter.get(), 1, "Task should execute even with zero pool size config");
   }
 
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Add configurable thread pool size for Helix controller stage execution

### Description

What 

- Add a new system property helix.stage.threadpool.size to configure the shared thread pool size used for parallel stage execution in StageThreadPoolHelper
- Add min/max bounds validation to prevent misconfiguration

Why:

- Different deployments have varying hardware and workload characteristics. A configurable pool size allows operators to tune parallelism based on their specific environment.
- Without bounds validation, users could misconfigure the pool with excessive values (causing resource exhaustion) or invalid values (causing unexpected behavior).

How:

- Added new system property helix.stage.threadpool.size in SystemPropertyKeys
- StageThreadPoolHelper.getPoolSize() reads the property and applies bounds:
  - Minimum: 1 thread
  - Maximum: availableProcessors() (optimal for CPU-bound stage execution)
  - Default: Math.min(4, availableProcessors()) when property is not set
  - Logs a warning when configured value is out of bounds


Thread Pool Size Behavior

```
Not set → Defaults to min(4, availableProcessors)

Set to 2 → Uses 2 threads

Set to 0 → Falls back to default

Set to 100 (on 8 cores) → Capped at 8 threads (warning logged)
```

### Tests

- TestStageThreadPoolHelper.testConfigurablePoolSize - Verifies that the pool size can be configured via system property and limits concurrent thread execution accordingly
- TestStageThreadPoolHelper.testPoolSizeBounds - Verifies that:
 Tasks execute correctly when pool size exceeds availableProcessors() (capped)
 Tasks execute correctly when pool size is zero (falls back to default)

