### PR TITLE
Validate instance operation transitions against merged config instead of stale ZK state

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -901,15 +901,13 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       Command command) {
     InstanceConfig originalInstanceConfigCopy =
         configAccessor.getInstanceConfig(clusterName, instanceName);
+    // Capture current operation before merging, since the merge will overwrite it.
     InstanceConstants.InstanceOperation currentOperation = originalInstanceConfigCopy.getInstanceOperation().getOperation();
     InstanceConstants.InstanceOperation targetOperation = newInstanceConfig.getInstanceOperation().getOperation();
-    try {
-      InstanceUtil.validateInstanceOperationTransition(configAccessor, clusterName, originalInstanceConfigCopy,
-          currentOperation, targetOperation);
-    } catch (HelixException e) {
-      throw new IllegalArgumentException(String.format(
-          "Failed topology setting update in instance %s, got exception %s", instanceName, e));
-    }
+
+    // Merge first so that DOMAIN and other fields are up-to-date before validating the
+    // operation transition. This is critical for swap-in where the caller updates the DOMAIN
+    // (to match the swap-out instance's logical ID) and sets SWAP_IN in a single request.
     if (command == Command.delete) {
       for (Map.Entry<String, String> entry : newInstanceConfig.getRecord().getSimpleFields()
           .entrySet()) {
@@ -917,6 +915,14 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       }
     } else {
       originalInstanceConfigCopy.getRecord().update(newInstanceConfig.getRecord());
+    }
+
+    try {
+      InstanceUtil.validateInstanceOperationTransition(configAccessor, clusterName, originalInstanceConfigCopy,
+          currentOperation, targetOperation);
+    } catch (HelixException e) {
+      throw new IllegalArgumentException(String.format(
+          "Failed topology setting update in instance %s, got exception %s", instanceName, e));
     }
     return originalInstanceConfigCopy
         .validateTopologySettingInInstanceConfig(configAccessor.getClusterConfig(clusterName),

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -1129,6 +1129,178 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
 
   }
 
+  /**
+   * Test that updating DOMAIN and SWAP_IN operation in a single request succeeds.
+   * This verifies that the merge of the new config happens before validation so that
+   * the updated DOMAIN (with a matching logical ID) is used for the transition check.
+   */
+  @Test
+  public void testSwapInWithDomainUpdateInSingleRequest() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+
+    // Set up topology on the cluster
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setTopologyAwareEnabled(true);
+    clusterConfig.setTopology("/zone/instance");
+    clusterConfig.setFaultZoneType("zone");
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    String swapOutInstance = CLUSTER_NAME + "localhost_12918";
+    String swapInInstance = CLUSTER_NAME + "localhost_12919";
+
+    // Set up swap-out instance with ENABLE and a specific logical ID in the DOMAIN
+    InstanceConfig swapOutConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapOutInstance);
+    swapOutConfig.setDomain("zone=zone_A,instance=LogicalId_A,host=" + swapOutInstance);
+    swapOutConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapOutInstance, swapOutConfig);
+
+    // Set up swap-in instance with UNKNOWN and a DIFFERENT logical ID in the DOMAIN
+    InstanceConfig swapInConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapInInstance);
+    swapInConfig.setDomain("zone=zone_A,instance=DifferentId,host=" + swapInInstance);
+    swapInConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.UNKNOWN)
+            .setSource(InstanceConstants.InstanceOperationSource.USER).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapInInstance, swapInConfig);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // Build a request that updates BOTH the DOMAIN (to match swap-out) AND sets SWAP_IN.
+    // This simulates what ACM does in setSwapInOperationAndEditConfigIfNeeded.
+    InstanceConfig updatedSwapInConfig = new InstanceConfig(swapInConfig.getRecord());
+    updatedSwapInConfig.setDomain("zone=zone_A,instance=LogicalId_A,host=" + swapInInstance);
+    updatedSwapInConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    updatedSwapInConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.SWAP_IN)
+            .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).build());
+
+    Entity entity = Entity.entity(
+        OBJECT_MAPPER.writeValueAsString(updatedSwapInConfig.getRecord()),
+        MediaType.APPLICATION_JSON_TYPE);
+
+    // This should succeed because the merged config has the correct DOMAIN for matching
+    new JerseyUriRequestBuilder("clusters/{}/instances/{}/configs?command=update")
+        .format(CLUSTER_NAME, swapInInstance)
+        .post(this, entity);
+
+    // Verify the config was updated in ZK
+    InstanceConfig resultConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapInInstance);
+    Assert.assertEquals(resultConfig.getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.SWAP_IN);
+    Assert.assertTrue(resultConfig.getDomainAsString().contains("instance=LogicalId_A"));
+
+    // Clean up: reset both instances to ENABLE with original domains
+    swapOutConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapOutInstance);
+    swapOutConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapOutInstance, swapOutConfig);
+
+    swapInConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapInInstance);
+    swapInConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapInInstance, swapInConfig);
+
+    // Reset topology
+    clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setTopologyAwareEnabled(false);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  /**
+   * Test that SWAP_IN without updating DOMAIN to match fails when logical IDs differ.
+   */
+  @Test
+  public void testSwapInWithoutMatchingDomainFails() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+
+    // Set up topology on the cluster
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setTopologyAwareEnabled(true);
+    clusterConfig.setTopology("/zone/instance");
+    clusterConfig.setFaultZoneType("zone");
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    String swapOutInstance = CLUSTER_NAME + "localhost_12918";
+    String swapInInstance = CLUSTER_NAME + "localhost_12919";
+
+    // Set up swap-out with ENABLE and a specific logical ID
+    InstanceConfig swapOutConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapOutInstance);
+    swapOutConfig.setDomain("zone=zone_A,instance=LogicalId_B,host=" + swapOutInstance);
+    swapOutConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapOutInstance, swapOutConfig);
+
+    // Set up swap-in with UNKNOWN and a DIFFERENT logical ID
+    InstanceConfig swapInConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapInInstance);
+    swapInConfig.setDomain("zone=zone_A,instance=MismatchedId,host=" + swapInInstance);
+    swapInConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.UNKNOWN)
+            .setSource(InstanceConstants.InstanceOperationSource.USER).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapInInstance, swapInConfig);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // Build a request that sets SWAP_IN but does NOT update the DOMAIN to match.
+    InstanceConfig badConfig = new InstanceConfig(swapInConfig.getRecord());
+    badConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    badConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.SWAP_IN)
+            .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).build());
+
+    Entity entity = Entity.entity(
+        OBJECT_MAPPER.writeValueAsString(badConfig.getRecord()),
+        MediaType.APPLICATION_JSON_TYPE);
+
+    // This should fail because even after merging, the DOMAIN still doesn't match
+    new JerseyUriRequestBuilder("clusters/{}/instances/{}/configs?command=update")
+        .expectedReturnStatusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+        .format(CLUSTER_NAME, swapInInstance)
+        .post(this, entity);
+
+    // Clean up
+    swapOutConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapOutInstance);
+    swapOutConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapOutInstance, swapOutConfig);
+
+    swapInConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapInInstance);
+    swapInConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapInInstance, swapInConfig);
+
+    clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setTopologyAwareEnabled(false);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
   @Test(dependsOnMethods = "testValidateDeltaInstanceConfigForUpdate")
   public void testGetResourcesOnInstance() throws JsonProcessingException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestPerInstanceAccessor.java
