### PR TITLE
Remove unused Restlet dependency references from helix-rest

### DIFF
--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -47,7 +47,6 @@
     <osgi.import>
       org.apache.helix*,
       org.apache.commons.cli*,
-      org.restlet*,
       org.slf4j*;version="[1.7,2)",
       org.apache.logging.log4j*;version="[2.17,3)",
       org.apache.logging.slf4j*;version="[2.17,3)",

--- a/helix-rest/src/test/resources/log4j2.properties
+++ b/helix-rest/src/test/resources/log4j2.properties
@@ -55,9 +55,6 @@ logger.apache.level = error
 logger.noelios.name = com.noelios
 logger.noelios.level = error
 
-logger.restlet.name = org.restlet
-logger.restlet.level = error
-
 logger.helixzkdatadump.name = org.apache.helix.monitoring.ZKPathDataDumpTask
 logger.helixzkdatadump.level = error
 logger.helixzkdatadump.appenderRef.statusdump.ref = STATUSDUMP


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Helix PRR review action item: helix-rest must not have any outdated/unused dependencies. Restlet was identified as a critical, legacy dependency (v2.3.12, EOL) that needed to be addressed.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Remove unused Restlet references from the `helix-rest` module — specifically the stale `org.restlet*` OSGi import in `helix-rest/pom.xml` and the Restlet logger configuration in `helix-rest/src/test/resources/log4j2.properties`.

**Why:** During the Helix PRR review, an action item was raised that `helix-rest` cannot have any outdated dependencies. Restlet (v2.3.12) was identified as a critical, legacy dependency. Upon investigation, `helix-rest` does not use Restlet at all — it uses Jersey 2.35 + Jetty 9.4 as its REST framework. Restlet is only consumed by `helix-admin-webapp` and `helix-agent`, which are not used by the LinkedIn multiproduct deployments (`helix-rest`, `helix-lib`). The references in `helix-rest` were stale leftovers.

**How:** 
- Removed `org.restlet*,` from the OSGi import list in `helix-rest/pom.xml`
- Removed `logger.restlet.name` and `logger.restlet.level` entries from `helix-rest/src/test/resources/log4j2.properties`

### Tests

- [x] The following tests are written for this issue:

No new tests required — this is a config-only cleanup removing unused references. No source code was changed.

- The following is the result of the "mvn test" command on the appropriate module:
```
[INFO] Reactor Summary for Apache Helix 1.4.4-SNAPSHOT: [INFO] [INFO] Apache Helix ....................................... SUCCESS [ 0.770 s] [INFO] Apache Helix :: Metrics Common ..................... SUCCESS [ 1.732 s] [INFO] Apache Helix :: Metadata Store Directory Common .... SUCCESS [ 1.380 s] [INFO] Apache Helix :: ZooKeeper API ...................... SUCCESS [ 3.106 s] [INFO] Apache Helix :: Helix Common ....................... SUCCESS [ 1.230 s] [INFO] Apache Helix :: Core ............................... SUCCESS [ 13.301 s] [INFO] Apache Helix :: Restful Interface .................. SUCCESS [ 3.249 s] [INFO] ------------------------------------------------------------------------ [INFO] BUILD SUCCESS [INFO] ------------------------------------------------------------------------ [INFO] Total time: 25.143 s
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
