### PR TITLE
Fix instance-level throttling for pending state transitions across resources

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -148,6 +148,29 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       Collections.sort(prioritizedResourceList);
     }
 
+    // Charge all pending transitions for all FULL_AUTO resources upfront before processing any
+    // resource. This ensures the throttle controller has an accurate picture of all in-flight
+    // transitions regardless of resource processing order. Only FULL_AUTO resources are charged
+    // because throttling is only applied to FULL_AUTO resources in computeIntermediatePartitionState.
+    for (String resourceName : resourceMap.keySet()) {
+      Resource resource = resourceMap.get(resourceName);
+      IdealState is = dataCache.getIdealState(resourceName);
+      if (is == null || !IdealState.RebalanceMode.FULL_AUTO.equals(is.getRebalanceMode())) {
+        continue;
+      }
+      StateModelDefinition stateModelDef = dataCache.getStateModelDef(is.getStateModelDefRef());
+      if (stateModelDef == null) {
+        continue;
+      }
+      Map<String, List<String>> preferenceLists =
+          bestPossibleStateOutput.getPreferenceLists(resourceName);
+      if (preferenceLists == null) {
+        preferenceLists = Collections.emptyMap();
+      }
+      chargePendingTransition(resource, currentStateOutput, throttleController, dataCache,
+          preferenceLists, stateModelDef);
+    }
+
     ClusterStatusMonitor clusterStatusMonitor =
         event.getAttribute(AttributeName.clusterStatusMonitor.name());
     List<String> failedResources = new ArrayList<>();
@@ -348,9 +371,6 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
     // Perform regular load balance only if the number of partitions in recovery and in error is
     // less than the threshold. Otherwise, only allow downward-transition load balance
     boolean onlyDownwardLoadBalance = numPartitionsWithErrorReplica > threshold;
-
-    chargePendingTransition(resource, currentStateOutput, throttleController, cache,
-        preferenceLists, stateModelDef);
 
     // Sort partitions in case of urgent partition need to take the quota first.
     List<Partition> partitions = new ArrayList<>(resource.getPartitions());

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -815,6 +815,100 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
         "2 partitions should be throttled and remain OFFLINE");
   }
 