@@ -1301,6 +1301,101 @@ public class TestPerInstanceAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
+  /**
+   * Test that a delete command removing the DOMAIN field causes the operation transition
+   * validation to fail when the transition depends on logical ID matching.
+   * Before the merge-before-validate fix, the validation would have passed because it ran
+   * against the original config (which still had the DOMAIN). Now the DOMAIN is removed
+   * before validation, so the logical ID matching correctly fails.
+   */
+  @Test
+  public void testDeleteDomainFailsWhenTransitionDependsOnLogicalId() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+
+    // Set up topology on the cluster
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setTopologyAwareEnabled(true);
+    clusterConfig.setTopology("/zone/instance");
+    clusterConfig.setFaultZoneType("zone");
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    String swapOutInstance = CLUSTER_NAME + "localhost_12918";
+    String swapInInstance = CLUSTER_NAME + "localhost_12919";
+
+    // Set up swap-out instance with ENABLE and a specific logical ID
+    InstanceConfig swapOutConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapOutInstance);
+    swapOutConfig.setDomain("zone=zone_A,instance=LogicalId_C,host=" + swapOutInstance);
+    swapOutConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapOutInstance, swapOutConfig);
+
+    // Set up swap-in instance with UNKNOWN and a MATCHING logical ID
+    InstanceConfig swapInConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapInInstance);
+    swapInConfig.setDomain("zone=zone_A,instance=LogicalId_C,host=" + swapInInstance);
+    swapInConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.UNKNOWN)
+            .setSource(InstanceConstants.InstanceOperationSource.USER).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapInInstance, swapInConfig);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    // Build a DELETE request that removes the DOMAIN field and sets SWAP_IN.
+    // The DOMAIN deletion happens before validation, so logical ID matching
+    // will fail because the config no longer has the DOMAIN field.
+    InstanceConfig deleteConfig = new InstanceConfig(swapInInstance);
+    deleteConfig.setDomain("zone=zone_A,instance=LogicalId_C,host=" + swapInInstance);
+    deleteConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    deleteConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.SWAP_IN)
+            .setSource(InstanceConstants.InstanceOperationSource.AUTOMATION).build());
+
+    Entity entity = Entity.entity(
+        OBJECT_MAPPER.writeValueAsString(deleteConfig.getRecord()),
+        MediaType.APPLICATION_JSON_TYPE);
+
+    // Should fail because the delete removes the DOMAIN before validation,
+    // so no matching logical ID is found for the UNKNOWN->SWAP_IN transition.
+    new JerseyUriRequestBuilder("clusters/{}/instances/{}/configs?command=delete")
+        .expectedReturnStatusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+        .format(CLUSTER_NAME, swapInInstance)
+        .post(this, entity);
+
+    // Verify the original config is unchanged in ZK
+    InstanceConfig resultConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapInInstance);
+    Assert.assertEquals(resultConfig.getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
+    Assert.assertTrue(resultConfig.getDomainAsString().contains("instance=LogicalId_C"));
+
+    // Clean up
+    swapOutConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapOutInstance);
+    swapOutConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapOutInstance, swapOutConfig);
+
+    swapInConfig = _configAccessor.getInstanceConfig(CLUSTER_NAME, swapInInstance);
+    swapInConfig.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(InstanceConstants.InstanceOperation.ENABLE)
+            .setSource(InstanceConstants.InstanceOperationSource.ADMIN).build());
+    _configAccessor.setInstanceConfig(CLUSTER_NAME, swapInInstance, swapInConfig);
+
+    clusterConfig = _configAccessor.getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setTopologyAwareEnabled(false);
+    _configAccessor.setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
   @Test(dependsOnMethods = "testValidateDeltaInstanceConfigForUpdate")
   public void testGetResourcesOnInstance() throws JsonProcessingException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Validate instance operation transitions against merged config instead of stale ZK state
