### PR TITLE
Current State Optimisation 

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -95,30 +95,24 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
       String instanceSessionId = instance.getEphemeralOwner();
       InstanceConfig instanceConfig = cache.getInstanceConfigMap().get(instanceName);
 
+      // Determine once whether this instance should be included in the UNKNOWN-excluding output,
+      // and resolve the secondary output to null for UNKNOWN instances
+      boolean isNotUnknown = instanceConfig == null || !instanceConfig.getInstanceOperation()
+          .getOperation()
+          .equals(InstanceConstants.InstanceOperation.UNKNOWN);
+      CurrentStateOutput secondaryOutput = isNotUnknown ? currentStateExcludingUnknown : null;
+
       Set<Message> existingStaleMessages = cache.getStaleMessagesByInstance(instanceName);
       Map<String, Message> messages = cache.getMessages(instanceName);
       Map<String, Message> relayMessages = cache.getRelayMessages(instanceName);
+      // Cache the getCurrentState result to avoid a duplicate cache lookup
+      Collection<CurrentState> currentStates =
+          cache.getCurrentState(instanceName, instanceSessionId, _isTaskFrameworkPipeline).values();
 
-      // update current states.
-      updateCurrentStates(instance,
-          cache.getCurrentState(instanceName, instanceSessionId, _isTaskFrameworkPipeline).values(),
-          currentStateOutput, resourceMap);
-      // update pending messages
+      // Single pass writes to both outputs simultaneously
+      updateCurrentStates(instance, currentStates, currentStateOutput, secondaryOutput, resourceMap);
       updatePendingMessages(instance, cache, messages.values(), relayMessages.values(),
-          existingStaleMessages, currentStateOutput, resourceMap);
-
-      // Only update the currentStateExcludingUnknown if the instance is not in UNKNOWN InstanceOperation.
-      if (instanceConfig == null || !instanceConfig.getInstanceOperation()
-          .getOperation()
-          .equals(InstanceConstants.InstanceOperation.UNKNOWN)) {
-        // update current states.
-        updateCurrentStates(instance,
-            cache.getCurrentState(instanceName, instanceSessionId, _isTaskFrameworkPipeline)
-                .values(), currentStateExcludingUnknown, resourceMap);
-        // update pending messages
-        updatePendingMessages(instance, cache, messages.values(), relayMessages.values(),
-            existingStaleMessages, currentStateExcludingUnknown, resourceMap);
-      }
+          existingStaleMessages, currentStateOutput, secondaryOutput, resourceMap);
     }
     event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
     event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateExcludingUnknown);
@@ -137,10 +131,11 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
   }
 
   // update all pending messages to CurrentStateOutput.
+  // secondaryOutput, when non-null, receives the same writes (used for currentStateExcludingUnknown).
   private void updatePendingMessages(LiveInstance instance, BaseControllerDataProvider cache,
       Collection<Message> pendingMessages, Collection<Message> pendingRelayMessages,
       Set<Message> existingStaleMessages, CurrentStateOutput currentStateOutput,
-      Map<String, Resource> resourceMap) {
+      CurrentStateOutput secondaryOutput, Map<String, Resource> resourceMap) {
     String instanceName = instance.getInstanceName();
     String instanceSessionId = instance.getEphemeralOwner();
 
@@ -175,6 +170,9 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
               instanceName);
           if (_isTaskFrameworkPipeline || !isStaleMessage(message, currentState)) {
             setMessageState(currentStateOutput, resourceName, partition, instanceName, message);
+            if (secondaryOutput != null) {
+              setMessageState(secondaryOutput, resourceName, partition, instanceName, message);
+            }
           } else {
             cache.addStaleMessage(instanceName, message);
           }
