### PR TITLE
Add instance state change support via setInstanceOperation API

### DIFF
--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -25,8 +25,8 @@ export class HelixCtrl {
 
     const user = req.session.username;
     const method = req.method.toLowerCase();
-    if (method != 'get' && !req.session.isAdmin) {
-      res.status(403).send('Forbidden');
+    if (method != 'get' && !req.session.username) {
+      res.status(401).send('Unauthorized, must be logged in to make write requests');
       return;
     }
 

--- a/helix-front/server/controllers/user.ts
+++ b/helix-front/server/controllers/user.ts
@@ -41,18 +41,17 @@ export class UserCtrl {
   }
 
   //
-  // Check the server-side session store,
-  // see if this helix-front ExpressJS server
-  // already knows that the current user is an admin.
+  // Returns true if the user is authenticated (has a valid session).
+  // Per-user authorization is handled by helix-rest's DatavaultAuthValidator
+  // via Identity-Token forwarding.
   //
   protected can(req: HelixRequest, res: Response) {
     try {
-      return res.json(req.session.isAdmin ? true : false);
+      return res.json(req.session.username ? true : false);
     } catch (err) {
       throw new Error(
-        `Error from /can logged in admin user session status endpoint: ${err}`
+        `Error from /can endpoint: ${err}`
       );
-      return false;
     }
   }
 
@@ -86,8 +85,7 @@ export class UserCtrl {
 
           ldap.search(LDAP.base, opts, function (err, result) {
             let isInAdminGroup = false;
-            let responseSent = false;
-            let tokenRequestPending = false;
+            let searchComplete = false;
             result.on('searchEntry', function (entry) {
               if (entry.object && !err) {
                 const groups = entry.object['memberOf'];
@@ -95,86 +93,69 @@ export class UserCtrl {
                   const groupName = group.split(',', 1)[0].split('=')[1];
                   if (groupName == LDAP.adminGroup) {
                     isInAdminGroup = true;
-
-                    //
-                    // Get an Identity-Token
-                    // if an IDENTITY_TOKEN_SOURCE
-                    // is specified in the config
-                    //
-                    if (IDENTITY_TOKEN_SOURCE) {
-                      tokenRequestPending = true;
-                      const body = JSON.stringify({
-                        username: credential.username,
-                        password: credential.password,
-                        ...CUSTOM_IDENTITY_TOKEN_REQUEST_BODY,
-                      });
-
-                      const options: HelixRequestOptions = {
-                        url: IDENTITY_TOKEN_SOURCE,
-                        json: '',
-                        body,
-                        headers: {
-                          'Content-Type': 'application/json',
-                        },
-                        agentOptions: {
-                          rejectUnauthorized: false,
-                        },
-                      };
-
-                      if (SSL.cafiles.length > 0) {
-                        options.agentOptions.ca = readFileSync(SSL.cafiles[0], {
-                          encoding: 'utf-8',
-                        });
-                      }
-
-                      function callback(error, _res, body) {
-                        tokenRequestPending = false;
-                        if (error || body?.error) {
-                          req.session.isAdmin = isInAdminGroup;
-                          responseSent = true;
-                          res.json(isInAdminGroup);
-                        } else {
-                          const parsedBody = JSON.parse(body);
-                          req.session.isAdmin = isInAdminGroup;
-                          req.session.identityToken = parsedBody;
-
-                          const cookieName = 'helixui_identity.token';
-                          const cookieValue =
-                            parsedBody.value[TOKEN_RESPONSE_KEY];
-                          const cookieExpiresDate = new Date(
-                            parsedBody.value[TOKEN_EXPIRATION_KEY]
-                          );
-                          const cookieOptions = {
-                            expires: cookieExpiresDate,
-                          };
-                          res.cookie(cookieName, cookieValue, cookieOptions);
-                          responseSent = true;
-                          res.json(isInAdminGroup);
-
-                          return parsedBody;
-                        }
-                      }
-                      request.post(options, callback);
-                    } else {
-                      req.session.isAdmin = isInAdminGroup;
-                      responseSent = true;
-                      res.json(isInAdminGroup);
-                    }
-                    //
-                    // END Get an Identity-Token
-                    //
                   }
                 }
-              } else {
-                req.session.isAdmin = isInAdminGroup;
-                responseSent = true;
-                res.json(isInAdminGroup);
               }
             });
             result.on('end', function () {
-              if (!responseSent && !tokenRequestPending) {
-                req.session.isAdmin = false;
-                res.json(false);
+              if (searchComplete) {
+                return;
+              }
+              searchComplete = true;
+              req.session.isAdmin = isInAdminGroup;
+
+              //
+              // Fetch an Identity-Token for ALL authenticated users
+              // so that helix-rest can perform per-user authorization
+              // via DatavaultAuthValidator.
+              //
+              if (IDENTITY_TOKEN_SOURCE) {
+                const body = JSON.stringify({
+                  username: credential.username,
+                  password: credential.password,
+                  ...CUSTOM_IDENTITY_TOKEN_REQUEST_BODY,
+                });
+
+                const options: HelixRequestOptions = {
+                  url: IDENTITY_TOKEN_SOURCE,
+                  json: '',
+                  body,
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  agentOptions: {
+                    rejectUnauthorized: false,
+                  },
+                };
+
+                if (SSL.cafiles.length > 0) {
+                  options.agentOptions.ca = readFileSync(SSL.cafiles[0], {
+                    encoding: 'utf-8',
+                  });
+                }
+
+                request.post(options, function (error, _res, body) {
+                  if (error || body?.error) {
+                    res.json(true);
+                  } else {
+                    const parsedBody = JSON.parse(body);
+                    req.session.identityToken = parsedBody;
+
+                    const cookieName = 'helixui_identity.token';
+                    const cookieValue =
+                      parsedBody.value[TOKEN_RESPONSE_KEY];
+                    const cookieExpiresDate = new Date(
+                      parsedBody.value[TOKEN_EXPIRATION_KEY]
+                    );
+                    const cookieOptions = {
+                      expires: cookieExpiresDate,
+                    };
+                    res.cookie(cookieName, cookieValue, cookieOptions);
+                    res.json(true);
+                  }
+                });
+              } else {
+                res.json(true);
               }
             });
           });

--- a/helix-front/src/app/core/helix.service.ts
+++ b/helix-front/src/app/core/helix.service.ts
@@ -2,7 +2,7 @@ import { throwError as observableThrowError, Observable } from 'rxjs';
 
 import { catchError } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
-import { HttpHeaders, HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpHeaders, HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 
 import { Settings } from './settings';
@@ -29,10 +29,11 @@ export class HelixService {
       .pipe(catchError(this.errorHandler));
   }
 
-  protected post(path: string, data: any): Observable<any> {
+  protected post(path: string, data: any, params?: HttpParams): Observable<any> {
     return this.http
       .post(`${Settings.helixAPI}${this.getHelixKey()}${path}`, data, {
         headers: this.getHeaders(),
+        params,
       })
       .pipe(catchError(this.errorHandler));
   }

--- a/helix-front/src/app/instance/instance-detail/instance-detail.component.html
+++ b/helix-front/src/app/instance/instance-detail/instance-detail.component.html
@@ -72,7 +72,15 @@
       <mat-menu #menu="matMenu">
         <button
           mat-menu-item
-          *ngIf="instance && instance.operationState === 'ENABLE'"
+          *ngIf="instance && instance.operationState !== 'ENABLE'"
+          (click)="enableInstance()"
+        >
+          <mat-icon>play_circle_outline</mat-icon>
+          <span>Enable this Instance</span>
+        </button>
+        <button
+          mat-menu-item
+          *ngIf="instance && instance.operationState !== 'DISABLE'"
           (click)="disableInstance()"
         >
           <mat-icon>not_interested</mat-icon>
@@ -80,12 +88,13 @@
         </button>
         <button
           mat-menu-item
-          *ngIf="instance && instance.operationState !== 'ENABLE'"
-          (click)="enableInstance()"
+          *ngIf="instance && instance.operationState !== 'EVACUATE'"
+          (click)="evacuateInstance()"
         >
-          <mat-icon>play_circle_outline</mat-icon>
-          <span>Enable this Instance</span>
+          <mat-icon>exit_to_app</mat-icon>
+          <span>Evacuate this Instance</span>
         </button>
+        <mat-divider></mat-divider>
         <button mat-menu-item (click)="removeInstance()">
           <mat-icon>delete</mat-icon>
           <span>REMOVE this Instance</span>

--- a/helix-front/src/app/instance/instance-detail/instance-detail.component.spec.ts
+++ b/helix-front/src/app/instance/instance-detail/instance-detail.component.spec.ts
@@ -34,12 +34,14 @@ describe('InstanceDetailComponent', () => {
     showConfirmation: () => Promise.resolve(false),
   };
 
-  function setupWithInstance(instance: Instance) {
+  function setupWithInstance(instance: Instance, mockServiceOverrides?: any) {
     const mockInstanceService = {
       get: () => of(instance),
       can: () => of(true),
       enable: () => of(null),
       disable: () => of(null),
+      setInstanceOperation: () => of(null),
+      ...mockServiceOverrides,
     };
 
     TestBed.configureTestingModule({
@@ -146,4 +148,25 @@ describe('InstanceDetailComponent', () => {
 
     expect(component.isLoading).toBe(false);
   });
+
+  it('should have evacuateInstance method', () => {
+    const instance = new Instance(
+      'host1_1234', 'TestCluster', true, true,
+      undefined, undefined, 'ENABLE'
+    );
+    setupWithInstance(instance);
+
+    expect(typeof component.evacuateInstance).toBe('function');
+  });
+
+  it('should have setInstanceState method', () => {
+    const instance = new Instance(
+      'host1_1234', 'TestCluster', true, true,
+      undefined, undefined, 'ENABLE'
+    );
+    setupWithInstance(instance);
+
+    expect(typeof component.setInstanceState).toBe('function');
+  });
+
 });

--- a/helix-front/src/app/instance/instance-detail/instance-detail.component.ts
+++ b/helix-front/src/app/instance/instance-detail/instance-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { Instance } from '../shared/instance.model';
+import { Instance, InstanceOperationState } from '../shared/instance.model';
 import { HelperService } from '../../shared/helper.service';
 import { InstanceService } from '../shared/instance.service';
 
@@ -58,19 +58,60 @@ export class InstanceDetailComponent implements OnInit {
   }
 
   enableInstance() {
-    this.service.enable(this.clusterName, this.instance.name).subscribe(
-      /* happy path */ () => this.loadInstance(),
-      /* error path */ (error) => this.helperService.showError(error),
-      /* onComplete */ () => (this.isLoading = false)
-    );
+    this.setInstanceState('ENABLE');
   }
 
   disableInstance() {
-    this.service.disable(this.clusterName, this.instance.name).subscribe(
-      /* happy path */ () => this.loadInstance(),
-      /* error path */ (error) => this.helperService.showError(error),
-      /* onComplete */ () => (this.isLoading = false)
-    );
+    this.setInstanceState('DISABLE');
+  }
+
+  evacuateInstance() {
+    this.setInstanceState('EVACUATE');
+  }
+
+  setInstanceState(targetState: InstanceOperationState) {
+    const stateLabel =
+      targetState === 'ENABLE'
+        ? 'Enable'
+        : targetState === 'DISABLE'
+        ? 'Disable'
+        : targetState === 'EVACUATE'
+        ? 'Evacuate'
+        : targetState;
+
+    this.helperService
+      .showInput(
+        `${stateLabel} Instance`,
+        `Please provide a reason for changing the state of ${this.instance.name} to ${targetState}:`,
+        {
+          reason: {
+            label: 'Reason',
+            type: 'input',
+          },
+        }
+      )
+      .then((result) => {
+        if (result && result.reason && result.reason.value) {
+          this.isLoading = true;
+          this.service
+            .setInstanceOperation(
+              this.clusterName,
+              this.instance.name,
+              targetState,
+              result.reason.value
+            )
+            .subscribe(
+              () => {
+                this.helperService.showSnackBar(
+                  `Instance ${this.instance.name} state changed to ${targetState}`
+                );
+                this.loadInstance();
+              },
+              (error) => this.helperService.showError(error),
+              () => (this.isLoading = false)
+            );
+        }
+      });
   }
 
   protected loadInstance() {

--- a/helix-front/src/app/instance/shared/instance.service.spec.ts
+++ b/helix-front/src/app/instance/shared/instance.service.spec.ts
@@ -355,4 +355,48 @@ describe('InstanceService', () => {
       });
     });
   });
+
+  describe('setInstanceOperation', () => {
+    it('should POST with correct query parameters for EVACUATE', (done) => {
+      service
+        .setInstanceOperation('TestCluster', 'host1_1234', 'EVACUATE', 'incident response')
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) =>
+        r.url.includes('/clusters/TestCluster/instances/host1_1234') &&
+        r.url.includes('command=setInstanceOperation') &&
+        r.url.includes('instanceOperation=EVACUATE') &&
+        r.url.includes('instanceOperationSource=USER') &&
+        r.url.includes('reason=incident%20response')
+      );
+      expect(req.request.method).toBe('POST');
+      req.flush(null);
+    });
+
+    it('should POST with correct query parameters for ENABLE', (done) => {
+      service
+        .setInstanceOperation('TestCluster', 'host1_1234', 'ENABLE', 'recovery complete')
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) =>
+        r.url.includes('command=setInstanceOperation') &&
+        r.url.includes('instanceOperation=ENABLE')
+      );
+      expect(req.request.method).toBe('POST');
+      req.flush(null);
+    });
+
+    it('should POST with correct query parameters for DISABLE', (done) => {
+      service
+        .setInstanceOperation('TestCluster', 'host1_1234', 'DISABLE', 'maintenance window')
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) =>
+        r.url.includes('command=setInstanceOperation') &&
+        r.url.includes('instanceOperation=DISABLE')
+      );
+      expect(req.request.method).toBe('POST');
+      req.flush(null);
+    });
+  });
 });