(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
When an atomic config update changes both the instance's DOMAIN (logicalId) and the HELIX_INSTANCE_OPERATIONS (from UNKNOWN to SWAP_IN) in a single REST POST to /clusters/venice-4/instances/ltx1-app100016.xyz_1690/configs, the operation transition validation fails with:

Failed validation for instance operation transition from UNKNOWN to SWAP_IN
This is because PerInstanceAccessor.validateDeltaTopologySettingInInstanceConfig validates the transition using the original instance config from ZooKeeper, not the incoming one. The UNKNOWN to SWAP_IN transition requires ANY_MATCH_ENABLE_OR_DISABLE , at least one instance with a matching logicalId must have ENABLE or DISABLE operation. Since the validator looks up matches using the pre-update logicalId (which differs from the swap-out's logicalId), it finds no matches and rejects the transition.

This blocks all swap operations for applications whose swap-in instances join with a bootstrap logicalId  that differs from the swap-out's logicalId. Helix ACM's setSwapInOperationAndEditConfigIfNeeded intentionally updates both fields atomically to avoid a window where two instances share the same logicalId without being in a swap relationship. The result is an infinite retry loop,  the swap-out stays in PREPARING and the swap-in never transitions to SWAP_IN.

The fix moves the config merge before the validation so that transition checks run against the intended final state of the
instance config, while still capturing the current operation from the original ZK config to preserve correct transition semantics.

### Tests

- [ ] The following tests are written for this issue:
New tests
(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
