### PR TITLE
Add cluster config flag for IntermediateStateCalcStage V2 Enablement

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -64,13 +64,23 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
   @Override
   public void process(ClusterEvent event) throws Exception {
     _eventId = event.getEventId();
+
+    // Check if V2 is enabled via cluster config and delegate if so
+    ResourceControllerDataProvider cache =
+        event.getAttribute(AttributeName.ControllerDataProvider.name());
+    if (cache != null && cache.getClusterConfig() != null
+        && cache.getClusterConfig().isIntermediateStateCalcStageV2Enabled()) {
+      LogUtil.logInfo(logger, _eventId,
+          "IntermediateStateCalcStage V2 is enabled via cluster config. Delegating to V2.");
+      new IntermediateStateCalcStageV2().process(event);
+      return;
+    }
+
     CurrentStateOutput currentStateOutput = event.getAttribute(AttributeName.CURRENT_STATE.name());
     BestPossibleStateOutput bestPossibleStateOutput =
         event.getAttribute(AttributeName.BEST_POSSIBLE_STATE.name());
     Map<String, Resource> resourceToRebalance =
         event.getAttribute(AttributeName.RESOURCES_TO_REBALANCE.name());
-    ResourceControllerDataProvider cache =
-        event.getAttribute(AttributeName.ControllerDataProvider.name());
     MessageOutput messageOutput = event.getAttribute(AttributeName.MESSAGES_SELECTED.name());
 
     if (currentStateOutput == null || bestPossibleStateOutput == null || resourceToRebalance == null

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -72,7 +72,7 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
         && cache.getClusterConfig().isIntermediateStateCalcStageV2Enabled()) {
       LogUtil.logInfo(logger, _eventId,
           "IntermediateStateCalcStage V2 is enabled via cluster config. Delegating to V2.");
-      new IntermediateStateCalcStageV2().process(event);
+      createV2Stage().process(event);
       return;
     }
 
@@ -103,6 +103,10 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       validateMaxPartitionsPerInstance(event, cache, intermediateStateOutput,
           maxPartitionPerInstance);
     }