--- a/helix-front/src/app/instance/shared/instance.service.ts
+++ b/helix-front/src/app/instance/shared/instance.service.ts
@@ -1,5 +1,6 @@
 import { map } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
+import { HttpParams } from '@angular/common/http';
 
 import { Instance, InstanceOperationState } from './instance.model';
 import { HelixService } from '../../core/helix.service';
@@ -139,15 +140,15 @@ export class InstanceService extends HelixService {
     operation: InstanceOperationState,
     reason: string
   ) {
-    const params = [
-      `command=setInstanceOperation`,
-      `instanceOperation=${operation}`,
-      `instanceOperationSource=USER`,
-      `reason=${encodeURIComponent(reason)}`,
-    ].join('&');
+    const params = new HttpParams()
+      .set('command', 'setInstanceOperation')
+      .set('instanceOperation', operation)
+      .set('instanceOperationSource', 'USER')
+      .set('reason', reason);
     return this.post(
-      `/clusters/${clusterName}/instances/${instanceName}?${params}`,
-      null
+      `/clusters/${clusterName}/instances/${instanceName}`,
+      null,
+      params
     );
   }
 }

--- a/helix-front/src/app/instance/shared/instance.service.ts
+++ b/helix-front/src/app/instance/shared/instance.service.ts
@@ -132,4 +132,22 @@ export class InstanceService extends HelixService {
       null
     );
   }
