### PR TITLE
Adding codeowners for PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default reviewers for all PRs.
+# At least one approval from a code owner is required before merging.
+# GitHub will automatically exclude the PR author from the reviewer list.
+* @kabragaurav @thestreak101 @ngngwr @Chr0nicl3 @proud-parselmouth @laxman-ch


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

N/A — This is a repository configuration change to enforce code review policies. No existing issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add a `CODEOWNERS` file to automatically assign reviewers when PRs are opened against the `dev` branch. This ensures every PR gets reviewed by at least one member of the core team before merging.

**What:** Adds `.github/CODEOWNERS` with the following default reviewers for all files:
- @kabragaurav
- @thestreak101
- @ngngwr
- @Chr0nicl3
- @proud-parselmouth
- @laxman-ch

**Why:** To enforce consistent code review practices and ensure no PR is merged without review from a designated team member. GitHub automatically excludes the PR author from the reviewer list, preventing self-review.

**How:** The `CODEOWNERS` file uses the `*` glob pattern to match all files, requesting reviews from the listed users on every PR. This works in conjunction with branch protection rules (to be configured by a repo admin) that require at least one code owner approval before merging.

**Note for repo admins:** After merging this PR, please enable the following branch protection rules on `dev`:
1. Require a pull request before merging (required approvals: 1)
2. Require review from Code Owners
3. Dismiss stale pull request approvals when new commits are pushed

### Tests

- [x] The following tests are written for this issue:

No tests required — this is a GitHub configuration file (`.github/CODEOWNERS`) with no impact on application code or build.

- The following is the result of the "mvn test" command on the appropriate module:

N/A — No code changes; only a GitHub repository configuration file was added.

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