+  }
+
+  protected IntermediateStateCalcStageV2 createV2Stage() {
+    return new IntermediateStateCalcStageV2();
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -177,6 +177,11 @@ public class ClusterConfig extends HelixProperty {
     // When enabled, messages are prioritized based on availability impact score across all resources,
     // rather than processing resources in priority order.
     AVAILABILITY_AWARE_PRIORITIZATION_ENABLED,
+
+    // Enable the refactored IntermediateStateCalcStage (V2) which uses a strategy pattern
+    // for message ordering and extracted throttle logic. When disabled (default), the original
+    // IntermediateStateCalcStage (V1) is used for backward compatibility.
+    INTERMEDIATE_STATE_CALC_STAGE_V2_ENABLED,
   }
 
   public enum GlobalRebalancePreferenceKey {
@@ -851,6 +856,28 @@ public class ClusterConfig extends HelixProperty {
    */
   public boolean isAvailabilityAwarePrioritizationEnabled() {
     return _record.getBooleanField(ClusterConfigProperty.AVAILABILITY_AWARE_PRIORITIZATION_ENABLED.name(), false);
+  }
+
+  /**
+   * Enable or disable the refactored IntermediateStateCalcStage (V2).
+   * When enabled, the controller uses IntermediateStateCalcStageV2 which features a strategy
+   * pattern for message ordering and extracted throttle logic. When disabled (default), the
+   * original IntermediateStateCalcStage (V1) is used for backward compatibility.
+   * @param enabled true to enable V2, false to use V1 (default)
+   */
+  public void setIntermediateStateCalcStageV2Enabled(boolean enabled) {
+    _record.setBooleanField(
+        ClusterConfigProperty.INTERMEDIATE_STATE_CALC_STAGE_V2_ENABLED.name(), enabled);
+  }
+
+  /**
+   * Check whether the refactored IntermediateStateCalcStage (V2) is enabled.
+   * By default, it is DISABLED (V1 is used).
+   * @return true if V2 is enabled
+   */
+  public boolean isIntermediateStateCalcStageV2Enabled() {
+    return _record.getBooleanField(
+        ClusterConfigProperty.INTERMEDIATE_STATE_CALC_STAGE_V2_ENABLED.name(), false);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.helix.api.config.StateTransitionThrottleConfig;
@@ -959,11 +960,18 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     runStage(event, new ReadClusterDataStage());
 
     // Run V1 stage -- it should delegate to V2
-    runStage(event, new IntermediateStateCalcStage());
+    AtomicBoolean v2Created = new AtomicBoolean(false);
+    IntermediateStateCalcStage stage = new IntermediateStateCalcStage() {
+      @Override
+      protected IntermediateStateCalcStageV2 createV2Stage() {
+        v2Created.set(true);
+        return super.createV2Stage();
+      }
+    };
+    runStage(event, stage);
 
-    // Verify intermediate state was computed (by V2)
-    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
-    Assert.assertNotNull(output, "V2 should have computed intermediate state output");
+    // Verify V2 was instantiated
+    Assert.assertTrue(v2Created.get(), "V2 stage should have been instantiated when enabled");
   }
 
   @Test
@@ -1014,10 +1022,20 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
         new ResourceControllerDataProvider());
     runStage(event, new ReadClusterDataStage());
 
-    // Run V1 stage -- it should use V1 logic
-    runStage(event, new IntermediateStateCalcStage());
+    // Run V1 stage -- it should use V1 logic, not delegate to V2
+    AtomicBoolean v2Created = new AtomicBoolean(false);
+    IntermediateStateCalcStage stage = new IntermediateStateCalcStage() {
+      @Override
+      protected IntermediateStateCalcStageV2 createV2Stage() {
+        v2Created.set(true);
+        return super.createV2Stage();
+      }
+    };
+    runStage(event, stage);
 
-    // Verify intermediate state was computed (by V1)
+    // Verify V2 was NOT instantiated
+    Assert.assertFalse(v2Created.get(), "V2 stage should NOT have been instantiated when disabled");
+    // Also verify V1 produced output
     IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
     Assert.assertNotNull(output, "V1 should have computed intermediate state output");
   }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -909,6 +909,119 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
     }
   }
 
+  @Test
+  public void testDelegatesToV2WhenEnabled() {
+    String resourcePrefix = "resource";
+    int nResource = 2;
+    int nPartition = 2;
+    int nReplica = 3;
+
+    String[] resources = new String[nResource];
+    for (int i = 0; i < nResource; i++) {
+      resources[i] = resourcePrefix + "_" + i;
+    }
+
+    preSetup(resources, nReplica, nReplica);
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+
+    // Enable V2
+    _clusterConfig.setIntermediateStateCalcStageV2Enabled(true);
+    _clusterConfig.setErrorOrRecoveryPartitionThresholdForLoadBalance(1);
+    setClusterConfig(_clusterConfig);
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+
+    for (String resource : resources) {
+      IdealState is = accessor.getProperty(accessor.keyBuilder().idealStates(resource));
+      setSingleIdealState(is);
+
+      for (int p = 0; p < nPartition; p++) {
+        Partition partition = new Partition(resource + "_" + p);
+        for (int r = 0; r < nReplica; r++) {
+          String instanceName = HOSTNAME_PREFIX + r;
+          currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
+          bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+        }
+      }
+    }
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+    runStage(event, new ReadClusterDataStage());
+
+    // Run V1 stage -- it should delegate to V2
+    runStage(event, new IntermediateStateCalcStage());
+
+    // Verify intermediate state was computed (by V2)
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+    Assert.assertNotNull(output, "V2 should have computed intermediate state output");
+  }
+
+  @Test
+  public void testUsesV1WhenV2Disabled() {
+    String resourcePrefix = "resource";
+    int nResource = 2;
+    int nPartition = 2;
+    int nReplica = 3;
+
+    String[] resources = new String[nResource];
+    for (int i = 0; i < nResource; i++) {
+      resources[i] = resourcePrefix + "_" + i;
+    }
+
+    preSetup(resources, nReplica, nReplica);
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "OnlineOffline"));
+
+    // V2 not enabled (default false)
+    _clusterConfig.setErrorOrRecoveryPartitionThresholdForLoadBalance(1);
+    setClusterConfig(_clusterConfig);
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+
+    for (String resource : resources) {
+      IdealState is = accessor.getProperty(accessor.keyBuilder().idealStates(resource));
+      setSingleIdealState(is);
+
+      for (int p = 0; p < nPartition; p++) {
+        Partition partition = new Partition(resource + "_" + p);
+        for (int r = 0; r < nReplica; r++) {
+          String instanceName = HOSTNAME_PREFIX + r;
+          currentStateOutput.setCurrentState(resource, partition, instanceName, "ONLINE");
+          bestPossibleStateOutput.setState(resource, partition, instanceName, "ONLINE");
+        }
+      }
+    }
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+    runStage(event, new ReadClusterDataStage());
+
+    // Run V1 stage -- it should use V1 logic
+    runStage(event, new IntermediateStateCalcStage());
+
+    // Verify intermediate state was computed (by V1)
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+    Assert.assertNotNull(output, "V1 should have computed intermediate state output");
+  }
+
   private void preSetup(String[] resources, int numOfLiveInstances, int numOfReplicas) {
     setupIdealState(numOfLiveInstances, resources, numOfLiveInstances, numOfReplicas,
         IdealState.RebalanceMode.FULL_AUTO, "OnlineOffline");

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -428,4 +428,20 @@ public class TestClusterConfig {
       // expected
     }
   }
