### PR TITLE
Improve HelixRebalanceException log message in WAGED rebalancer

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -112,8 +112,13 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
       // stop immediately if any replica cannot find best assignable node
       if (!maybeBestNode.isPresent() || optimalAssignment.hasAnyFailure()) {
         String errorMessage = String.format(
-            "Unable to find any available candidate node for partition %s; Fail reasons: %s",
-            replica.getPartitionName(), optimalAssignment.getFailures());
+            "Unable to find any available candidate node for partition %s (resource: %s, cluster: %s); "
+                + "Failure summary: %s; Fail reasons: %s",
+            replica.getPartitionName(),
+            replica.getResourceName(),
+            clusterModel.getContext().getClusterName(),
+            optimalAssignment.getFailureSummary(),
+            optimalAssignment.getFailures());
         throw new HelixRebalanceException(errorMessage,
             HelixRebalanceException.Type.FAILED_TO_CALCULATE);
       }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/OptimalAssignment.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/OptimalAssignment.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.model.Partition;
@@ -89,5 +90,17 @@ public class OptimalAssignment {
   public String getFailures() {
     // TODO: format the error string
     return _failedAssignments.toString();
+  }
+
+  /**
+   * @return A map of failure reason description to the number of nodes that failed for that reason,
+   *         aggregated across all failed replicas.
+   */
+  public Map<String, Long> getFailureSummary() {
+    return _failedAssignments.values().stream()
+        .flatMap(nodeFailures -> nodeFailures.values().stream())
+        .flatMap(List::stream)
+        .collect(Collectors.groupingBy(reason -> reason != null ? reason : "Unknown",
+            Collectors.counting()));
   }
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

  ### Description
  - [x] Enriches the `HelixRebalanceException` error message in `ConstraintBasedAlgorithm` when no candidate node can be found for a partition placement.

  Previously the log only dumped a flat per-instance failure map, requiring manual counting to identify the dominant failure type. For clusters with many nodes (30+), this was hard to parse at a glance.

  **Before:**
  \`\`\`
  Unable to find any available candidate node for partition perf-0_0; Fail reasons: {perf-0-perf-0_0-STANDBY={lor1-0007314...=[Instance doesn't have the tag of the replica], ...}}
  \`\`\`

  **After:**
  \`\`\`
  Unable to find any available candidate node for partition perf-0_0 (resource: perf-0, cluster: MyCluster); Failure summary: {Instance doesn't have the tag of the replica=5, A fault zone cannot contain more than 1
   replica of same partition=2}; Fail reasons: {perf-0-perf-0_0-STANDBY={...}}
  \`\`\`

  Changes:
  - Add `getFailureSummary()` to `OptimalAssignment` — aggregates failure reason descriptions by count across all failed replicas
  - Include resource name and cluster name in the exception message for faster log lookup/filtering
  - Prepend categorized failure summary before the full per-instance reasons

  ### Tests
  - `TestConstraintBasedAlgorithm` — all 7 existing tests pass with no modifications needed

  - The following is the result of the "mvn test" command:
  \`\`\`
  Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
  \`\`\`

  ### Changes that Break Backward Compatibility (Optional)
  - None. The exception message format changes but `HelixRebalanceException.Type` and the throw site are unchanged.

  ### Code Quality
  - Diff formatted per helix-style.xml