+
+  public setInstanceOperation(
+    clusterName: string,
+    instanceName: string,
+    operation: InstanceOperationState,
+    reason: string
+  ) {
+    const params = [
+      `command=setInstanceOperation`,
+      `instanceOperation=${operation}`,
+      `instanceOperationSource=USER`,
+      `reason=${encodeURIComponent(reason)}`,
+    ].join('&');
+    return this.post(
+      `/clusters/${clusterName}/instances/${instanceName}?${params}`,
+      null
+    );
+  }
 }

--- a/helix-front/src/app/shared/helper.service.ts
+++ b/helix-front/src/app/shared/helper.service.ts
@@ -4,6 +4,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { AlertDialogComponent } from './dialog/alert-dialog/alert-dialog.component';
 import { ConfirmDialogComponent } from './dialog/confirm-dialog/confirm-dialog.component';
+import { InputDialogComponent } from './dialog/input-dialog/input-dialog.component';
 
 @Injectable()
 export class HelperService {
@@ -42,6 +43,15 @@ export class HelperService {
           title,
           confirmButtonText,
         },
+      })
+      .afterClosed()
+      .toPromise();
+  }
+
+  showInput(title: string, message: string, values: any) {
+    return this.dialog
+      .open(InputDialogComponent, {
+        data: { title, message, values },
       })
       .afterClosed()
       .toPromise();


### PR DESCRIPTION
## Summary
### Instance State Change Support (Ask 2)
- Add `setInstanceOperation()` to `InstanceService` for ENABLE/DISABLE/EVACUATE with reason and audit trail (`instanceOperationSource=USER`)
- Add `showInput()` to `HelperService` using `InputDialogComponent` for collecting reason before state changes
- Refactor `enableInstance`/`disableInstance` to use `setInstanceOperation`, add `evacuateInstance` method
- Expand admin menu with Enable/Disable/Evacuate options, each prompting for a reason
- Add unit tests for `setInstanceOperation` service method and component
### Remove helix-admin Gate for UI Write Operations
- **user.ts**: Fetch identity tokens for ALL authenticated users (not just `helix-admin` members) so `helix-rest` can perform per-user Datavault ACL checks via `DatavaultAuthValidator`. Update `/can` endpoint to return `true` for any logged-in user.
- **helix.ts**: Replace `isAdmin` proxy check with `username` check (require login, not admin group membership).

### Security Model
Previously, the `helix-admin` LDAP group was a coarse-grained gate in `helix-ui` that restricted both menu visibility and write operations. This PR delegates per-user authorization to `helix-rest`'s `DatavaultAuthValidator`, which checks individual user Datavault ACLs via the `Identity-Token` header. The critical change is fetching identity tokens for ALL authenticated users (not just `helix-admin` members), ensuring every proxied write request carries the user's identity for per-user ACL validation.
Made-with: Cursor
### Tests
- Unit tests for `setInstanceOperation` in `InstanceService` (EVACUATE, ENABLE, DISABLE)
- Unit tests for `evacuateInstance` and `setInstanceState` methods in `InstanceDetailComponent`
- Local verification: server boot, `/can` endpoint, proxy auth check, TypeScript compilation
### Changes that Break Backward Compatibility
- The `/api/user/can` endpoint now returns `true` for any authenticated user instead of only `helix-admin` members
- The proxy write gate now requires authentication (401) instead of `helix-admin` membership (403)
- Identity tokens are now fetched for all authenticated users during login

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