+  @Test
+  public void testAnyTypeThrottleWithPendingMessagesBlockNewResource() {
+    String existingResource = "existingResource";
+    String newResource = "newResource";
+    String[] resources = new String[]{existingResource, newResource};
+    int nPartition = 4;
+    int nInstances = 3;
+    int nReplica = 1;
+
+    // Use a custom setup with RebalanceType.ANY at INSTANCE scope, limit 3.
+    // This directly reproduces the customer scenario where MAX_PARTITION_IN_TRANSITION
+    // is configured at INSTANCE scope regardless of rebalance type.
+    setupIdealState(nInstances, resources, nInstances, nReplica,
+        IdealState.RebalanceMode.FULL_AUTO, "OnlineOffline");
+    setupStateModel();
+    setupInstances(nInstances);
+    setupLiveInstances(nInstances);
+    _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    _clusterConfig.setStateTransitionThrottleConfigs(ImmutableList.of(
+        new StateTransitionThrottleConfig(StateTransitionThrottleConfig.RebalanceType.ANY,
+            StateTransitionThrottleConfig.ThrottleScope.INSTANCE, 3)));
+    setClusterConfig(_clusterConfig);
+
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+
+    String instanceName = HOSTNAME_PREFIX + 0;
+
+    // existingResource: 3 partitions on localhost_0 with pending OFFLINE→ONLINE messages.
+    // These 3 pending messages exhaust the ANY quota of 3 on this instance.
+    IdealState existingIs =
+        accessor.getProperty(accessor.keyBuilder().idealStates(existingResource));
+    setSingleIdealState(existingIs);
+    Map<String, List<String>> existingPartitionMap = new HashMap<>();
+    for (int p = 0; p < 3; p++) {
+      Partition partition = new Partition(existingResource + "_" + p);
+      existingPartitionMap
+          .put(partition.getPartitionName(), Collections.singletonList(instanceName));
+      currentStateOutput.setCurrentState(existingResource, partition, instanceName, "OFFLINE");
+      bestPossibleStateOutput.setState(existingResource, partition, instanceName, "ONLINE");
+      Message pendingMessage = generateMessage("OFFLINE", "ONLINE", instanceName);
+      currentStateOutput
+          .setPendingMessage(existingResource, partition, instanceName, pendingMessage);
+    }
+    // 4th partition is already ONLINE
+    Partition stablePartition = new Partition(existingResource + "_3");
+    existingPartitionMap
+        .put(stablePartition.getPartitionName(), Collections.singletonList(instanceName));
+    currentStateOutput.setCurrentState(existingResource, stablePartition, instanceName, "ONLINE");
+    bestPossibleStateOutput.setState(existingResource, stablePartition, instanceName, "ONLINE");
+    bestPossibleStateOutput.setPreferenceLists(existingResource, existingPartitionMap);
+
+    // newResource: 4 partitions on localhost_0 needing OFFLINE→ONLINE.
+    // Since the ANY quota on localhost_0 is fully exhausted, all messages should be throttled.
+    IdealState newIs = accessor.getProperty(accessor.keyBuilder().idealStates(newResource));
+    setSingleIdealState(newIs);
+    Map<String, List<String>> newPartitionMap = new HashMap<>();
+    for (int p = 0; p < nPartition; p++) {
+      Partition partition = new Partition(newResource + "_" + p);
+      newPartitionMap.put(partition.getPartitionName(), Collections.singletonList(instanceName));
+      currentStateOutput.setCurrentState(newResource, partition, instanceName, "OFFLINE");
+      bestPossibleStateOutput.setState(newResource, partition, instanceName, "ONLINE");
+      messageSelectOutput.addMessage(newResource, partition,
+          generateMessage("OFFLINE", "ONLINE", instanceName));
+    }
+    bestPossibleStateOutput.setPreferenceLists(newResource, newPartitionMap);
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    Map<Partition, Map<String, String>> newResourceStateMap =
+        output.getPartitionStateMap(newResource).getStateMap();
+    for (int p = 0; p < nPartition; p++) {
+      Partition partition = new Partition(newResource + "_" + p);
+      Assert.assertEquals(newResourceStateMap.get(partition).get(instanceName), "OFFLINE",
+          "Partition " + partition.getPartitionName()
+              + " should be throttled because ANY quota on the instance is exhausted");
+    }
+  }
+
   private void preSetup(String[] resources, int numOfLiveInstances, int numOfReplicas) {
     setupIdealState(numOfLiveInstances, resources, numOfLiveInstances, numOfReplicas,
         IdealState.RebalanceMode.FULL_AUTO, "OnlineOffline");

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -650,6 +650,171 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     }
   }
 
