### PR TITLE
Add lenient match mode to StrictMatchExternalViewVerifier

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -92,8 +92,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
   private StrictMatchExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Set<String> expectLiveInstances, boolean isDeactivatedNodeAware,
       boolean isLenientMatch, int waitPeriodTillVerify, boolean usesExternalZkClient) {
-    // Initialize StrictMatchExternalViewVerifier with usesExternalZkClient = false so that
-    // StrictMatchExternalViewVerifier::close() would close ZkClient to prevent thread leakage
+    // When usesExternalZkClient is false, close() will close the client to prevent thread leakage.
     super(zkClient, clusterName, usesExternalZkClient, waitPeriodTillVerify);
     _resources = resources == null ? new HashSet<>() : new HashSet<>(resources);
     _expectLiveInstances =
@@ -336,6 +335,10 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
       // ignore jobs
     default:
       return true;
+    }
+
+    if (!_isLenientMatch) {
+      return mappingInExternalView.equals(idealPartitionState);
     }
 
     StateModelDefinition stateModelDef =

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixException;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
@@ -56,11 +57,12 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
   private final Set<String> _resources;
   private final Set<String> _expectLiveInstances;
   private final boolean _isDeactivatedNodeAware;
+  private final boolean _isLenientMatch;
 
   @Deprecated
   public StrictMatchExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
       Set<String> expectLiveInstances) {
-    this(zkAddr, clusterName, resources, expectLiveInstances, false, 0);
+    this(zkAddr, clusterName, resources, expectLiveInstances, false, false, 0);
   }
 
   @Deprecated
@@ -73,20 +75,23 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
     _expectLiveInstances =
         expectLiveInstances == null ? new HashSet<>() : new HashSet<>(expectLiveInstances);
     _isDeactivatedNodeAware = false;
+    _isLenientMatch = false;
   }
 
   @Deprecated
   private StrictMatchExternalViewVerifier(String zkAddr, String clusterName, Set<String> resources,
-      Set<String> expectLiveInstances, boolean isDeactivatedNodeAware, int waitTillVerify) {
+      Set<String> expectLiveInstances, boolean isDeactivatedNodeAware, boolean isLenientMatch,
+      int waitTillVerify) {
     super(zkAddr, clusterName, waitTillVerify);
     _resources = resources;
     _expectLiveInstances = expectLiveInstances;
     _isDeactivatedNodeAware = isDeactivatedNodeAware;
+    _isLenientMatch = isLenientMatch;
   }
 
   private StrictMatchExternalViewVerifier(RealmAwareZkClient zkClient, String clusterName,
       Set<String> resources, Set<String> expectLiveInstances, boolean isDeactivatedNodeAware,
-      int waitPeriodTillVerify, boolean usesExternalZkClient) {
+      boolean isLenientMatch, int waitPeriodTillVerify, boolean usesExternalZkClient) {
     // Initialize StrictMatchExternalViewVerifier with usesExternalZkClient = false so that
     // StrictMatchExternalViewVerifier::close() would close ZkClient to prevent thread leakage
     super(zkClient, clusterName, usesExternalZkClient, 0);
@@ -94,6 +99,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
     _expectLiveInstances =
         expectLiveInstances == null ? new HashSet<>() : new HashSet<>(expectLiveInstances);
     _isDeactivatedNodeAware = isDeactivatedNodeAware;
+    _isLenientMatch = isLenientMatch;
   }
 
   public static class Builder extends ZkHelixClusterVerifier.Builder<Builder> {
@@ -103,6 +109,9 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
     private RealmAwareZkClient _zkClient;
     // For backward compatibility, set the default isDeactivatedNodeAware to be false.
     private boolean _isDeactivatedNodeAware = false;
+    // For backward compatibility, set the default isLenientMatch to be false.
+    // When true, OFFLINE (initialState) and DROPPED entries are stripped before comparison.
+    private boolean _isLenientMatch = false;
     private boolean _usesExternalZkClient = false; // false by default
 
     public StrictMatchExternalViewVerifier build() {
@@ -112,22 +121,23 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
 
       if (_zkClient != null) {
         return new StrictMatchExternalViewVerifier(_zkClient, _clusterName, _resources,
-            _expectLiveInstances, _isDeactivatedNodeAware, _waitPeriodTillVerify,
-            _usesExternalZkClient);
+            _expectLiveInstances, _isDeactivatedNodeAware, _isLenientMatch,
+            _waitPeriodTillVerify, _usesExternalZkClient);
       }
 
       if (_realmAwareZkConnectionConfig == null || _realmAwareZkClientConfig == null) {
         // For backward-compatibility
         return new StrictMatchExternalViewVerifier(_zkAddress, _clusterName, _resources,
-            _expectLiveInstances, _isDeactivatedNodeAware, _waitPeriodTillVerify);
+            _expectLiveInstances, _isDeactivatedNodeAware, _isLenientMatch,
+            _waitPeriodTillVerify);
       }
 
       validate();
       return new StrictMatchExternalViewVerifier(
           createZkClient(RealmAwareZkClient.RealmMode.SINGLE_REALM, _realmAwareZkConnectionConfig,
               _realmAwareZkClientConfig, _zkAddress), _clusterName, _resources,
-          _expectLiveInstances, _isDeactivatedNodeAware, _waitPeriodTillVerify,
-          _usesExternalZkClient);
+          _expectLiveInstances, _isDeactivatedNodeAware, _isLenientMatch,
+          _waitPeriodTillVerify, _usesExternalZkClient);
     }
 
     public Builder(String clusterName) {
@@ -173,6 +183,15 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
 
     public Builder setDeactivatedNodeAwareness(boolean isDeactivatedNodeAware) {
       _isDeactivatedNodeAware = isDeactivatedNodeAware;
+      return this;
+    }
+
+    public boolean getLenientMatch() {
+      return _isLenientMatch;
+    }
+
+    public Builder setLenientMatch(boolean isLenientMatch) {
+      _isLenientMatch = isLenientMatch;
       return this;
     }
 
@@ -319,7 +338,48 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
       return true;
     }
 