+
+  @Test
+  public void testIntermediateStateCalcStageV2Enabled() {
+    ClusterConfig clusterConfig = new ClusterConfig("testCluster");
+
+    // Default should be disabled
+    Assert.assertFalse(clusterConfig.isIntermediateStateCalcStageV2Enabled());
+
+    // Enable
+    clusterConfig.setIntermediateStateCalcStageV2Enabled(true);
+    Assert.assertTrue(clusterConfig.isIntermediateStateCalcStageV2Enabled());
+
+    // Disable
+    clusterConfig.setIntermediateStateCalcStageV2Enabled(false);
+    Assert.assertFalse(clusterConfig.isIntermediateStateCalcStageV2Enabled());
+  }
 }


### PR DESCRIPTION
### Issues

- [x] My PR adds a cluster config flag to control IntermediateStateCalcStage V2 entry in the rebalance pipeline

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Adds `INTERMEDIATE_STATE_CALC_STAGE_V2_ENABLED` cluster config property to dynamically switch between V1 and V2 IntermediateStateCalcStage at runtime. When enabled, V1's `process()` delegates to V2 which uses strategy pattern for message ordering and extracted throttle logic. Defaults to disabled (V1) for backward compatibility — no behavioral change unless explicitly opted in. Config changes take effect on the next pipeline invocation (no restart needed).

**Changes:**
- **ClusterConfig.java**: New enum entry + getter/setter (`isIntermediateStateCalcStageV2Enabled()` / `setIntermediateStateCalcStageV2Enabled()`)
- **IntermediateStateCalcStage.java**: Delegation check at top of `process()` — routes to V2 when flag is enabled
- **TestClusterConfig.java**: Unit test for default value, enable/disable round-trip
- **TestIntermediateStateCalcStage.java**: Tests for V2 delegation when enabled and V1 usage when disabled

### Tests

- [x] The following tests are written for this issue:

- `TestClusterConfig#testIntermediateStateCalcStageV2Enabled` — verifies config flag default and round-trip
- `TestIntermediateStateCalcStage#testDelegatesToV2WhenEnabled` — verifies V2 executes when flag is on
- `TestIntermediateStateCalcStage#testUsesV1WhenV2Disabled` — verifies V1 executes when flag is off
- All 10 existing IntermediateStateCalcStage tests pass (backward compatibility)

```
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

### Changes that Break Backward Compatibility (Optional)

None. The new config flag defaults to `false`, preserving existing V1 behavior.

### Commits

- [x] Commits follow the guidelines from "How to write a good git commit message"