### PR TITLE
Rebalancing Fix : Handle All Nodes Disabled Case 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -471,7 +471,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     for (Resource resource : wagedRebalancedResourceMap.values()) {
       IdealState is = newIdealStates.get(resource.getResourceName());
       // Check if the WAGED rebalancer has calculated the result for this resource or not.
-      if (is != null && checkBestPossibleStateCalculation(is)) {
+      if (is != null && checkBestPossibleStateCalculation(is, resource, currentStateOutput)) {
         // The WAGED rebalancer calculates a valid result, record in the output
         updateBestPossibleStateOutput(output, resource, is);
       } else {
@@ -540,7 +540,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
             rebalancer.computeNewIdealState(resourceName, idealState, currentStateOutput, cache);
 
         // Check if calculation is done successfully
-        if (!checkBestPossibleStateCalculation(idealState)) {
+        if (!checkBestPossibleStateCalculation(idealState, resource, currentStateOutput)) {
           LogUtil.logWarn(logger, _eventId,
               "The calculated idealState is not valid, resource: " + resourceName);
           return false;
@@ -577,13 +577,16 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     return false;
   }
 
-  private boolean checkBestPossibleStateCalculation(IdealState idealState) {
+  private boolean checkBestPossibleStateCalculation(IdealState idealState, Resource resource,
+      CurrentStateOutput currentStateOutput) {
     // If replicas is 0, indicate the resource is not fully initialized or ready to be rebalanced
     if (idealState.getRebalanceMode() == IdealState.RebalanceMode.FULL_AUTO && !idealState
         .getReplicas().equals("0")) {
       Map<String, List<String>> preferenceLists = idealState.getPreferenceLists();
       if (preferenceLists == null || preferenceLists.isEmpty()) {
-        return false;
+        // Empty preference lists: allow only when there are existing replicas to clean up
+        // (e.g., all nodes disabled). Reject when resource is not initialized (no current state).
+        return hasCurrentStateForResource(resource, currentStateOutput);
       }
       int emptyListCount = 0;
       for (List<String> preferenceList : preferenceLists.values()) {
@@ -591,12 +594,37 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
           emptyListCount++;
         }
       }
-      // If all lists are empty, rebalance fails completely
-      return emptyListCount != preferenceLists.values().size();
+      if (emptyListCount == preferenceLists.values().size()) {
+        // All lists empty: allow only when there are replicas to clean up (all nodes disabled).
+        return hasCurrentStateForResource(resource, currentStateOutput);
+      }
+      // Some but not all lists empty: inconsistent state, reject.
+      return emptyListCount == 0;
     } else {
       // For non FULL_AUTO RebalanceMode, rebalancing is not controlled by Helix
       return true;
     }
+  }
+
+  /**
+   * Returns true if the resource has at least one partition with existing replicas in current state.
+   * Used to distinguish "all nodes disabled" (replicas exist, need cleanup) from "resource not
+   * initialized" (no replicas, should skip).
+   */
+private boolean hasCurrentStateForResource(Resource resource,
+      CurrentStateOutput currentStateOutput) {
+    if (currentStateOutput == null) {
+      return false;
+    }
+    String resourceName = resource.getResourceName();
+    for (Partition partition : resource.getPartitions()) {
+      Map<String, String> currentStateMap =
+          currentStateOutput.getCurrentStateMap(resourceName, partition);
+      if (currentStateMap != null && !currentStateMap.isEmpty()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private Rebalancer<ResourceControllerDataProvider> getCustomizedRebalancer(

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -585,7 +585,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
       // getPreferenceLists() always returns an initialized map (never null) since ZNRecord
       // initializes listFields as a TreeMap. A null result would indicate a programming error.
       Map<String, List<String>> preferenceLists = idealState.getPreferenceLists();
-      if (preferenceLists.isEmpty()) {
+      if (preferenceLists == null || preferenceLists.isEmpty()) {
         return checkEmptyPreferenceListAllowed(idealState, resource, currentStateOutput, cache);
       }
       int emptyListCount = 0;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -611,9 +611,9 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
    * Used to distinguish "all nodes disabled" (replicas exist, need cleanup) from "resource not
    * initialized" (no replicas, should skip).
    */
-private boolean hasCurrentStateForResource(Resource resource,
+  private boolean hasCurrentStateForResource(Resource resource,
       CurrentStateOutput currentStateOutput) {
-    if (currentStateOutput == null) {
+    if (resource == null || currentStateOutput == null) {
       return false;
     }
     String resourceName = resource.getResourceName();

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -471,7 +471,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     for (Resource resource : wagedRebalancedResourceMap.values()) {
       IdealState is = newIdealStates.get(resource.getResourceName());
       // Check if the WAGED rebalancer has calculated the result for this resource or not.
-      if (is != null && checkBestPossibleStateCalculation(is, resource, currentStateOutput)) {
+      if (is != null && checkBestPossibleStateCalculation(is, resource, currentStateOutput, cache)) {
         // The WAGED rebalancer calculates a valid result, record in the output
         updateBestPossibleStateOutput(output, resource, is);
       } else {
@@ -540,7 +540,7 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
             rebalancer.computeNewIdealState(resourceName, idealState, currentStateOutput, cache);
 
         // Check if calculation is done successfully
-        if (!checkBestPossibleStateCalculation(idealState, resource, currentStateOutput)) {
+        if (!checkBestPossibleStateCalculation(idealState, resource, currentStateOutput, cache)) {
           LogUtil.logWarn(logger, _eventId,
               "The calculated idealState is not valid, resource: " + resourceName);
           return false;
@@ -578,15 +578,15 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
   }
 
   private boolean checkBestPossibleStateCalculation(IdealState idealState, Resource resource,
-      CurrentStateOutput currentStateOutput) {
+      CurrentStateOutput currentStateOutput, ResourceControllerDataProvider cache) {
     // If replicas is 0, indicate the resource is not fully initialized or ready to be rebalanced
     if (idealState.getRebalanceMode() == IdealState.RebalanceMode.FULL_AUTO && !idealState
         .getReplicas().equals("0")) {
+      // getPreferenceLists() always returns an initialized map (never null) since ZNRecord
+      // initializes listFields as a TreeMap. A null result would indicate a programming error.
       Map<String, List<String>> preferenceLists = idealState.getPreferenceLists();
-      if (preferenceLists == null || preferenceLists.isEmpty()) {
-        // Empty preference lists: allow only when there are existing replicas to clean up
-        // (e.g., all nodes disabled). Reject when resource is not initialized (no current state).
-        return hasCurrentStateForResource(resource, currentStateOutput);
+      if (preferenceLists.isEmpty()) {
+        return checkEmptyPreferenceListAllowed(idealState, resource, currentStateOutput, cache);
       }
       int emptyListCount = 0;
       for (List<String> preferenceList : preferenceLists.values()) {
@@ -595,21 +595,59 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         }
       }
       if (emptyListCount == preferenceLists.values().size()) {
-        // All lists empty: allow only when there are replicas to clean up (all nodes disabled).
-        return hasCurrentStateForResource(resource, currentStateOutput);
+        // All per-partition lists are empty — treat the same as map-level empty.
+        return checkEmptyPreferenceListAllowed(idealState, resource, currentStateOutput, cache);
       }
-      // Some but not all lists empty: this is valid when maxPartitionsPerInstance limits capacity.
-      // Only reject when maxPartitionsPerInstance is NOT set and we have inconsistent empty lists.
-      if (emptyListCount > 0 && idealState.getMaxPartitionsPerInstance() > 0) {
-        // Empty lists are expected when capacity is limited by maxPartitionsPerInstance
+      // Some but not all per-partition lists are empty. This is expected when
+      // maxPartitionsPerInstance is explicitly configured and capacity is exhausted for some nodes.
+      // The default value of maxPartitionsPerInstance is Integer.MAX_VALUE (unconstrained), so we
+      // only treat partial empty lists as valid when it has been explicitly set to a finite value.
+      if (emptyListCount > 0 && idealState.getMaxPartitionsPerInstance() != Integer.MAX_VALUE) {
         return true;
       }
-      // No maxPartitionsPerInstance configured: empty lists indicate inconsistent state, reject.
+      // maxPartitionsPerInstance is not configured: partial empty lists indicate an inconsistent
+      // rebalance result, reject.
       return emptyListCount == 0;
     } else {
       // For non FULL_AUTO RebalanceMode, rebalancing is not controlled by Helix
       return true;
     }
+  }
+
+  /**
+   * Determines whether it is safe to proceed with rebalancing when the rebalancer produced an
+   * empty preference list. There are two distinct scenarios:
+   *
+   * <p><b>all nodes disabled:</b> No enabled live instances exist, so the rebalancer
+   * correctly returns an empty assignment. Rebalancing is allowed only if replicas already exist
+   * in the current state so they can be transitioned to OFFLINE/DROPPED cleanly.
+   *
+   * <p><b>Unsafe — rebalancer failure:</b> Enabled live instances exist but the rebalancer still
+   * returned an empty list. Proceeding would assign all existing replicas to DROPPED/OFFLINE,
+   * causing catastrophic data loss. Rebalancing is blocked to protect existing replicas.
+   */
+  private boolean checkEmptyPreferenceListAllowed(IdealState idealState, Resource resource,
+      CurrentStateOutput currentStateOutput, ResourceControllerDataProvider cache) {
+    if (!cache.getEnabledLiveInstances().isEmpty()) {
+      // Enabled live instances are available but the rebalancer returned empty preference lists.
+      // This indicates a silent rebalancer failure. Block rebalancing to prevent accidentally
+      // dropping all existing replicas.
+      LogUtil.logError(logger, _eventId,
+          "Preference list is empty for resource " + idealState.getResourceName()
+              + " but there are enabled live instances. This indicates a rebalancer failure."
+              + " Skipping rebalance to protect existing replicas.");
+      return false;
+    }
+    // No enabled live instances — all nodes are disabled. Allow rebalancing only if replicas
+    // exist in the current state so they can be transitioned to OFFLINE/DROPPED cleanly.
+    // If there is no current state, the resource was never assigned — nothing to clean up.
+    boolean hasCurrent = hasCurrentStateForResource(resource, currentStateOutput);
+    if (hasCurrent) {
+      LogUtil.logInfo(logger, _eventId,
+          "All nodes are disabled for resource " + idealState.getResourceName()
+              + " and replicas exist in current state. Allowing rebalance to clean up.");
+    }
+    return hasCurrent;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -598,7 +598,13 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
         // All lists empty: allow only when there are replicas to clean up (all nodes disabled).
         return hasCurrentStateForResource(resource, currentStateOutput);
       }
-      // Some but not all lists empty: inconsistent state, reject.
+      // Some but not all lists empty: this is valid when maxPartitionsPerInstance limits capacity.
+      // Only reject when maxPartitionsPerInstance is NOT set and we have inconsistent empty lists.
+      if (emptyListCount > 0 && idealState.getMaxPartitionsPerInstance() > 0) {
+        // Empty lists are expected when capacity is limited by maxPartitionsPerInstance
+        return true;
+      }
+      // No maxPartitionsPerInstance configured: empty lists indicate inconsistent state, reject.
       return emptyListCount == 0;
     } else {
       // For non FULL_AUTO RebalanceMode, rebalancing is not controlled by Helix

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
@@ -28,6 +28,7 @@ import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
@@ -300,6 +301,79 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
     BestPossibleStateOutput output = event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
     // SEMI_AUTO uses preference list from IdealState; pipeline should complete
     Assert.assertNotNull(output, "Output should not be null");
+  }
+
+  /**
+   * Tests that when the rebalancer silently returns empty preference lists while enabled live
+   * instances still exist, the pipeline blocks the rebalance entirely to protect existing replicas.
+   *
+   * <p>This distinguishes a rebalancer failure from the legitimate "all nodes disabled" scenario:
+   * <ul>
+   *   <li>All nodes disabled: {@code getEnabledLiveInstances()} is empty → allow cleanup</li>
+   *   <li>Rebalancer failure: {@code getEnabledLiveInstances()} is non-empty but rebalancer
+   *       returned empty lists → block to prevent accidentally dropping all replicas</li>
+   * </ul>
+   *
+   * <p>The failure is simulated by setting an instance group tag on the resource that no live
+   * instance has. The DelayedAutoRebalancer finds no eligible instances for the tag and returns
+   * an empty assignment, but {@code getEnabledLiveInstances()} still returns all untagged instances.
+   */
+  @Test
+  public void testSilentRebalancerFailureDoesNotDropExistingReplicas() {
+    String resourceName = "resource_1";
+    String[] resources = new String[]{resourceName};
+    int numInstances = 3;
+    int numPartitions = 1;
+
+    List<IdealState> idealStates = setupIdealState(numInstances, resources, numPartitions, 1,
+        RebalanceMode.FULL_AUTO, BuiltInStateModelDefinitions.LeaderStandby.name(),
+        DelayedAutoRebalancer.class.getName());
+    setupInstances(numInstances);
+    setupLiveInstances(numInstances);  // all instances are live and enabled (no tag)
+    setupStateModel();
+
+    // Set an instance group tag that NO instance has. This causes DelayedAutoRebalancer to find
+    // zero eligible instances and silently return empty preference lists — while
+    // getEnabledLiveInstances() still returns the full set of untagged live instances.
+    // This simulates a silent rebalancer failure (e.g., tag misconfiguration or a rebalancer bug
+    // that returns empty results without throwing).
+    IdealState idealState = idealStates.get(0);
+    idealState.setInstanceGroupTag("ghost-tag-no-instance-has-this");
+    accessor.setProperty(accessor.keyBuilder().idealStates(resourceName), idealState);
+
+    ClusterConfig clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    clusterConfig.setRebalanceDelayTime(0);
+    clusterConfig.setDelayRebalaceEnabled(true);
+    setClusterConfig(clusterConfig);
+
+    Map<String, Resource> resourceMap =
+        getResourceMap(resources, numPartitions, BuiltInStateModelDefinitions.LeaderStandby.name());
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+
+    // Existing replica: localhost_2 holds LEADER — it must not be dropped due to a rebalancer bug.
+    Partition partition = new Partition(resourceName + "_0");
+    currentStateOutput.setCurrentState(resourceName, partition, "localhost_2", "LEADER");
+
+    event.addAttribute(AttributeName.helixmanager.name(), manager);
+    event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new BestPossibleStateCalcStage());
+
+    BestPossibleStateOutput output = event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
+
+    // The pipeline must block the rebalance. If it proceeded with empty preference lists while
+    // enabled live instances exist, the downstream mapping calculator would assign all replicas
+    // to DROPPED/OFFLINE, causing catastrophic data loss.
+    Assert.assertFalse(output.containsResource(resourceName),
+        "Resource should NOT be in output when enabled live instances exist but the rebalancer "
+            + "returned empty preference lists — this indicates a silent rebalancer failure, not "
+            + "an all-nodes-disabled scenario.");
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
@@ -268,6 +268,41 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
   }
 
   /**
+   * Tests that SEMI_AUTO mode is unaffected - empty preference lists are allowed
+   * (rebalancing is not controlled by Helix) and the pipeline continues.
+   */
+  @Test
+  public void testSemiAutoModeUnaffectedByEmptyPreferenceList() {
+    String[] resources = new String[]{"resource_1"};
+    int numInstances = 3;
+    int numPartitions = 1;
+
+    setupIdealState(numInstances, resources, numPartitions, 1, RebalanceMode.SEMI_AUTO,
+        BuiltInStateModelDefinitions.MasterSlave.name());
+    setupInstances(numInstances);
+    setupLiveInstances(numInstances);
+    setupStateModel();
+
+    Map<String, Resource> resourceMap =
+        getResourceMap(resources, numPartitions, BuiltInStateModelDefinitions.MasterSlave.name());
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+
+    event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new BestPossibleStateCalcStage());
+
+    BestPossibleStateOutput output = event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
+    // SEMI_AUTO uses preference list from IdealState; pipeline should complete
+    Assert.assertNotNull(output, "Output should not be null");
+  }
+
+  /**
    * Test parallel computation with multiple FULL_AUTO resources.
    * Verifies that parallel computation using StageThreadPoolHelper produces correct results.
    */

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
@@ -23,7 +23,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.helix.HelixDefinedState;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.IdealState.RebalanceMode;
@@ -154,6 +156,115 @@ public class TestBestPossibleStateCalcStage extends BaseStageTest {
     Assert.assertNull(
         output.getInstanceStateMap("testResourceName", new Partition("testResourceName_1"))
             .get("localhost_2"));
+  }
+
+  /**
+   * Tests that when all instances are disabled, the pipeline continues and computes DROPPED
+   * transitions for existing replicas. This verifies the fix for the bug where the last instance
+   * would stay stuck as LEADER when all nodes are disabled.
+   */
+  @Test
+  public void testAllNodesDisabledComputesDroppedForExistingReplicas() {
+    String[] resources = new String[]{"resource_1"};
+    int numInstances = 3;
+    int numPartitions = 1;
+
+    setupIdealState(numInstances, resources, numPartitions, 1, RebalanceMode.FULL_AUTO,
+        BuiltInStateModelDefinitions.LeaderStandby.name(),
+        DelayedAutoRebalancer.class.getName());
+    setupInstances(numInstances);
+    List<String> liveInstances = setupLiveInstances(numInstances);
+    setupStateModel();
+
+    // Short delay so disabled instances are immediately inactive (no delay window)
+    ClusterConfig clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    clusterConfig.setRebalanceDelayTime(0);
+    clusterConfig.setDelayRebalaceEnabled(true);
+    setClusterConfig(clusterConfig);
+
+    Map<String, Resource> resourceMap =
+        getResourceMap(resources, numPartitions, BuiltInStateModelDefinitions.LeaderStandby.name());
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+
+    // Simulate existing replica: localhost_2 holds LEADER for resource_1_0
+    Partition partition = new Partition("resource_1_0");
+    currentStateOutput.setCurrentState("resource_1", partition, "localhost_2", "LEADER");
+
+    // Disable ALL instances
+    for (String instance : liveInstances) {
+      admin.enableInstance(_clusterName, instance, false);
+    }
+
+    event.addAttribute(AttributeName.helixmanager.name(), manager);
+    event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new BestPossibleStateCalcStage());
+
+    BestPossibleStateOutput output = event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
+
+    // Pipeline should continue and compute DROPPED for the instance that had LEADER
+    Assert.assertTrue(output.containsResource("resource_1"),
+        "Resource should be in output when all nodes disabled but replicas exist");
+    Assert.assertEquals(
+        output.getInstanceStateMap("resource_1", partition).get("localhost_2"),
+        HelixDefinedState.DROPPED.name(),
+        "Instance with LEADER should transition to DROPPED when all nodes are disabled");
+  }
+
+  /**
+   * Tests that when all instances are disabled AND no current state exists (resource not
+   * initialized), the pipeline correctly rejects and does not add the resource to output.
+   */
+  @Test
+  public void testAllNodesDisabledRejectsWhenNoCurrentState() {
+    String[] resources = new String[]{"resource_1"};
+    int numInstances = 3;
+    int numPartitions = 1;
+
+    setupIdealState(numInstances, resources, numPartitions, 1, RebalanceMode.FULL_AUTO,
+        BuiltInStateModelDefinitions.LeaderStandby.name(),
+        DelayedAutoRebalancer.class.getName());
+    setupInstances(numInstances);
+    List<String> liveInstances = setupLiveInstances(numInstances);
+    setupStateModel();
+
+    ClusterConfig clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    clusterConfig.setRebalanceDelayTime(0);
+    clusterConfig.setDelayRebalaceEnabled(true);
+    setClusterConfig(clusterConfig);
+
+    Map<String, Resource> resourceMap =
+        getResourceMap(resources, numPartitions, BuiltInStateModelDefinitions.LeaderStandby.name());
+    // No current state - resource not initialized
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+
+    // Disable ALL instances
+    for (String instance : liveInstances) {
+      admin.enableInstance(_clusterName, instance, false);
+    }
+
+    event.addAttribute(AttributeName.helixmanager.name(), manager);
+    event.addAttribute(AttributeName.RESOURCES.name(), resourceMap);
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(), resourceMap);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new BestPossibleStateCalcStage());
+
+    BestPossibleStateOutput output = event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
+
+    // Resource should NOT be in output when no current state exists (not initialized)
+    Assert.assertFalse(output.containsResource("resource_1"),
+        "Resource should not be in output when all nodes disabled and no replicas exist");
   }
 
   /**


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:


### Description

SCENARIO 
- 3 instances
- All instances disabled 

Observation (Without Fix)
- Last replica was not dropped from IDEALSTATE and EXTERNALVIEW 


Reason:
- The checkBestPossibleStateCalculation method treats an empty preference list as a rebalance failure. For our case, empty preference list is a legitimate result — all nodes are disabled, so there should be no assignment.
- No best possible state is computed for the resource (no DROPPED/OFFLINE **assignments)**
- No messages are generated by MessageGenerationPhase (nothing to transition)
- No state transition messages are sent to localhost_12000
- The participant stays in LEADER forever — it never receives a message to go to STANDBY → OFFLINE
- The External View (which reflects actual current state from participants) keeps showing LEADER

BEFORE
<img width="931" height="619" alt="image" src="https://github.com/user-attachments/assets/9143445f-e9dd-40ab-be22-1c79209cf237" />


**AFTER** 



<img width="931" height="619" alt="image" src="https://github.com/user-attachments/assets/0aae8528-453f-45f9-b95c-2e7f32d7c0e9" />


  1. New Change(Commit 6c5f23b7b): Enhanced checkBestPossibleStateCalculation() to support the "all nodes disabled" scenario
    - Added hasCurrentStateForResource() helper method
    - Allows empty preference lists when existing replicas need cleanup (all nodes disabled)
    - Distinguishes between "not initialized" (reject) vs "all disabled" (allow for cleanup)
  2. Test Coverage (Commit 2cb9caebb): Added comprehensive unit tests in TestBestPossibleStateCalcStage
    - Test case for all nodes disabled with current state (should allow)
    - Test case for uninitialized resource (should reject)
  

  **Code Changes:**
  - Modified: helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
    - Enhanced checkBestPossibleStateCalculation() method signature to accept Resource and CurrentStateOutput
    - Added hasCurrentStateForResource() helper method
    - Added logic to distinguish between three scenarios:
        **i. All lists empty + current state exists → Allow (all nodes disabled cleanup)
      ii. Some lists empty + maxPartitionsPerInstance set → Allow (capacity-limited)
      iii. Some lists empty + no maxPartitionsPerInstance → Reject (inconsistent state)**
  - Modified: helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestAutoRebalancePartitionLimit.java
    - Enhanced test timing to use TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME
    - Added Thread.sleep() calls to ensure controller processes state changes
    - Increased verifier timeout from 10s to 60s for better CI stability
  - Added: Tests in helix-core/src/test/java/org/apache/helix/controller/stages/TestBestPossibleStateCalcStage.java
    - Unit tests for "all nodes disabled" scenario
    - Unit tests for uninitialized resource rejection


### Tests

  - TestBestPossibleStateCalcStage.testCheckBestPossibleStateCalculation_AllNodesDisabled_WithCurrentState() - Validates "all nodes disabled" feature
  - TestBestPossibleStateCalcStage.testCheckBestPossibleStateCalculation_ResourceNotInitialized() - Ensures uninitialized resources are rejected
  