@@ -190,6 +188,9 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
             Partition partition = resource.getPartition(partitionName);
             if (partition != null) {
               setMessageState(currentStateOutput, resourceName, partition, instanceName, message);
+              if (secondaryOutput != null) {
+                setMessageState(secondaryOutput, resourceName, partition, instanceName, message);
+              }
             } else {
               LogUtil.logDebug(LOG, _eventId, String.format(
                   "Ignore a pending message %s for a non-exist resource %s and partition %s",
@@ -202,6 +203,9 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
       // Add the state model into the map for lookup of Task Framework pending partitions
       if (resource.getStateModelDefRef() != null) {
         currentStateOutput.setResourceStateModelDef(resourceName, resource.getStateModelDefRef());
+        if (secondaryOutput != null) {
+          secondaryOutput.setResourceStateModelDef(resourceName, resource.getStateModelDefRef());
+        }
       }
     }
 
@@ -227,6 +231,9 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
         Partition partition = resource.getPartition(partitionName);
         if (partition != null) {
           currentStateOutput.setPendingRelayMessage(resourceName, partition, instanceName, message);
+          if (secondaryOutput != null) {
+            secondaryOutput.setPendingRelayMessage(resourceName, partition, instanceName, message);
+          }
         } else {
           LogUtil.logDebug(LOG, _eventId, String.format(
               "Ignore a pending relay message %s for a non-exist resource %s and partition %s",
@@ -249,7 +256,8 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
 
   // update current states in CurrentStateOutput
   private void updateCurrentStates(LiveInstance instance, Collection<CurrentState> currentStates,
-      CurrentStateOutput currentStateOutput, Map<String, Resource> resourceMap) {
+      CurrentStateOutput currentStateOutput, CurrentStateOutput secondaryOutput,
+      Map<String, Resource> resourceMap) {
     String instanceName = instance.getInstanceName();
     String instanceSessionId = instance.getEphemeralOwner();
 
@@ -265,27 +273,53 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
       }
       if (stateModelDefName != null) {
         currentStateOutput.setResourceStateModelDef(resourceName, stateModelDefName);
+        if (secondaryOutput != null) {
+          secondaryOutput.setResourceStateModelDef(resourceName, stateModelDefName);
+        }
       }
 
-      currentStateOutput.setBucketSize(resourceName, currentState.getBucketSize());
+      int bucketSize = currentState.getBucketSize();
+      currentStateOutput.setBucketSize(resourceName, bucketSize);
+      if (secondaryOutput != null) {
+        secondaryOutput.setBucketSize(resourceName, bucketSize);
+      }
 
-      Map<String, String> partitionStateMap = currentState.getPartitionStateMap();
-      for (String partitionName : partitionStateMap.keySet()) {
+      // Iterate the ZNRecord map fields directly rather than building an intermediate
+      // getPartitionStateMap() snapshot. This avoids allocating a new HashMap and eliminates
+      // the repeated per-property TreeMap lookups (getState/getEndTime/getInfo/getRequestedState
+      // each called getMapField separately). All four fields are read from the same map entry
+      // in a single pass
+      for (Map.Entry<String, Map<String, String>> partitionEntry :
+          currentState.getRecord().getMapFields().entrySet()) {
+        String partitionName = partitionEntry.getKey();
         Partition partition = resource.getPartition(partitionName);
-        if (partition != null) {
-          currentStateOutput.setCurrentState(resourceName, partition, instanceName,
-              currentState.getState(partitionName));
-          currentStateOutput.setEndTime(resourceName, partition, instanceName,
-              currentState.getEndTime(partitionName));
-          String info = currentState.getInfo(partitionName);
-          // This is to avoid null value entries in the map, and reduce memory usage by avoiding extra empty entries in the map.
+        if (partition == null) {
+          continue;
+        }
+        Map<String, String> fields = partitionEntry.getValue();
+        String state = fields.get(CurrentState.CurrentStateProperty.CURRENT_STATE.name());
+        String endTimeStr = fields.get(CurrentState.CurrentStateProperty.END_TIME.name());
+        long endTime = endTimeStr == null ? -1L : Long.parseLong(endTimeStr);
+        String info = fields.get(CurrentState.CurrentStateProperty.INFO.name());
+        String requestedState = fields.get(CurrentState.CurrentStateProperty.REQUESTED_STATE.name());
+
+        currentStateOutput.setCurrentState(resourceName, partition, instanceName, state);
+        currentStateOutput.setEndTime(resourceName, partition, instanceName, endTime);
+        // Avoid null value entries in the map to reduce memory usage (unchanged behaviour).
+        if (info != null) {
+          currentStateOutput.setInfo(resourceName, partition, instanceName, info);
+        }
+        if (requestedState != null) {
+          currentStateOutput.setRequestedState(resourceName, partition, instanceName, requestedState);
+        }
+        if (secondaryOutput != null) {
+          secondaryOutput.setCurrentState(resourceName, partition, instanceName, state);
+          secondaryOutput.setEndTime(resourceName, partition, instanceName, endTime);
           if (info != null) {
-            currentStateOutput.setInfo(resourceName, partition, instanceName, info);
+            secondaryOutput.setInfo(resourceName, partition, instanceName, info);
           }
-          String requestState = currentState.getRequestedState(partitionName);
-          if (requestState != null) {
-            currentStateOutput
-                .setRequestedState(resourceName, partition, instanceName, requestState);
+          if (requestedState != null) {
+            secondaryOutput.setRequestedState(resourceName, partition, instanceName, requestedState);
           }
         }
       }


### PR DESCRIPTION
## Issues

Fixes #200

## Description

Optimizes `CurrentStateComputationStage` to reduce redundant work when computing current state and pending messages for both the primary (`currentStateOutput`) and UNKNOWN-excluding (`currentStateExcludingUnknown`) outputs.

**What changed:**
- **Single-pass dual-write:** Instead of calling `updateCurrentStates()` and `updatePendingMessages()` twice (once per output), both outputs are now populated in a single pass via a `secondaryOutput` parameter. For UNKNOWN instances, `secondaryOutput` is set to `null` and all secondary writes are skipped.
- **Eliminate duplicate cache lookups:** `cache.getCurrentState()` is called once per instance and the result is reused, instead of being called twice.
- **Direct ZNRecord map field iteration:** Replaces `getPartitionStateMap()` (which allocates a new `HashMap`) and separate per-property accessor calls (`getState`, `getEndTime`, `getInfo`, `getRequestedState` — each performing its own `TreeMap` lookup) with a single iteration over `getRecord().getMapFields()`, reading all four properties from the same map entry in one pass.

**Why:**
This stage runs on every pipeline cycle for every live instance. For clusters with many instances and partitions, the duplicated iterations, repeated `HashMap`/`TreeMap` allocations, and redundant cache lookups add measurable overhead to the controller pipeline latency.

**Savings**

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-09f385b8-7fff-d14f-f8da-73dddf1b1961"><div dir="ltr" style="margin-left:0pt;" align="left">
Optimization | Samples Saved | % of Stage CPU
-- | -- | --
OPT-1 — Eliminate duplicate pass | ~1,865 | ~49%
OPT-2 — Single-pass field extraction (on remaining pass) | ~725 | ~19%
Combined Impact | ~2,590 | ~68%


## Performance Tests

```
- A micro-benchmark (TestCurrentStateComputationStagePerf) was run against dev (baseline) and this branch using an in-memory mock cluster with:

50 instances
20 resources
100 partitions
Total: 100,000 partition entries

- Each partition had all 4 properties populated (state, endTime, info, requestedState).

The stage was:
Warmed up for 5 iterations
Measured over 20 iterations

- The benchmark isolates CurrentStateComputationStage.process() (no ZK I/O) to measure pure CPU and allocation savings from:

Single-pass dual-write
Direct ZNRecord map iteration
Cached getCurrentState() lookup
```

</div><br /></b>
<img width="782" height="156" alt="image" src="https://github.com/user-attachments/assets/7efc9099-c427-44d9-b625-aec0314c3511" />




## Tests

- Existing unit tests in `TestCurrentStateComputationStage` pass without modification, confirming behavioral equivalence.
- The refactoring preserves all null-checks (info, requestedState) and the partition-existence guard, so edge-case behavior is unchanged.