### PR TITLE
Add recovery rebalance support for top state downward transitions

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -372,6 +372,9 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
     // less than the threshold. Otherwise, only allow downward-transition load balance
     boolean onlyDownwardLoadBalance = numPartitionsWithErrorReplica > threshold;
 
+    boolean recoveryRebalanceForTopStateDownwardTransition =
+        clusterConfig.isRecoveryRebalanceForTopStateDownwardTransitionEnabled();
+
     // Sort partitions in case of urgent partition need to take the quota first.
     List<Partition> partitions = new ArrayList<>(resource.getPartitions());
     partitions.sort(new PartitionPriorityComparator(bestPossiblePartitionStateMap.getStateMap(),
@@ -394,6 +397,11 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       for (Message message : messagesToThrottle) {
         RebalanceType rebalanceType =
             getRebalanceTypePerMessage(requiredState, message, derivedCurrentStateMap);
+        if (recoveryRebalanceForTopStateDownwardTransition
+            && rebalanceType.equals(RebalanceType.LOAD_BALANCE)
+            && isTopStateDownwardTransition(stateModelDef, message)) {
+          rebalanceType = RebalanceType.RECOVERY_BALANCE;
+        }
 
         // Number of states required by StateModelDefinition are not satisfied, need recovery
         if (rebalanceType.equals(RebalanceType.RECOVERY_BALANCE)) {
@@ -452,6 +460,23 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
 
     LogUtil.logDebug(logger, _eventId, String.format("End processing resource: %s", resourceName));
     return intermediatePartitionStateMap;
+  }
+
+  /**
+   * Check if the message represents a top state downward transition (e.g., MASTER→SLAVE, LEADER→STANDBY).
+   * Used when the cluster config enables treating such transitions as recovery rebalance.
+   */
+  private boolean isTopStateDownwardTransition(StateModelDefinition stateModelDef, Message msg) {
+    String topState = stateModelDef.getTopState();
+    if (topState == null) {
+      return false;
+    }
+    String secondTopState =
+        stateModelDef.getNextStateForTransition(topState, stateModelDef.getInitialState());
+    if (secondTopState == null) {
+      return false;
+    }
+    return topState.equals(msg.getFromState()) && secondTopState.equals(msg.getToState());
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/IntermediateStateCalcStage.java
@@ -397,9 +397,8 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       for (Message message : messagesToThrottle) {
         RebalanceType rebalanceType =
             getRebalanceTypePerMessage(requiredState, message, derivedCurrentStateMap);
-        if (recoveryRebalanceForTopStateDownwardTransition
-            && rebalanceType.equals(RebalanceType.LOAD_BALANCE)
-            && isTopStateDownwardTransition(stateModelDef, message)) {
+        if (StateTransitionHelper.shouldReclassifyForTopStateHandOff(
+            recoveryRebalanceForTopStateDownwardTransition, message, stateModelDef)) {
           rebalanceType = RebalanceType.RECOVERY_BALANCE;
         }
 
@@ -463,23 +462,6 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
   }
 
   /**
-   * Check if the message represents a top state downward transition (e.g., MASTER→SLAVE, LEADER→STANDBY).
-   * Used when the cluster config enables treating such transitions as recovery rebalance.
-   */
-  private boolean isTopStateDownwardTransition(StateModelDefinition stateModelDef, Message msg) {
-    String topState = stateModelDef.getTopState();
-    if (topState == null) {
-      return false;
-    }
-    String secondTopState =
-        stateModelDef.getNextStateForTransition(topState, stateModelDef.getInitialState());
-    if (secondTopState == null) {
-      return false;
-    }
-    return topState.equals(msg.getFromState()) && secondTopState.equals(msg.getToState());
-  }
-
-  /**
    * Determine the message is downward message or not.
    * @param message                  message for load rebalance
    * @param stateModelDefinition     state model definition object for this resource
@@ -509,6 +491,8 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       StateTransitionThrottleController throttleController, ResourceControllerDataProvider cache,
       Map<String, List<String>> preferenceLists, StateModelDefinition stateModelDefinition) {
     String resourceName = resource.getResourceName();
+    boolean recoveryRebalanceForTopStateDownwardTransition =
+        cache.getClusterConfig().isRecoveryRebalanceForTopStateDownwardTransitionEnabled();
     // check and charge pending transitions
     for (Partition partition : resource.getPartitions()) {
       // To clarify that custom mode does not apply recovery/load rebalance since user can define different number of
@@ -531,6 +515,10 @@ public class IntermediateStateCalcStage extends AbstractBaseStage {
       for (Message message : pendingMessages) {
         StateTransitionThrottleConfig.RebalanceType rebalanceType =
             getRebalanceTypePerMessage(requiredStates, message, currentStateMap);
+        if (StateTransitionHelper.shouldReclassifyForTopStateHandOff(
+            recoveryRebalanceForTopStateDownwardTransition, message, stateModelDefinition)) {
+          rebalanceType = RebalanceType.RECOVERY_BALANCE;
+        }
         String currentState = currentStateMap.get(message.getTgtName());
         if (currentState == null) {
           currentState = stateModelDefinition.getInitialState();

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MessageThrottleProcessor.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MessageThrottleProcessor.java
@@ -145,8 +145,12 @@ public class MessageThrottleProcessor {
       StateModelDefinition stateModelDef = idealState != null
           ? cache.getStateModelDef(idealState.getStateModelDefRef()) : null;
 
-      // Classify message
       RebalanceType type = classifyMessage(requiredStates, message, derivedState);
+      if (StateTransitionHelper.shouldReclassifyForTopStateHandOff(
+          cache.getClusterConfig().isRecoveryRebalanceForTopStateDownwardTransitionEnabled(),
+          message, stateModelDef)) {
+        type = RebalanceType.RECOVERY_BALANCE;
+      }
       message.setSTRebalanceType(type == RebalanceType.RECOVERY_BALANCE
           ? Message.STRebalanceType.RECOVERY_REBALANCE
           : Message.STRebalanceType.LOAD_REBALANCE);
@@ -255,6 +259,8 @@ public class MessageThrottleProcessor {
       Map<String, List<String>> preferenceLists, StateModelDefinition stateModelDef) {
 
     String resourceName = resource.getResourceName();
+    boolean recoveryRebalanceForTopStateDownwardTransition =
+        cache.getClusterConfig().isRecoveryRebalanceForTopStateDownwardTransitionEnabled();
 
     for (Partition partition : resource.getPartitions()) {
       List<String> preferenceList = preferenceLists.get(partition.getPartitionName());
@@ -272,6 +278,10 @@ public class MessageThrottleProcessor {
 
       for (Message message : pendingMessages) {
         RebalanceType type = classifyMessage(requiredStates, message, currentStateMap);
+        if (StateTransitionHelper.shouldReclassifyForTopStateHandOff(
+            recoveryRebalanceForTopStateDownwardTransition, message, stateModelDef)) {
+          type = RebalanceType.RECOVERY_BALANCE;
+        }
         String currentState = currentStateMap.getOrDefault(
             message.getTgtName(), stateModelDef.getInitialState());
 

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/StateTransitionHelper.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/StateTransitionHelper.java
@@ -22,6 +22,7 @@ package org.apache.helix.controller.stages;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.helix.model.Message;
 import org.apache.helix.model.Partition;
 import org.apache.helix.model.StateModelDefinition;
 
@@ -128,5 +129,32 @@ public class StateTransitionHelper {
       }
     }
     return matches;
+  }
+
+  /**
+   * Determines whether a state-transition message should be reclassified from
+   * {@link RebalanceType#LOAD_BALANCE} to {@link RebalanceType#RECOVERY_BALANCE}.
+   *
+   * <p>Normally, a top-state downward transition (e.g., MASTER-&gt;SLAVE or LEADER-&gt;STANDBY)
+   * is classified as {@code LOAD_BALANCE} by the standard rebalance-type logic because the
+   * second-top-state count already satisfies {@code minActiveReplicas}. This means the transition
+   * shares throttle quota with regular load-balance work, potentially delaying urgent leadership
+   * handoffs when load-balance throttles are saturated.</p>
+   *
+   * <p>When the cluster config flag
+   * {@code ENABLE_RECOVERY_REBALANCE_FOR_TOPSTATE_DOWNWARD_TRANSITION} is enabled, this method
+   * returns {@code true} for any message whose {@code fromState} is the top state and whose
+   * transition is downward, so callers can reclassify it as {@code RECOVERY_BALANCE} and give
+   * it higher throttle priority.</p>
+   *
+   * @param configEnabled whether the cluster config flag is enabled
+   * @param message       the state-transition message to evaluate
+   * @param stateModelDef the state model definition for the resource (may be {@code null})
+   * @return {@code true} if the message should be reclassified as recovery rebalance
+   */
+  public static boolean shouldReclassifyForTopStateHandOff(boolean configEnabled, Message message,
+      StateModelDefinition stateModelDef) {
+    return configEnabled && stateModelDef != null && isTopStateHandoff(message.getFromState(),
+        message.getToState(), stateModelDef.getTopState(), stateModelDef);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -173,6 +173,10 @@ public class ClusterConfig extends HelixProperty {
     // Allow disabled partitions to remain OFFLINE instead of being reassigned in WAGED rebalancer
     RELAXED_DISABLED_PARTITION_CONSTRAINT,
 
+    // If enabled, all downward transitions from TopState (e.g., MASTER→SLAVE or LEADER→STANDBY)
+    // are classified as RECOVERY_REBALANCE instead of LOAD_BALANCE.
+    ENABLE_RECOVERY_REBALANCE_FOR_TOPSTATE_DOWNWARD_TRANSITION,
+
     // Enable availability-aware cross-resource prioritization for state transitions.
     // When enabled, messages are prioritized based on availability impact score across all resources,
     // rather than processing resources in priority order.
@@ -1354,5 +1358,26 @@ public class ClusterConfig extends HelixProperty {
    */
   public boolean isParticipantDeregistrationEnabled() {
     return getParticipantDeregistrationTimeout() > -1;
+  }
+
+  /**
+   * @return true if top state downward transitions (e.g., MASTER->SLAVE, LEADER->STANDBY)
+   *         should be classified as RECOVERY_REBALANCE instead of LOAD_BALANCE
+   */
+  public boolean isRecoveryRebalanceForTopStateDownwardTransitionEnabled() {
+    return _record.getBooleanField(
+        ClusterConfigProperty.ENABLE_RECOVERY_REBALANCE_FOR_TOPSTATE_DOWNWARD_TRANSITION.name(),
+        false);
+  }
+
+  /**
+   * Enable or disable classifying top state downward transitions as RECOVERY_REBALANCE.
+   *
+   * @param enabled true to classify top state downward transitions as RECOVERY_REBALANCE
+   */
+  public void setRecoveryRebalanceForTopStateDownwardTransitionEnabled(boolean enabled) {
+    _record.setBooleanField(
+        ClusterConfigProperty.ENABLE_RECOVERY_REBALANCE_FOR_TOPSTATE_DOWNWARD_TRANSITION.name(),
+        enabled);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestIntermediateStateCalcStage.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -648,6 +649,232 @@ public class TestIntermediateStateCalcStage extends BaseStageTest {
           .getStateMap()
           .equals(expectedResult.getPartitionStateMap(resource).getStateMap()));
     }
+  }
+
+  @Test
+  public void testEnableRecoveryRebalanceForTopStateDownwardStateTransition() {
+    String[] resources = {"TestResource"};
+    String resource = resources[0];
+    int nReplica = 3;
+    int nPartition = 1;
+
+    setupIdealState(4, resources, nPartition, nReplica, IdealState.RebalanceMode.FULL_AUTO,
+        "MasterSlave", null, null, 2);
+    setupStateModel();
+    setupInstances(4);
+    setupLiveInstances(4);
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "MasterSlave"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "MasterSlave"));
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+
+    // Set load balance throttling to allow 0 load balance messages per instance so that
+    // a MASTER->SLAVE message classified as LOAD_BALANCE gets throttled
+    _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    _clusterConfig.setStateTransitionThrottleConfigs(ImmutableList.of(
+        new StateTransitionThrottleConfig(StateTransitionThrottleConfig.RebalanceType.LOAD_BALANCE,
+            StateTransitionThrottleConfig.ThrottleScope.INSTANCE, 0)));
+    setClusterConfig(_clusterConfig);
+
+    Partition partition = new Partition(resource + "_0");
+    Map<String, List<String>> partitionMap = new HashMap<>();
+    partitionMap.put(partition.getPartitionName(),
+        Arrays.asList("localhost_1", "localhost_2", "localhost_3"));
+    bestPossibleStateOutput.setPreferenceLists(resource, partitionMap);
+
+    bestPossibleStateOutput.setState(resource, partition, "localhost_1", "MASTER");
+    bestPossibleStateOutput.setState(resource, partition, "localhost_2", "SLAVE");
+    bestPossibleStateOutput.setState(resource, partition, "localhost_3", "SLAVE");
+
+    currentStateOutput.setCurrentState(resource, partition, "localhost_0", "MASTER");
+    currentStateOutput.setCurrentState(resource, partition, "localhost_1", "SLAVE");
+    currentStateOutput.setCurrentState(resource, partition, "localhost_2", "SLAVE");
+
+    messageSelectOutput.addMessage(resource, partition,
+        generateMessage("MASTER", "SLAVE", "localhost_0"));
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    // Without the config, the MASTER->SLAVE message is classified as LOAD_BALANCE and gets throttled
+    Assert.assertEquals(messageSelectOutput.getMessages(resource, partition).size(), 0);
+    Assert.assertTrue(
+        output.getPartitionStateMap(resource).getPartitionMap(partition)
+            .equals(currentStateOutput.getCurrentStateMap(resource, partition)));
+
+    // Now enable the config to treat topState downward transition as recovery rebalance
+    _clusterConfig.setRecoveryRebalanceForTopStateDownwardTransitionEnabled(true);
+    setClusterConfig(_clusterConfig);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+    messageSelectOutput.addMessage(resource, partition,
+        generateMessage("MASTER", "SLAVE", "localhost_0"));
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    // With the config enabled, the MASTER->SLAVE message is now RECOVERY_REBALANCE and not throttled
+    Assert.assertEquals(messageSelectOutput.getMessages(resource, partition).size(), 1);
+    Assert.assertEquals(
+        messageSelectOutput.getMessages(resource, partition).get(0).getSTRebalanceType(),
+        Message.STRebalanceType.RECOVERY_REBALANCE);
+    Map<String, String> stateMap =
+        output.getPartitionStateMap(resource).getPartitionMap(partition);
+    Assert.assertTrue(
+        stateMap.values().stream().allMatch(state -> state.equals("SLAVE")),
+        "All hosts should be in SLAVE state after MASTER->SLAVE transition is allowed");
+  }
+
+  @Test
+  public void testNonTopStateDownwardTransitionNotReclassifiedAsRecovery() {
+    String[] resources = {"TestResource"};
+    String resource = resources[0];
+    int nReplica = 3;
+    int nPartition = 1;
+
+    setupIdealState(4, resources, nPartition, nReplica, IdealState.RebalanceMode.FULL_AUTO,
+        "MasterSlave", null, null, 2);
+    setupStateModel();
+    setupInstances(4);
+    setupLiveInstances(4);
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "MasterSlave"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "MasterSlave"));
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+
+    // Enable recovery rebalance for top state downward transition AND
+    // set load balance throttle to 0 so load balance messages get throttled
+    _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    _clusterConfig.setRecoveryRebalanceForTopStateDownwardTransitionEnabled(true);
+    _clusterConfig.setStateTransitionThrottleConfigs(ImmutableList.of(
+        new StateTransitionThrottleConfig(StateTransitionThrottleConfig.RebalanceType.LOAD_BALANCE,
+            StateTransitionThrottleConfig.ThrottleScope.INSTANCE, 0)));
+    setClusterConfig(_clusterConfig);
+
+    Partition partition = new Partition(resource + "_0");
+    Map<String, List<String>> partitionMap = new HashMap<>();
+    partitionMap.put(partition.getPartitionName(),
+        Arrays.asList("localhost_1", "localhost_2", "localhost_3"));
+    bestPossibleStateOutput.setPreferenceLists(resource, partitionMap);
+
+    bestPossibleStateOutput.setState(resource, partition, "localhost_1", "MASTER");
+    bestPossibleStateOutput.setState(resource, partition, "localhost_2", "SLAVE");
+    bestPossibleStateOutput.setState(resource, partition, "localhost_3", "SLAVE");
+
+    // localhost_0 is SLAVE and needs to go OFFLINE (non-top-state downward transition)
+    currentStateOutput.setCurrentState(resource, partition, "localhost_0", "SLAVE");
+    currentStateOutput.setCurrentState(resource, partition, "localhost_1", "MASTER");
+    currentStateOutput.setCurrentState(resource, partition, "localhost_2", "SLAVE");
+
+    // SLAVE->OFFLINE is NOT a top-state downward transition, should remain LOAD_BALANCE
+    messageSelectOutput.addMessage(resource, partition,
+        generateMessage("SLAVE", "OFFLINE", "localhost_0"));
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    // SLAVE->OFFLINE should still be throttled because it is LOAD_BALANCE, not reclassified
+    Assert.assertEquals(messageSelectOutput.getMessages(resource, partition).size(), 0,
+        "SLAVE->OFFLINE should NOT be reclassified as RECOVERY_REBALANCE");
+  }
+
+  @Test
+  public void testRecoveryRebalanceForTopStateDownwardWithLeaderStandby() {
+    String[] resources = {"TestResource"};
+    String resource = resources[0];
+    int nReplica = 3;
+    int nPartition = 1;
+
+    setupIdealState(4, resources, nPartition, nReplica, IdealState.RebalanceMode.FULL_AUTO,
+        "LeaderStandby", null, null, 2);
+    setupStateModel();
+    setupInstances(4);
+    setupLiveInstances(4);
+    event.addAttribute(AttributeName.RESOURCES.name(),
+        getResourceMap(resources, nPartition, "LeaderStandby"));
+    event.addAttribute(AttributeName.RESOURCES_TO_REBALANCE.name(),
+        getResourceMap(resources, nPartition, "LeaderStandby"));
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    MessageOutput messageSelectOutput = new MessageOutput();
+
+    // Enable recovery rebalance for top state downward transition AND
+    // set load balance throttle to 0 so load balance messages get throttled
+    _clusterConfig = accessor.getProperty(accessor.keyBuilder().clusterConfig());
+    _clusterConfig.setRecoveryRebalanceForTopStateDownwardTransitionEnabled(true);
+    _clusterConfig.setStateTransitionThrottleConfigs(ImmutableList.of(
+        new StateTransitionThrottleConfig(StateTransitionThrottleConfig.RebalanceType.LOAD_BALANCE,
+            StateTransitionThrottleConfig.ThrottleScope.INSTANCE, 0)));
+    setClusterConfig(_clusterConfig);
+
+    Partition partition = new Partition(resource + "_0");
+    Map<String, List<String>> partitionMap = new HashMap<>();
+    partitionMap.put(partition.getPartitionName(),
+        Arrays.asList("localhost_1", "localhost_2", "localhost_3"));
+    bestPossibleStateOutput.setPreferenceLists(resource, partitionMap);
+
+    bestPossibleStateOutput.setState(resource, partition, "localhost_1", "LEADER");
+    bestPossibleStateOutput.setState(resource, partition, "localhost_2", "STANDBY");
+    bestPossibleStateOutput.setState(resource, partition, "localhost_3", "STANDBY");
+
+    currentStateOutput.setCurrentState(resource, partition, "localhost_0", "LEADER");
+    currentStateOutput.setCurrentState(resource, partition, "localhost_1", "STANDBY");
+    currentStateOutput.setCurrentState(resource, partition, "localhost_2", "STANDBY");
+
+    // LEADER->STANDBY is a top-state downward transition
+    messageSelectOutput.addMessage(resource, partition,
+        generateMessage("LEADER", "STANDBY", "localhost_0"));
+
+    event.addAttribute(AttributeName.BEST_POSSIBLE_STATE.name(), bestPossibleStateOutput);
+    event.addAttribute(AttributeName.MESSAGES_SELECTED.name(), messageSelectOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE.name(), currentStateOutput);
+    event.addAttribute(AttributeName.CURRENT_STATE_EXCLUDING_UNKNOWN.name(), currentStateOutput);
+    event.addAttribute(AttributeName.ControllerDataProvider.name(),
+        new ResourceControllerDataProvider());
+
+    runStage(event, new ReadClusterDataStage());
+    runStage(event, new IntermediateStateCalcStage());
+
+    IntermediateStateOutput output = event.getAttribute(AttributeName.INTERMEDIATE_STATE.name());
+
+    // LEADER->STANDBY should be reclassified as RECOVERY_REBALANCE and not throttled
+    Assert.assertEquals(messageSelectOutput.getMessages(resource, partition).size(), 1,
+        "LEADER->STANDBY should be reclassified as RECOVERY_REBALANCE and not throttled");
+    Assert.assertEquals(
+        messageSelectOutput.getMessages(resource, partition).get(0).getSTRebalanceType(),
+        Message.STRebalanceType.RECOVERY_REBALANCE);
+    Map<String, String> stateMap =
+        output.getPartitionStateMap(resource).getPartitionMap(partition);
+    Assert.assertTrue(
+        stateMap.values().stream().allMatch(state -> state.equals("STANDBY")),
+        "All hosts should be in STANDBY state after LEADER->STANDBY transition is allowed");
   }
 
   @Test


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Presently any top state downward transition message from MASTER->SLAVE or LEADER->STANDBY gets evaluated as a load balance message. This is because when determining message type, Helix checks how many present participants are in the second-top state (e.g., SLAVE) and if that count is >= min active required number (almost always 1), it treats the top state downward transition message as load balance since it is increasing the number of replicas in that state. This causes an issue when it is urgently required to transfer the top state and the load balance messages are throttled due to ST throttle configs.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Added a new cluster config `ENABLE_RECOVERY_REBALANCE_FOR_TOPSTATE_DOWNWARD_TRANSITION` to handle such cases. When enabled, the IntermediateStateCalcStage reclassifies any top state downward ST message (e.g., MASTER->SLAVE, LEADER->STANDBY) as `RECOVERY_REBALANCE` instead of `LOAD_BALANCE`, ensuring these transitions are not throttled.

Changes:
- **ClusterConfig.java**: Added new `ENABLE_RECOVERY_REBALANCE_FOR_TOPSTATE_DOWNWARD_TRANSITION` config property with getter/setter
- **IntermediateStateCalcStage.java**: Added `isTopStateDownwardTransition()` method that checks if a message transitions from the top state to the second-top state. When the config is enabled and a message is classified as LOAD_BALANCE but is a top state downward transition, it is reclassified as RECOVERY_BALANCE

### Tests

- [x] The following tests are written for this issue:

1. `TestIntermediateStateCalcStage.testEnableRecoveryRebalanceForTopStateDownwardStateTransition` — Verifies MASTER->SLAVE is throttled as LOAD_BALANCE without config, and passes as RECOVERY_REBALANCE with config enabled
2. `TestIntermediateStateCalcStage.testNonTopStateDownwardTransitionNotReclassifiedAsRecovery` — Verifies SLAVE->OFFLINE is NOT reclassified even with config enabled (negative test)
3. `TestIntermediateStateCalcStage.testRecoveryRebalanceForTopStateDownwardWithLeaderStandby` — Verifies LEADER->STANDBY is correctly reclassified with LeaderStandby state model

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
