### PR TITLE
Availability Aware Priortization - Part 2 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/intermediate/AvailabilityAwareOrderingStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/intermediate/AvailabilityAwareOrderingStrategy.java
@@ -1,0 +1,238 @@
+package org.apache.helix.controller.stages.intermediate;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.controller.stages.StateTransitionHelper;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.Message;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.StateModelDefinition;
+
+/**
+ * Message ordering strategy that prioritizes messages based on their availability impact.
+ * Sorts messages cross-resource based on availability scores to prioritize partitions
+ * with fewer active replicas over those closer to their target replica count.
+ */
+public class AvailabilityAwareOrderingStrategy implements MessageOrderingStrategy {
+  private static final double TOP_STATE_MISSING_IMPACT = Double.MAX_VALUE;
+  private static final double TOP_STATE_HANDOFF_IMPACT = Double.MAX_VALUE - 1;
+
+  private final ResourceControllerDataProvider cache;
+  private final CurrentStateOutput currentStateOutput;
+  private String eventId;
+
+  public AvailabilityAwareOrderingStrategy(ResourceControllerDataProvider cache,
+      CurrentStateOutput currentStateOutput) {
+    this.cache = cache;
+    this.currentStateOutput = currentStateOutput;
+  }
+
+  public void setEventId(String eventId) {
+    this.eventId = eventId;
+  }
+
+  @Override
+  public void sortMessages(List<MessageContext> messages) {
+    // Create fresh caches for this sort operation
+    Map<String, Double> impactCache = new HashMap<>();
+    Map<String, Integer> activeReplicasCache = new HashMap<>();
+    Map<String, Integer> pendingMessageCountCache = new HashMap<>();
+    Map<String, Integer> messageIndexTracker = new HashMap<>();
+
+    messages.sort((m1, m2) -> {
+      double score1 = computeAvailabilityImpact(m1.message, impactCache, activeReplicasCache,
+          pendingMessageCountCache, messageIndexTracker);
+      double score2 = computeAvailabilityImpact(m2.message, impactCache, activeReplicasCache,
+          pendingMessageCountCache, messageIndexTracker);
+
+      // Higher score = higher priority (reverse order)
+      int delta = Double.compare(score2, score1);
+      if (delta != 0) {
+        return delta;
+      }
+
+      // Stable tiebreaking: resource name, then partition name
+      int resourceCompare = m1.resourceName.compareTo(m2.resourceName);
+      if (resourceCompare != 0) {
+        return resourceCompare;
+      }
+      return m1.partition.getPartitionName().compareTo(m2.partition.getPartitionName());
+    });
+  }
+
+  /**
+   * Compute availability impact score for a message.
+   * Higher score = higher priority (more urgent for availability).
+   */
+  private double computeAvailabilityImpact(Message message,
+      Map<String, Double> impactCache,
+      Map<String, Integer> activeReplicasCache,
+      Map<String, Integer> pendingMessageCountCache,
+      Map<String, Integer> messageIndexTracker) {
+
+    String key = cacheKey(message);
+    if (impactCache.containsKey(key)) {
+      return impactCache.get(key);
+    }
+
+    IdealState idealState = cache.getIdealState(message.getResourceName());
+    if (idealState == null) {
+      return cacheImpact(key, 0.0, impactCache);
+    }
+
+    StateModelDefinition stateModelDef = cache.getStateModelDef(idealState.getStateModelDefRef());
+    if (stateModelDef == null) {
+      return cacheImpact(key, 0.0, impactCache);
+    }
+
+    String topState = stateModelDef.getTopState();
+
+    // Highest priority: Missing top state replica (partition unavailable)
+    boolean missingTopState = StateTransitionHelper.isPartitionMissingTopState(
+        message.getResourceName(), message.getPartitionName(), topState, currentStateOutput);
+    if (missingTopState && message.getToState().equals(topState)) {
+      return cacheImpact(key, TOP_STATE_MISSING_IMPACT, impactCache);
+    }
+
+    // Second highest priority: Top state handoff (minimize unavailability window)
+    if (StateTransitionHelper.isTopStateHandoff(
+        message.getFromState(), message.getToState(), topState, stateModelDef)) {
+      return cacheImpact(key, TOP_STATE_HANDOFF_IMPACT, impactCache);
+    }
+
+    // Only prioritize upward transitions (bringing replicas online)
+    if (!StateTransitionHelper.isUpwardTransition(
+        message.getFromState(), message.getToState(), stateModelDef)) {
+      return cacheImpact(key, 0.0, impactCache);
+    }
+
+    // Compute impact based on current active replicas and min active threshold
+    double impact = computeUpwardImpact(message, idealState, activeReplicasCache,
+        pendingMessageCountCache, messageIndexTracker);
+    return cacheImpact(key, impact, impactCache);
+  }
+
+  /**
+   * Compute impact score for upward transitions.
+   * Score is higher when current active count is below min active replicas.
+   */
+  private double computeUpwardImpact(Message message, IdealState idealState,
+      Map<String, Integer> activeReplicasCache,
+      Map<String, Integer> pendingMessageCountCache,
+      Map<String, Integer> messageIndexTracker) {
+
+    String resource = message.getResourceName();
+    String partition = message.getPartitionName();
+    String partitionKey = resource + ":" + partition;
+
+    int minActive = idealState.getMinActiveReplicas();
+    int currentActive = getCurrentActiveReplicas(resource, partition, activeReplicasCache);
+    int pending = getPendingMessages(resource, partition, pendingMessageCountCache);
+
+    // Track message index for this partition to account for multiple messages
+    int index = messageIndexTracker.getOrDefault(partitionKey, 0);
+    messageIndexTracker.put(partitionKey, index + 1);
+
+    int effectiveCount = currentActive + pending + index;
+
+    // When minActiveReplicas is not configured, use base impact scaled by current active count
+    if (minActive == 0) {
+      return 1.0 / (effectiveCount + 1);
+    }
+
+    // Impact is inversely proportional to how close we are to min active threshold
+    return (double) minActive / (effectiveCount + 1);
+  }
+
+  /**
+   * Count current active replicas for a partition.
+   */
+  private int getCurrentActiveReplicas(String resource, String partition,
+      Map<String, Integer> activeReplicasCache) {
+
+    String key = resource + ":" + partition;
+    if (activeReplicasCache.containsKey(key)) {
+      return activeReplicasCache.get(key);
+    }
+
+    Map<String, String> currentStates =
+        currentStateOutput.getCurrentStateMap(resource, new Partition(partition));
+    int count = (currentStates == null) ? 0 :
+        (int) currentStates.values().stream()
+            .filter(StateTransitionHelper::isActiveState)
+            .count();
+
+    activeReplicasCache.put(key, count);
+    return count;
+  }
+
+  /**
+   * Count pending upward transition messages for a partition.
+   */
+  private int getPendingMessages(String resource, String partition,
+      Map<String, Integer> pendingMessageCountCache) {
+
+    String key = resource + ":" + partition;
+    if (pendingMessageCountCache.containsKey(key)) {
+      return pendingMessageCountCache.get(key);
+    }
+
+    int count = 0;
+    Map<String, Message> pendingMsgs =
+        currentStateOutput.getPendingMessageMap(resource, new Partition(partition));
+
+    if (pendingMsgs != null && !pendingMsgs.isEmpty()) {
+      IdealState idealState = cache.getIdealState(resource);
+      if (idealState != null) {
+        StateModelDefinition stateModelDef =
+            cache.getStateModelDef(idealState.getStateModelDefRef());
+        if (stateModelDef != null) {
+          count = (int) pendingMsgs.values().stream()
+              .filter(msg -> StateTransitionHelper.isUpwardTransition(
+                  msg.getFromState(), msg.getToState(), stateModelDef))
+              .count();
+        }
+      }
+    }
+
+    pendingMessageCountCache.put(key, count);
+    return count;
+  }
+
+  private double cacheImpact(String key, double impact, Map<String, Double> impactCache) {
+    impactCache.put(key, impact);
+    return impact;
+  }
+
+  private String cacheKey(Message message) {
+    return String.join(":",
+        message.getResourceName(),
+        message.getPartitionName(),
+        message.getFromState(),
+        message.getToState(),
+        message.getTgtName());
+  }
+}
+

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/intermediate/MessageOrderingStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/intermediate/MessageOrderingStrategy.java
@@ -1,0 +1,61 @@
+package org.apache.helix.controller.stages.intermediate;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+/**
+ * Strategy interface for ordering messages before throttling.
+ * Different implementations can provide different prioritization schemes
+ * (e.g., availability-aware vs. resource-priority based).
+ */
+public interface MessageOrderingStrategy {
+  /**
+   * Sort the given list of message contexts in-place according to the strategy's
+   * prioritization logic.
+   *
+   * @param messages List of message contexts to sort (will be modified in-place)
+   */
+  void sortMessages(List<MessageContext> messages);
+
+  /**
+   * Data class to encapsulate message with its context for ordering decisions.
+   */
+  class MessageContext {
+    public final org.apache.helix.model.Message message;
+    public final org.apache.helix.model.Partition partition;
+    public final String resourceName;
+    public final org.apache.helix.model.StateModelDefinition stateModelDef;
+    public final java.util.Map<String, Integer> requiredStates;
+
+    public MessageContext(org.apache.helix.model.Message message,
+        org.apache.helix.model.Partition partition,
+        String resourceName,
+        org.apache.helix.model.StateModelDefinition stateModelDef,
+        java.util.Map<String, Integer> requiredStates) {
+      this.message = message;
+      this.partition = partition;
+      this.resourceName = resourceName;
+      this.stateModelDef = stateModelDef;
+      this.requiredStates = requiredStates;
+    }
+  }
+}
+

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/intermediate/ResourcePriorityOrderingStrategy.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/intermediate/ResourcePriorityOrderingStrategy.java
@@ -1,0 +1,230 @@
+package org.apache.helix.controller.stages.intermediate;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.controller.common.PartitionStateMap;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.stages.BestPossibleStateOutput;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.Partition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message ordering strategy that prioritizes messages based on:
+ * 1. Resource priority (from configuration)
+ * 2. Partition priority (missing top state, active replicas, ideal matches)
+ * 3. Message priority (state priority, preference order)
+ */
+public class ResourcePriorityOrderingStrategy implements MessageOrderingStrategy {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ResourcePriorityOrderingStrategy.class.getName());
+
+  private final ResourceControllerDataProvider cache;
+  private final BestPossibleStateOutput bestPossibleStateOutput;
+  private final CurrentStateOutput currentStateOutput;
+
+  public ResourcePriorityOrderingStrategy(ResourceControllerDataProvider cache,
+      BestPossibleStateOutput bestPossibleStateOutput,
+      CurrentStateOutput currentStateOutput) {
+    this.cache = cache;
+    this.bestPossibleStateOutput = bestPossibleStateOutput;
+    this.currentStateOutput = currentStateOutput;
+  }
+
+  @Override
+  public void sortMessages(List<MessageContext> messages) {
+    // Build resource priority and insertion-order index for stable tiebreaking
+    Map<String, int[]> resourcePriorityMap = buildResourcePriorityMap(messages);
+
+    // Build partition priority scores per resource
+    Map<String, Map<String, int[]>> partitionPriorityScores = buildPartitionPriorityScores(messages);
+
+    messages.sort((m1, m2) -> {
+      // 1. Resource priority (higher value = higher priority, so reverse)
+      int[] rp1 = resourcePriorityMap.getOrDefault(m1.resourceName, new int[]{Integer.MIN_VALUE, 0});
+      int[] rp2 = resourcePriorityMap.getOrDefault(m2.resourceName, new int[]{Integer.MIN_VALUE, 0});
+      if (rp1[0] != rp2[0]) {
+        return Integer.compare(rp2[0], rp1[0]);
+      }
+      // Stable tiebreak: preserve original iteration order for equal priorities
+      if (rp1[1] != rp2[1]) {
+        return Integer.compare(rp1[1], rp2[1]);
+      }
+
+      // 2. Within same resource: partition priority
+      int[] pp1 = getPartitionScore(partitionPriorityScores, m1);
+      int[] pp2 = getPartitionScore(partitionPriorityScores, m2);
+      for (int i = 0; i < pp1.length; i++) {
+        if (pp1[i] != pp2[i]) {
+          return Integer.compare(pp1[i], pp2[i]);
+        }
+      }
+
+      // 3. Within same partition: message priority (state priority, preference order)
+      return compareMessagePriority(m1, m2);
+    });
+  }
+
+  /**
+   * Builds resource priority map: resource -> [priority, insertionOrder].
+   * The insertion order preserves the original resource map iteration order
+   * for stable tiebreaking when priorities are equal.
+   */
+  private Map<String, int[]> buildResourcePriorityMap(List<MessageContext> messages) {
+    Map<String, int[]> priorityMap = new HashMap<>();
+    String priorityField = cache.getClusterConfig().getResourcePriorityField();
+
+    // Capture iteration order from the messages (which follows resourceMap order)
+    int index = 0;
+    for (MessageContext ctx : messages) {
+      if (!priorityMap.containsKey(ctx.resourceName)) {
+        priorityMap.put(ctx.resourceName, new int[]{Integer.MIN_VALUE, index++});
+      }
+    }
+
+    if (priorityField == null) {
+      return priorityMap;
+    }
+
+    for (Map.Entry<String, int[]> entry : priorityMap.entrySet()) {
+      String resourceName = entry.getKey();
+      String priority = null;
+      if (cache.getResourceConfig(resourceName) != null) {
+        priority = cache.getResourceConfig(resourceName).getSimpleConfig(priorityField);
+      }
+      if (priority == null) {
+        IdealState is = cache.getIdealState(resourceName);
+        if (is != null) {
+          priority = is.getRecord().getSimpleField(priorityField);
+        }
+      }
+      if (priority != null) {
+        try {
+          entry.getValue()[0] = Integer.parseInt(priority);
+        } catch (NumberFormatException e) {
+          logger.warn("Invalid priority '{}' for resource {}", priority, resourceName);
+        }
+      }
+    }
+    return priorityMap;
+  }
+
+  /**
+   * Builds partition priority scores for sorting.
+   * Returns {resource -> {partition -> [missingTopState, activeReplicas, idealMatches]}}.
+   */
+  private Map<String, Map<String, int[]>> buildPartitionPriorityScores(
+      List<MessageContext> messages) {
+
+    Map<String, Map<String, int[]>> scores = new HashMap<>();
+
+    for (MessageContext ctx : messages) {
+      String key = ctx.resourceName;
+      scores.computeIfAbsent(key, k -> {
+        Map<String, int[]> partScores = new HashMap<>();
+        PartitionStateMap bestPossibleState =
+            bestPossibleStateOutput.getPartitionStateMap(ctx.resourceName);
+        Map<Partition, Map<String, String>> currentStates =
+            currentStateOutput.getCurrentStateMap(ctx.resourceName);
+        String topState = ctx.stateModelDef != null ? ctx.stateModelDef.getTopState() : null;
+
+        if (bestPossibleState != null && currentStates != null && topState != null) {
+          for (Map.Entry<Partition, Map<String, String>> e : bestPossibleState.getStateMap().entrySet()) {
+            Partition p = e.getKey();
+            Map<String, String> bpMap = e.getValue();
+            Map<String, String> csMap = currentStates.getOrDefault(p, Collections.emptyMap());
+
+            int missingTop = csMap.containsValue(topState) ? 1 : 0;
+            int active = countActiveReplicas(bpMap, csMap);
+            int matched = countIdealMatches(bpMap, csMap);
+            partScores.put(p.getPartitionName(), new int[]{missingTop, active, matched});
+          }
+        }
+        return partScores;
+      });
+    }
+    return scores;
+  }
+
+  private int[] getPartitionScore(Map<String, Map<String, int[]>> scores, MessageContext ctx) {
+    Map<String, int[]> resourceScores = scores.get(ctx.resourceName);
+    if (resourceScores != null) {
+      int[] score = resourceScores.get(ctx.partition.getPartitionName());
+      if (score != null) {
+        return score;
+      }
+    }
+    return new int[]{0, 0, 0};
+  }
+
+  private int compareMessagePriority(MessageContext m1, MessageContext m2) {
+    // Compare by state priority (lower number = higher priority)
+    if (m1.stateModelDef != null && !m1.message.getToState().equals(m2.message.getToState())) {
+      Map<String, Integer> statePriorityMap = m1.stateModelDef.getStatePriorityMap();
+      Integer p1 = statePriorityMap.get(m1.message.getToState());
+      Integer p2 = statePriorityMap.get(m2.message.getToState());
+      if (p1 != null && p2 != null && !p1.equals(p2)) {
+        return p1.compareTo(p2);
+      }
+    }
+
+    // Deterministic fallback
+    int partCmp = m1.partition.getPartitionName().compareTo(m2.partition.getPartitionName());
+    if (partCmp != 0) {
+      return partCmp;
+    }
+    return m1.message.getTgtName().compareTo(m2.message.getTgtName());
+  }
+
+  private int countActiveReplicas(Map<String, String> bestPossible,
+      Map<String, String> currentState) {
+    Map<String, Integer> stateCount = new HashMap<>();
+    for (String state : bestPossible.values()) {
+      stateCount.merge(state, 1, Integer::sum);
+    }
+
+    int count = 0;
+    for (String state : currentState.values()) {
+      if (stateCount.containsKey(state) && stateCount.get(state) > 0) {
+        count++;
+        stateCount.put(state, stateCount.get(state) - 1);
+      }
+    }
+    return count;
+  }
+
+  private int countIdealMatches(Map<String, String> bestPossible,
+      Map<String, String> currentState) {
+    int matches = 0;
+    for (Map.Entry<String, String> entry : bestPossible.entrySet()) {
+      if (entry.getValue().equals(currentState.get(entry.getKey()))) {
+        matches++;
+      }
+    }
+    return matches;
+  }
+}
+


### PR DESCRIPTION
### Issues
This PR introduces availability-aware cross-resource prioritization for state transitions in the Helix controller's intermediate state calculation stage.

### Description

Part - 1 :  https://github.com/linkedin/helix/pull/117/changes

Changes in this PR
---------------------
1. [AvailabilityAwareMessageComparator.java‎](https://github.com/linkedin/helix/pull/117/changes#diff-5d75bbd973719c8a76ea1c00539d6f5e5cdacad3cfd8747763db189d2996eaed) - merged with AvailabilityAwareOrderingStrategy
2. Refactoring Intermediate State Change File : Extracted out the existing resource priortization as separate strategy.

#TODO in next PR.

- [AvailabilityAwareOrderingStrategy.java‎](https://github.com/linkedin/helix/pull/118/changes#diff-31be7688911121505753722cf8e28819a76fa7bb76c6cf825f3084f8ff94861b) - Remove this file, once part 1 is reviewed 
- Add unit tests for this. Not added to reduce the PR volume.

### Note For Reviewers
- No test added to control the volume of PR.
- Will raise separate PR for the tests