+  @Test
+  public void testPendingMessagesExceedThresholdBlockNewResource() {
+    String existingResource = "existingResource";
+    String newResource = "newResource";
+    String[] resources = new String[]{existingResource, newResource};
+    int nPartition = 3;
+    int nInstances = 3;
+    int nReplica = 1;
+
+    preSetup(resources, nInstances, nReplica);
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+
+    String instanceName = HOSTNAME_PREFIX + 0;
+
+    // existingResource: 3 partitions on localhost_0 with pending OFFLINE→ONLINE messages.
+    // These 3 pending messages will exhaust the instance-level RECOVERY_BALANCE quota of 3.
+    IdealState existingIs =
+        accessor.getProperty(accessor.keyBuilder().idealStates(existingResource));
+    setSingleIdealState(existingIs);
+    Map<String, List<String>> existingPartitionMap = new HashMap<>();
+    for (int p = 0; p < nPartition; p++) {
+      Partition partition = new Partition(existingResource + "_" + p);
+      existingPartitionMap
+          .put(partition.getPartitionName(), Collections.singletonList(instanceName));
+      currentStateOutput.setCurrentState(existingResource, partition, instanceName, "OFFLINE");
+      bestPossibleStateOutput.setState(existingResource, partition, instanceName, "ONLINE");
+      Message pendingMessage = generateMessage("OFFLINE", "ONLINE", instanceName);
+      currentStateOutput
+          .setPendingMessage(existingResource, partition, instanceName, pendingMessage);
+    }
+    bestPossibleStateOutput.setPreferenceLists(existingResource, existingPartitionMap);
+
+    // newResource: 3 partitions on localhost_0 needing OFFLINE→ONLINE (recovery).
+    // Since the throttle quota on localhost_0 is already exhausted by existingResource's pending
+    // messages, all transitions for newResource should be throttled.
+    IdealState newIs = accessor.getProperty(accessor.keyBuilder().idealStates(newResource));
+    setSingleIdealState(newIs);
+    Map<String, List<String>> newPartitionMap = new HashMap<>();
+    for (int p = 0; p < nPartition; p++) {
+      Partition partition = new Partition(newResource + "_" + p);
+      newPartitionMap.put(partition.getPartitionName(), Collections.singletonList(instanceName));
+      currentStateOutput.setCurrentState(newResource, partition, instanceName, "OFFLINE");
+      bestPossibleStateOutput.setState(newResource, partition, instanceName, "ONLINE");
+      messageSelectOutput.addMessage(newResource, partition,
+          generateMessage("OFFLINE", "ONLINE", instanceName));
+    }
+    bestPossibleStateOutput.setPreferenceLists(newResource, newPartitionMap);
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    Map<Partition, Map<String, String>> newResourceStateMap =
+        output.getPartitionStateMap(newResource).getStateMap();
+    for (int p = 0; p < nPartition; p++) {
+      Partition partition = new Partition(newResource + "_" + p);
+      Assert.assertEquals(newResourceStateMap.get(partition).get(instanceName), "OFFLINE",
+          "Partition " + partition.getPartitionName()
+              + " should be throttled because pending messages already exhausted the quota");
+    }
+  }
+
+  @Test
+  public void testPendingMessagesBelowThresholdPartiallyThrottleNewResource() {
+    String existingResource = "existingResource";
+    String newResource = "newResource";
+    String[] resources = new String[]{existingResource, newResource};
+    int nPartition = 3;
+    int nInstances = 3;
+    int nReplica = 1;
+
+    preSetup(resources, nInstances, nReplica);
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+
+    String instanceName = HOSTNAME_PREFIX + 0;
+
+    // existingResource: 2 partitions with pending messages, 1 partition already ONLINE.
+    // This charges 2 of the 3 instance-level RECOVERY_BALANCE quota, leaving 1 remaining.
+    IdealState existingIs =
+        accessor.getProperty(accessor.keyBuilder().idealStates(existingResource));
+    setSingleIdealState(existingIs);
+    Map<String, List<String>> existingPartitionMap = new HashMap<>();
+    for (int p = 0; p < nPartition; p++) {
+      Partition partition = new Partition(existingResource + "_" + p);
+      existingPartitionMap
+          .put(partition.getPartitionName(), Collections.singletonList(instanceName));
+      if (p < 2) {
+        currentStateOutput.setCurrentState(existingResource, partition, instanceName, "OFFLINE");
+        bestPossibleStateOutput.setState(existingResource, partition, instanceName, "ONLINE");
+        Message pendingMessage = generateMessage("OFFLINE", "ONLINE", instanceName);
+        currentStateOutput
+            .setPendingMessage(existingResource, partition, instanceName, pendingMessage);
+      } else {
+        currentStateOutput.setCurrentState(existingResource, partition, instanceName, "ONLINE");
+        bestPossibleStateOutput.setState(existingResource, partition, instanceName, "ONLINE");
+      }
+    }
+    bestPossibleStateOutput.setPreferenceLists(existingResource, existingPartitionMap);
+
+    // newResource: 3 partitions on localhost_0 needing OFFLINE→ONLINE (recovery).
+    // With 1 quota remaining, exactly 1 partition should transition and 2 should be throttled.
+    IdealState newIs = accessor.getProperty(accessor.keyBuilder().idealStates(newResource));
+    setSingleIdealState(newIs);
+    Map<String, List<String>> newPartitionMap = new HashMap<>();
+    for (int p = 0; p < nPartition; p++) {
+      Partition partition = new Partition(newResource + "_" + p);
+      newPartitionMap.put(partition.getPartitionName(), Collections.singletonList(instanceName));
+      currentStateOutput.setCurrentState(newResource, partition, instanceName, "OFFLINE");
+      bestPossibleStateOutput.setState(newResource, partition, instanceName, "ONLINE");
+      messageSelectOutput.addMessage(newResource, partition,
+          generateMessage("OFFLINE", "ONLINE", instanceName));
+    }
+    bestPossibleStateOutput.setPreferenceLists(newResource, newPartitionMap);
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    Map<Partition, Map<String, String>> newResourceStateMap =
+        output.getPartitionStateMap(newResource).getStateMap();
+    int onlineCount = 0;
+    int offlineCount = 0;
+    for (int p = 0; p < nPartition; p++) {
+      Partition partition = new Partition(newResource + "_" + p);
+      String state = newResourceStateMap.get(partition).get(instanceName);
+      if ("ONLINE".equals(state)) {
+        onlineCount++;
+      } else if ("OFFLINE".equals(state)) {
+        offlineCount++;
+      }
+    }
+    Assert.assertEquals(onlineCount, 1,
+        "Exactly 1 partition should have transitioned with the remaining quota");
+    Assert.assertEquals(offlineCount, 2,
+        "2 partitions should be throttled and remain OFFLINE");
+  }
+
   private void preSetup(String[] resources, int numOfLiveInstances, int numOfReplicas) {
     setupIdealState(numOfLiveInstances, resources, numOfLiveInstances, numOfReplicas,
         IdealState.RebalanceMode.FULL_AUTO, "OnlineOffline");


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fix instance-level state transition throttling not accounting for pending messages across all resources before processing. When `chargePendingTransition` was called inside `computeIntermediatePartitionState` (per-resource), the throttle controller's view of in-flight transitions depended on resource processing order. If a resource with many pending messages was processed after a new resource, the new resource's transitions were not throttled, allowing more messages than the configured instance-level limit.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

**What:** Moved the `chargePendingTransition` call from inside `computeIntermediatePartitionState` (per-resource) into a separate upfront loop in the `compute` method that iterates over all resources before any resource's intermediate state is computed.

**Why:** A customer reported seeing 4000+ messages on an instance despite configuring `STATE_TRANSITION_THROTTLE_CONFIGS` with `MAX_PARTITION_IN_TRANSITION: 200` at the `INSTANCE` scope. The root cause is that `chargePendingTransition` was called inside the per-resource loop, so if ResourceB was processed before ResourceA, the throttle controller had no knowledge of ResourceA's pending messages when deciding whether to throttle ResourceB's new transitions.

**How:**
1. Added a new loop in `compute()` (before the main resource processing loop) that calls `chargePendingTransition` for every resource in the resource map. This ensures the throttle controller has a complete picture of all in-flight transitions across all resources before any throttling decisions are made.
2. Removed the `chargePendingTransition` call from `computeIntermediatePartitionState()` to avoid double-charging.

### Tests

- [ ] The following tests are written for this issue:

1. `testPendingMessagesExceedThresholdBlockNewResource` — Verifies that when an instance already has pending messages that fully exhaust the throttle quota, a new resource's transitions on that instance are completely blocked.
2. `testPendingMessagesBelowThresholdPartiallyThrottleNewResource` — Verifies that when an instance has pending messages below the throttle limit, a new resource's transitions are partially throttled (only the remaining quota is used).


(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
