### PR TITLE
Fix flaky TestWagedRebalancerMetrics.testInstanceCapacityMetrics

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/AbstractTestClusterModel.java
@@ -133,27 +133,13 @@ public abstract class AbstractTestClusterModel {
     // Resource 2:
     // -------------- partition 3 - MASTER
     // -------------- partition 4 - SLAVE
-    CurrentState testCurrentStateResource1 = Mockito.mock(CurrentState.class);
-    Map<String, String> partitionStateMap1 = new HashMap<>();
-    partitionStateMap1.put(_partitionNames.get(0), "MASTER");
-    partitionStateMap1.put(_partitionNames.get(1), "SLAVE");
-    when(testCurrentStateResource1.getResourceName()).thenReturn(_resourceNames.get(0));
-    when(testCurrentStateResource1.getPartitionStateMap()).thenReturn(partitionStateMap1);
-    when(testCurrentStateResource1.getStateModelDefRef()).thenReturn("MasterSlave");
-    when(testCurrentStateResource1.getState(_partitionNames.get(0))).thenReturn("MASTER");
-    when(testCurrentStateResource1.getState(_partitionNames.get(1))).thenReturn("SLAVE");
-    when(testCurrentStateResource1.getSessionId()).thenReturn(_sessionId);
+    CurrentState testCurrentStateResource1 = buildCurrentState(
+        _resourceNames.get(0), _sessionId, "MasterSlave",
+        _partitionNames.get(0), "MASTER", _partitionNames.get(1), "SLAVE");
 
-    CurrentState testCurrentStateResource2 = Mockito.mock(CurrentState.class);
-    Map<String, String> partitionStateMap2 = new HashMap<>();
-    partitionStateMap2.put(_partitionNames.get(2), "MASTER");
-    partitionStateMap2.put(_partitionNames.get(3), "SLAVE");
-    when(testCurrentStateResource2.getResourceName()).thenReturn(_resourceNames.get(1));
-    when(testCurrentStateResource2.getPartitionStateMap()).thenReturn(partitionStateMap2);
-    when(testCurrentStateResource2.getStateModelDefRef()).thenReturn("MasterSlave");
-    when(testCurrentStateResource2.getState(_partitionNames.get(2))).thenReturn("MASTER");
-    when(testCurrentStateResource2.getState(_partitionNames.get(3))).thenReturn("SLAVE");
-    when(testCurrentStateResource2.getSessionId()).thenReturn(_sessionId);
+    CurrentState testCurrentStateResource2 = buildCurrentState(
+        _resourceNames.get(1), _sessionId, "MasterSlave",
+        _partitionNames.get(2), "MASTER", _partitionNames.get(3), "SLAVE");
 
     Map<String, CurrentState> currentStatemap = new HashMap<>();
     currentStatemap.put(_resourceNames.get(0), testCurrentStateResource1);
@@ -202,16 +188,9 @@ public abstract class AbstractTestClusterModel {
     _partitionNames.add("Partition6");
     ResourceControllerDataProvider testCache = setupClusterDataCache();
 
-    CurrentState testCurrentStateResource3 = Mockito.mock(CurrentState.class);
-    Map<String, String> partitionStateMap3 = new HashMap<>();
-    partitionStateMap3.put(_partitionNames.get(4), "MASTER");
-    partitionStateMap3.put(_partitionNames.get(5), "SLAVE");
-    when(testCurrentStateResource3.getResourceName()).thenReturn(_resourceNames.get(2));
-    when(testCurrentStateResource3.getPartitionStateMap()).thenReturn(partitionStateMap3);
-    when(testCurrentStateResource3.getStateModelDefRef()).thenReturn("MasterSlave");
-    when(testCurrentStateResource3.getState(_partitionNames.get(4))).thenReturn("MASTER");
-    when(testCurrentStateResource3.getState(_partitionNames.get(5))).thenReturn("SLAVE");
-    when(testCurrentStateResource3.getSessionId()).thenReturn(_sessionId);
+    CurrentState testCurrentStateResource3 = buildCurrentState(
+        _resourceNames.get(2), _sessionId, "MasterSlave",
+        _partitionNames.get(4), "MASTER", _partitionNames.get(5), "SLAVE");
 
     Map<String, CurrentState> currentStatemap = testCache.getCurrentState(_testInstanceId, _sessionId);
     currentStatemap.put(_resourceNames.get(2), testCurrentStateResource3);
@@ -240,16 +219,9 @@ public abstract class AbstractTestClusterModel {
     _partitionNames.add("Partition8");
     ResourceControllerDataProvider testCache = setupClusterDataCache();
 
-    CurrentState testCurrentStateResource4 = Mockito.mock(CurrentState.class);
-    Map<String, String> partitionStateMap4 = new HashMap<>();
-    partitionStateMap4.put(_partitionNames.get(4), "MASTER");
-    partitionStateMap4.put(_partitionNames.get(5), "SLAVE");
-    when(testCurrentStateResource4.getResourceName()).thenReturn(_resourceNames.get(2));
-    when(testCurrentStateResource4.getPartitionStateMap()).thenReturn(partitionStateMap4);
-    when(testCurrentStateResource4.getStateModelDefRef()).thenReturn("MasterSlave");
-    when(testCurrentStateResource4.getState(_partitionNames.get(4))).thenReturn("MASTER");
-    when(testCurrentStateResource4.getState(_partitionNames.get(5))).thenReturn("SLAVE");
-    when(testCurrentStateResource4.getSessionId()).thenReturn(_sessionId);
+    CurrentState testCurrentStateResource4 = buildCurrentState(
+        _resourceNames.get(2), _sessionId, "MasterSlave",
+        _partitionNames.get(4), "MASTER", _partitionNames.get(5), "SLAVE");
 
     Map<String, CurrentState> currentStatemap =
         testCache.getCurrentState(_testInstanceId, _sessionId);
@@ -293,5 +265,20 @@ public abstract class AbstractTestClusterModel {
     testCache.getAssignableInstanceConfigMap().values().forEach(config -> nodeSet
         .add(new AssignableNode(testCache.getClusterConfig(), config, config.getInstanceName())));
     return nodeSet;
+  }
+
+  /**
+   * Build a real CurrentState object with the given partition-state pairs.
+   * Real objects are used instead of mocks because HelixProperty.getRecord() is final.
+   */
+  protected static CurrentState buildCurrentState(String resourceName, String sessionId,
+      String stateModelDefRef, String... partitionStatePairs) {
+    CurrentState cs = new CurrentState(resourceName);
+    cs.setSessionId(sessionId);
+    cs.setStateModelDefRef(stateModelDefRef);
+    for (int i = 0; i < partitionStatePairs.length; i += 2) {
+      cs.setState(partitionStatePairs[i], partitionStatePairs[i + 1]);
+    }
+    return cs;
   }
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fix consistently failing test `TestWagedRebalancerMetrics.testInstanceCapacityMetrics`.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

**What:** Replaced mock `CurrentState` objects with real instances in `AbstractTestClusterModel` to fix an NPE in `TestWagedRebalancerMetrics.testInstanceCapacityMetrics`.

**Why:** `CurrentStateComputationStage` was optimized to read partition states directly from `currentState.getRecord().getMapFields()` instead of calling individual getters. The test's mock `CurrentState` objects couldn't stub `getRecord()` because it's declared `final` in `HelixProperty`, so Mockito returned `null`, causing an NPE.

**How:** Replaced all 4 mock `CurrentState` objects across 3 setup methods (`setupClusterDataCache`, `setupClusterDataCacheForNearFullUtil`, `setupClusterDataCacheForNoFitUtil`) with real `CurrentState` instances built via a new `buildCurrentState()` factory method. Real objects naturally have a backing `ZNRecord` accessible via `getRecord()`, eliminating the NPE. This also reduces boilerplate — each mock setup (8-10 lines of `when().thenReturn()`) is replaced with a single factory call.

Only test files were modified; no source code changes.

### Tests

- [ ] The following tests are written for this issue:

No new tests added. The existing test `TestWagedRebalancerMetrics.testInstanceCapacityMetrics` was fixed.

- The following is the result of the "mvn test" command on the appropriate module:

Target test — 10 consecutive runs, all passing:
```
=== Run 1 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.047 s [INFO] BUILD SUCCESS === Run 2 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.046 s [INFO] BUILD SUCCESS === Run 3 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.081 s [INFO] BUILD SUCCESS === Run 4 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.95 s [INFO] BUILD SUCCESS === Run 5 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.046 s [INFO] BUILD SUCCESS === Run 6 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.026 s [INFO] BUILD SUCCESS === Run 7 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.006 s [INFO] BUILD SUCCESS === Run 8 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.99 s [INFO] BUILD SUCCESS === Run 9 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.037 s [INFO] BUILD SUCCESS === Run 10 === [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.994 s [INFO] BUILD SUCCESS
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