+    if (_isLenientMatch) {
+      String stateModelDefName = idealState.getStateModelDefRef();
+      StateModelDefinition stateModelDef = dataCache.getStateModelDef(stateModelDefName);
+      if (stateModelDef != null) {
+        Set<String> ignoreStates = new HashSet<>(
+            Arrays.asList(stateModelDef.getInitialState(), HelixDefinedState.DROPPED.toString()));
+        Map<String, Map<String, String>> evCopy = deepCopyMapFields(mappingInExtview);
+        Map<String, Map<String, String>> idealCopy = deepCopyMapFields(idealPartitionState);
+        removeEntriesWithIgnoredStates(evCopy.entrySet().iterator(), ignoreStates);
+        removeEntriesWithIgnoredStates(idealCopy.entrySet().iterator(), ignoreStates);
+        return evCopy.equals(idealCopy);
+      }
+    }
     return mappingInExtview.equals(idealPartitionState);
+  }
+
+  private static Map<String, Map<String, String>> deepCopyMapFields(
+      Map<String, Map<String, String>> original) {
+    Map<String, Map<String, String>> copy = new HashMap<>();
+    for (Map.Entry<String, Map<String, String>> entry : original.entrySet()) {
+      copy.put(entry.getKey(), new HashMap<>(entry.getValue()));
+    }
+    return copy;
+  }
+
+  private void removeEntriesWithIgnoredStates(
+      Iterator<Map.Entry<String, Map<String, String>>> partitionInstanceStateMapIter,
+      Set<String> ignoredStates) {
+    while (partitionInstanceStateMapIter.hasNext()) {
+      Map.Entry<String, Map<String, String>> entry = partitionInstanceStateMapIter.next();
+      Map<String, String> instanceStateMap = entry.getValue();
+      Iterator<Map.Entry<String, String>> insIter = instanceStateMap.entrySet().iterator();
+      while (insIter.hasNext()) {
+        String state = insIter.next().getValue();
+        if (ignoredStates.contains(state)) {
+          insIter.remove();
+        }
+      }
+      if (instanceStateMap.isEmpty()) {
+        partitionInstanceStateMapIter.remove();
+      }
+    }
   }
 
   private Map<String, Map<String, String>> computeIdealPartitionState(

--- a/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
+++ b/helix-core/src/main/java/org/apache/helix/tools/ClusterVerifiers/StrictMatchExternalViewVerifier.java
@@ -94,7 +94,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
       boolean isLenientMatch, int waitPeriodTillVerify, boolean usesExternalZkClient) {
     // Initialize StrictMatchExternalViewVerifier with usesExternalZkClient = false so that
     // StrictMatchExternalViewVerifier::close() would close ZkClient to prevent thread leakage
-    super(zkClient, clusterName, usesExternalZkClient, 0);
+    super(zkClient, clusterName, usesExternalZkClient, waitPeriodTillVerify);
     _resources = resources == null ? new HashSet<>() : new HashSet<>(resources);
     _expectLiveInstances =
         expectLiveInstances == null ? new HashSet<>() : new HashSet<>(expectLiveInstances);
@@ -307,7 +307,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
 
   private boolean verifyExternalView(ResourceControllerDataProvider dataCache, ExternalView externalView,
       IdealState idealState) {
-    Map<String, Map<String, String>> mappingInExtview = externalView.getRecord().getMapFields();
+    Map<String, Map<String, String>> mappingInExternalView = externalView.getRecord().getMapFields();
     Map<String, Map<String, String>> idealPartitionState;
 
     switch (idealState.getRebalanceMode()) {
@@ -338,20 +338,28 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
       return true;
     }
 
-    if (_isLenientMatch) {
-      String stateModelDefName = idealState.getStateModelDefRef();
-      StateModelDefinition stateModelDef = dataCache.getStateModelDef(stateModelDefName);
-      if (stateModelDef != null) {
-        Set<String> ignoreStates = new HashSet<>(
-            Arrays.asList(stateModelDef.getInitialState(), HelixDefinedState.DROPPED.toString()));
-        Map<String, Map<String, String>> evCopy = deepCopyMapFields(mappingInExtview);
-        Map<String, Map<String, String>> idealCopy = deepCopyMapFields(idealPartitionState);
-        removeEntriesWithIgnoredStates(evCopy.entrySet().iterator(), ignoreStates);
-        removeEntriesWithIgnoredStates(idealCopy.entrySet().iterator(), ignoreStates);
-        return evCopy.equals(idealCopy);
-      }
+    StateModelDefinition stateModelDef =
+        dataCache.getStateModelDef(idealState.getStateModelDefRef());
+    return compareMappings(mappingInExternalView, idealPartitionState, stateModelDef);
+  }
+
+  private boolean compareMappings(Map<String, Map<String, String>> actualMappings,
+      Map<String, Map<String, String>> expectedMappings, StateModelDefinition stateModelDef) {
+    if (!_isLenientMatch || stateModelDef == null) {
+      return actualMappings.equals(expectedMappings);
     }
-    return mappingInExtview.equals(idealPartitionState);
+
+    Set<String> ignoredStates = new HashSet<>(
+        Arrays.asList(stateModelDef.getInitialState(), HelixDefinedState.DROPPED.toString()));
+    return copyWithoutIgnoredStates(actualMappings, ignoredStates)
+        .equals(copyWithoutIgnoredStates(expectedMappings, ignoredStates));
+  }
+
+  private static Map<String, Map<String, String>> copyWithoutIgnoredStates(
+      Map<String, Map<String, String>> original, Set<String> ignoredStates) {
+    Map<String, Map<String, String>> copiedMappings = deepCopyMapFields(original);
+    removeEntriesWithIgnoredStates(copiedMappings.entrySet().iterator(), ignoredStates);
+    return copiedMappings;
   }
 
   private static Map<String, Map<String, String>> deepCopyMapFields(
@@ -363,7 +371,7 @@ public class StrictMatchExternalViewVerifier extends ZkHelixClusterVerifier {
     return copy;
   }
 
-  private void removeEntriesWithIgnoredStates(
+  private static void removeEntriesWithIgnoredStates(
       Iterator<Map.Entry<String, Map<String, String>>> partitionInstanceStateMapIter,
       Set<String> ignoredStates) {
     while (partitionInstanceStateMapIter.hasNext()) {

--- a/helix-core/src/test/java/org/apache/helix/tools/TestClusterVerifier.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestClusterVerifier.java
@@ -320,4 +320,87 @@ public class TestClusterVerifier extends ZkUnitTestBase {
         .build();
     Assert.assertTrue(bestPossibleVerifier.verify(10000));
   }
+
+  @Test
+  public void testLenientMatchStableCluster() throws InterruptedException {
+    // When cluster is fully stable, lenient match should pass just like strict match
+    HelixClusterVerifier strictVerifier =
+        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(RESOURCES)).setDeactivatedNodeAwareness(true)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertTrue(strictVerifier.verify(10000));
+
+    HelixClusterVerifier lenientVerifier =
+        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(RESOURCES)).setDeactivatedNodeAwareness(true)
+            .setLenientMatch(true)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertTrue(lenientVerifier.verify(10000));
+  }
+
+  @Test
+  public void testLenientMatchWithStoppedParticipant() throws InterruptedException {
+    // Ensure stable first
+    HelixClusterVerifier lenientVerifier =
+        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(SEMI_AUTO_RESOURCES)).setDeactivatedNodeAwareness(true)
+            .setLenientMatch(true)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertTrue(lenientVerifier.verify(10000));
+
+    // Stop a participant — creates OFFLINE entries in ExternalView for Semi-Auto resources
+    _participants[0].syncStop();
+    Thread.sleep(500);
+
+    // Strict mode: OFFLINE entries don't match ideal state → fails within short timeout
+    HelixClusterVerifier strictVerifier =
+        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(SEMI_AUTO_RESOURCES)).setDeactivatedNodeAwareness(true)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertFalse(strictVerifier.verify(3000));
+
+    // Lenient mode: OFFLINE entries stripped → remaining active states match
+    lenientVerifier =
+        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(SEMI_AUTO_RESOURCES)).setDeactivatedNodeAwareness(true)
+            .setLenientMatch(true)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertTrue(lenientVerifier.verify(10000));
+  }
+
+  @Test
+  public void testLenientMatchWithSleepTransition() throws InterruptedException {
+    // Ensure stable first
+    HelixClusterVerifier lenientVerifier =
+        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(RESOURCES)).setDeactivatedNodeAwareness(true)
+            .setLenientMatch(true)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertTrue(lenientVerifier.verify(10000));
+
+    // Restart participant with stuck transitions — state transitions never complete,
+    // so MASTER/SLAVE assignments won't match ExternalView
+    _participants[0].syncStop();
+    Thread.sleep(1000);
+
+    _participants[0] = new MockParticipantManager(ZK_ADDR, _clusterName, _participants[0].getInstanceName());
+    _participants[0].setTransition(new SleepTransition(99999999));
+    _participants[0].syncStart();
+
+    // Even lenient mode should fail — this is an active state mismatch (stuck transitions),
+    // not just OFFLINE/DROPPED entries
+    lenientVerifier =
+        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+            .setResources(Sets.newHashSet(RESOURCES)).setDeactivatedNodeAwareness(true)
+            .setLenientMatch(true)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertFalse(lenientVerifier.verify(3000));
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/tools/TestClusterVerifier.java
+++ b/helix-core/src/test/java/org/apache/helix/tools/TestClusterVerifier.java
@@ -21,19 +21,26 @@ package org.apache.helix.tools;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.TestHelper;
 import org.apache.helix.ZkUnitTestBase;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.mock.participant.SleepTransition;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.IdealState.RebalanceMode;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
@@ -341,36 +348,56 @@ public class TestClusterVerifier extends ZkUnitTestBase {
   }
 
   @Test
-  public void testLenientMatchWithStoppedParticipant() throws InterruptedException {
+  public void testLenientMatchWithOfflineEntryInExternalView() throws InterruptedException {
     // Ensure stable first
+    final String resource = SEMI_AUTO_RESOURCES[0];
     HelixClusterVerifier lenientVerifier =
         new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
-            .setResources(Sets.newHashSet(SEMI_AUTO_RESOURCES)).setDeactivatedNodeAwareness(true)
+            .setResources(Sets.newHashSet(resource)).setDeactivatedNodeAwareness(true)
             .setLenientMatch(true)
             .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
             .build();
     Assert.assertTrue(lenientVerifier.verify(10000));
 
-    // Stop a participant — creates OFFLINE entries in ExternalView for Semi-Auto resources
-    _participants[0].syncStop();
-    Thread.sleep(500);
+    // Pause the cluster and inject an OFFLINE entry into ExternalView that strict matching should
+    // reject while lenient matching strips away.
+    _admin.enableCluster(_clusterName, false);
+    try {
+      HelixDataAccessor accessor =
+          new ZKHelixDataAccessor(_clusterName, new ZkBaseDataAccessor<>(_gZkClient));
+      PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+      ExternalView externalView = accessor.getProperty(keyBuilder.externalView(resource));
+      String partitionName = resource + "_0";
+      Map<String, String> currentStateMap = new HashMap<>(externalView.getStateMap(partitionName));
+      String extraOfflineInstance =
+          Arrays.stream(_participants).map(MockParticipantManager::getInstanceName)
+              .filter(instance -> !currentStateMap.containsKey(instance)).findFirst().orElseThrow(
+                  () -> new IllegalStateException(
+                      "No spare participant found for OFFLINE entry injection."));
+      currentStateMap.put(extraOfflineInstance,
+          BuiltInStateModelDefinitions.MasterSlave.getStateModelDefinition().getInitialState());
+      externalView.getRecord().setMapField(partitionName, currentStateMap);
+      Assert.assertTrue(accessor.setProperty(keyBuilder.externalView(resource), externalView));
 
-    // Strict mode: OFFLINE entries don't match ideal state → fails within short timeout
-    HelixClusterVerifier strictVerifier =
-        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
-            .setResources(Sets.newHashSet(SEMI_AUTO_RESOURCES)).setDeactivatedNodeAwareness(true)
-            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
-            .build();
-    Assert.assertFalse(strictVerifier.verify(3000));
+      // Strict mode: OFFLINE entries don't match ideal state -> fails within short timeout.
+      HelixClusterVerifier strictVerifier =
+          new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+              .setResources(Sets.newHashSet(resource)).setDeactivatedNodeAwareness(true)
+              .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+              .build();
+      Assert.assertFalse(strictVerifier.verify(3000));
 
-    // Lenient mode: OFFLINE entries stripped → remaining active states match
-    lenientVerifier =
-        new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
-            .setResources(Sets.newHashSet(SEMI_AUTO_RESOURCES)).setDeactivatedNodeAwareness(true)
-            .setLenientMatch(true)
-            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
-            .build();
-    Assert.assertTrue(lenientVerifier.verify(10000));
+      // Lenient mode: OFFLINE entries stripped -> remaining active states match.
+      lenientVerifier =
+          new StrictMatchExternalViewVerifier.Builder(_clusterName).setZkClient(_gZkClient)
+              .setResources(Sets.newHashSet(resource)).setDeactivatedNodeAwareness(true)
+              .setLenientMatch(true)
+              .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+              .build();
+      Assert.assertTrue(lenientVerifier.verify(10000));
+    } finally {
+      _admin.enableCluster(_clusterName, true);
+    }
   }
 
   @Test


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
Add lenient match mode to StrictMatchExternalViewVerifier

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

`BestPossibleExternalViewVerifier` convergence checks are broken for WAGED rebalancer clusters, the `DryrunWagedRebalancer` recomputes all assignments from scratch with genuine non-determinism.

`StrictMatchExternalViewVerifier` (which reads persisted assignments from  IdealState) fixes the non-determinism, but its exact-match comparison fails on transient OFFLINE/DROPPED entries, whereas BestPossibleExternalViewVerifier is lenient for these scenarios and it strips these state from both EV and IS before comparing.

The new lenient match mode strips these transient states before comparison, giving us deterministic verification that tolerates in-progress operations.

### Tests
New tests testLenientMatchStableCluster, testLenientMatchWithStoppedParticipant, testLenientMatchWithSleepTransition

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
