### PR TITLE
Fix offline CUSTOMIZED evacuation check to use union instead of intersection

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionExclusionHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/evacuation/PartitionExclusionHelper.java
@@ -22,6 +22,7 @@ package org.apache.helix.manager.zk.evacuation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -159,16 +160,18 @@ public class PartitionExclusionHelper {
   }
 
   /**
-   * Gets partitions from current states for customized resources that are still assigned 
-   * to the instance (i.e., not yet reassigned to other instances).
-   * This is used for offline instances.
+   * Gets partitions that block evacuation for an offline instance with customized resources.
+   * Uses union semantics: a partition blocks evacuation if it exists in CurrentState (data still
+   * on the instance) OR if it is assigned to this instance in IdealState (assignment not moved).
+   * This prevents premature evacuation completion when partition names rotate in IdealState
+   * (e.g., segment generation changes) while the instance still holds data.
    *
    * @param currentStates List of current states
    * @param idealStates List of ideal states
    * @param instanceName The instance being checked
    * @param allowedResources Set of allowed resources (already filtered)
    * @param filters Exclusion filters to apply
-   * @return List of partitions that are still assigned to the instance (after exclusions)
+   * @return List of partitions blocking evacuation (union of CurrentState and IdealState)
    */
   public static List<PartitionInfo> getCustomizedPartitionsStillOnInstance(
       List<CurrentState> currentStates, List<IdealState> idealStates, String instanceName,
@@ -178,44 +181,59 @@ public class PartitionExclusionHelper {
       return Collections.emptyList();
     }
 
-    // Create a map of resourceName -> CurrentState
     Map<String, CurrentState> currentStateMap = currentStates.stream()
         .collect(Collectors.toMap(CurrentState::getResourceName, cs -> cs));
 
-    // Create a map of resourceName -> IdealState for CUSTOMIZED resources
     Map<String, IdealState> customizedIdealStateMap = idealStates.stream()
-        .filter(is -> is.getRebalanceMode() == IdealState.RebalanceMode.CUSTOMIZED &&
-            currentStateMap.containsKey(is.getResourceName()) &&
-            allowedResources.contains(is.getResourceName()))
+        .filter(is -> is.getRebalanceMode() == IdealState.RebalanceMode.CUSTOMIZED
+            && allowedResources.contains(is.getResourceName()))
         .collect(Collectors.toMap(IdealState::getResourceName, is -> is));
 
     List<PartitionInfo> partitionsStillOnInstance = new ArrayList<>();
 
-    // For each customized resource, check which partitions are still assigned to the instance
     for (Map.Entry<String, IdealState> entry : customizedIdealStateMap.entrySet()) {
       String resourceName = entry.getKey();
       IdealState idealState = entry.getValue();
       CurrentState cs = currentStateMap.get(resourceName);
+      Set<String> seenPartitions = new HashSet<>();
 
-      if (cs == null || cs.getPartitionStateMap() == null) {
-        continue;
+      // Any non-excluded partition in CurrentState blocks evacuation, regardless of whether
+      // it appears in IdealState. This handles partition name rotation (e.g., segment
+      // generation changes) where old-gen partitions in CS no longer match new-gen IS names.
+      if (cs != null && cs.getPartitionStateMap() != null) {
+        for (Map.Entry<String, String> partitionEntry : cs.getPartitionStateMap().entrySet()) {
+          String partition = partitionEntry.getKey();
+          String state = partitionEntry.getValue();
+
+          PartitionInfo partitionInfo = new PartitionInfo(partition, state, resourceName);
+
+          if (shouldExcludePartition(partitionInfo, filters)) {
+            continue;
+          }
+
+          if (seenPartitions.add(partition)) {
+            partitionsStillOnInstance.add(partitionInfo);
+          }
+        }
       }
 
-      for (Map.Entry<String, String> partitionEntry : cs.getPartitionStateMap().entrySet()) {
-        String partition = partitionEntry.getKey();
-        String state = partitionEntry.getValue();
-
-        PartitionInfo partitionInfo = new PartitionInfo(partition, state, resourceName);
-
-        // Apply exclusion filters
-        if (shouldExcludePartition(partitionInfo, filters)) {
-          continue; // Skip excluded partitions
-        }
-
-        // Check if this partition is still assigned to the instance in IdealState
-        Map<String, String> instanceStateMap = idealState.getInstanceStateMap(partition);
-        if (instanceStateMap != null && instanceStateMap.containsKey(instanceName)) {
-          partitionsStillOnInstance.add(partitionInfo);
+      // Any partition assigned to this instance in IdealState also blocks evacuation, even if
+      // not present in CurrentState (e.g., new assignment the offline instance hasn't picked up).
+      Map<String, Map<String, String>> mapFields = idealState.getRecord().getMapFields();
+      if (mapFields != null) {
+        for (Map.Entry<String, Map<String, String>> isEntry : mapFields.entrySet()) {
+          String partition = isEntry.getKey();
+          if (seenPartitions.contains(partition)) {
+            continue;
+          }
+          Map<String, String> instanceStateMap = isEntry.getValue();
+          if (instanceStateMap != null && instanceStateMap.containsKey(instanceName)) {
+            String desiredState = instanceStateMap.get(instanceName);
+            if (seenPartitions.add(partition)) {
+              partitionsStillOnInstance.add(
+                  new PartitionInfo(partition, desiredState, resourceName));
+            }
+          }
         }
       }
     }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestEvacuateWithExclusions.java
@@ -309,7 +309,9 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
   }
 
   /**
-   * Test offline instance with CUSTOMIZED resources
+   * Test offline instance with CUSTOMIZED resources uses union semantics.
+   * Evacuation remains in-progress if partitions still exist in CurrentState,
+   * even after the instance is removed from IdealState.
    */
   @Test
   public void testOfflineInstanceWithCustomizedResource() throws Exception {
@@ -362,9 +364,10 @@ public class TestEvacuateWithExclusions extends TaskTestBase {
     _gSetupTool.getClusterManagementTool().setResourceIdealState(CLUSTER_NAME, customDB, newIdealState);
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
-    // Now evacuation SHOULD be finished
-    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet()),
-        "Evacuation should be finished after removing instance from CUSTOMIZED IdealState");
+    // With union semantics, evacuation is still NOT finished because the offline instance
+    // still has CurrentState entries for this resource.
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate, Collections.emptySet()),
+        "Evacuation should remain in progress while CurrentState still has partitions, even if IdealState no longer assigns the instance");
 
     // Cleanup
     _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, customDB);


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fix offline CUSTOMIZED evacuation check to use union instead of intersection
(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
For offline instances, treat blocking partitions as the union of CurrentState partitions and IdealState assignments, instead of only their intersection. This prevents false evacuation completion when IdealState partition names rotate but the instance still has CurrentState entries. 

Context: this is the behavior that pinot desires. They want union and not the intersection(current behavior). Because of this behavior one of their instance was prematurely deleted.

### Tests
Modified existing tests.
- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
