### PR TITLE
Add DomainInfoValidGauge metric to InstanceMonitor

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -405,6 +405,22 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   /**
+   * Updates the domain info validity gauge for each instance. Instances in the invalidInstances
+   * set will have their gauge set to 0 (invalid), all other registered instances will be set
+   * to 1 (valid).
+   *
+   * @param invalidInstances the set of instance names whose domain info is not correctly populated
+   */
+  public void updateInstanceDomainInfoValidity(Set<String> invalidInstances) {
+    synchronized (_instanceMonitorMap) {
+      for (Map.Entry<String, InstanceMonitor> entry : _instanceMonitorMap.entrySet()) {
+        boolean isInvalid = invalidInstances.contains(entry.getKey());
+        entry.getValue().updateDomainInfoValid(!isInvalid);
+      }
+    }
+  }
+
+  /**
    * Update the duration of handling a cluster event in a certain phase.
    * @param phase
    * @param duration

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -412,6 +412,9 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
    * @param invalidInstances the set of instance names whose domain info is not correctly populated
    */
   public void updateInstanceDomainInfoValidity(Set<String> invalidInstances) {
+    if (invalidInstances == null) {
+      invalidInstances = Collections.emptySet();
+    }
     synchronized (_instanceMonitorMap) {
       for (Map.Entry<String, InstanceMonitor> entry : _instanceMonitorMap.entrySet()) {
         boolean isInvalid = invalidInstances.contains(entry.getKey());

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -60,7 +60,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     INSTANCE_OPERATION_DURATION_SWAP_IN_GAUGE("InstanceOperationDuration_SWAP_IN"),
     INSTANCE_OPERATION_DURATION_UNKNOWN_GAUGE("InstanceOperationDuration_UNKNOWN"),
     PARTITION_COUNT_GAUGE("PartitionGauge"),
-    TOP_STATE_PARTITION_COUNT_GAUGE("TopStatePartitionGauge");
+    TOP_STATE_PARTITION_COUNT_GAUGE("TopStatePartitionGauge"),
+    DOMAIN_INFO_VALID_GAUGE("DomainInfoValidGauge");
 
     private final String metricName;
 
@@ -93,6 +94,7 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   private SimpleDynamicMetric<Long> _errorPartitionsGauge;
   private SimpleDynamicMetric<Long> _partitionCountGauge;
   private SimpleDynamicMetric<Long> _topStatePartitionCountGauge;
+  private SimpleDynamicMetric<Long> _domainInfoValidGauge;
 
   // Instance Operation Duration Gauges (in milliseconds)
   private SimpleDynamicMetric<Long> _instanceOperationDurationEnableGauge;
@@ -171,6 +173,9 @@ public class InstanceMonitor extends DynamicMBeanProvider {
         InstanceMonitorMetric.INSTANCE_OPERATION_DURATION_SWAP_IN_GAUGE.metricName(), 0L);
     _instanceOperationDurationUnknownGauge = new SimpleDynamicMetric<>(
         InstanceMonitorMetric.INSTANCE_OPERATION_DURATION_UNKNOWN_GAUGE.metricName(), 0L);
+
+    _domainInfoValidGauge = new SimpleDynamicMetric<>(
+        InstanceMonitorMetric.DOMAIN_INFO_VALID_GAUGE.metricName(), 1L);
   }
 
   private List<DynamicMetric<?, ?>> buildAttributeList() {
@@ -190,7 +195,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
         _instanceOperationDurationDisableGauge,
         _instanceOperationDurationEvacuateGauge,
         _instanceOperationDurationSwapInGauge,
-        _instanceOperationDurationUnknownGauge
+        _instanceOperationDurationUnknownGauge,
+        _domainInfoValidGauge
     );
 
     attributeList.addAll(_dynamicCapacityMetricsMap.values());
@@ -229,6 +235,16 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   protected long getPartitionCount() { return _partitionCountGauge.getValue(); }
 
   protected long getTopStatePartitionCount() { return _topStatePartitionCountGauge.getValue(); }
+
+  protected long getDomainInfoValid() { return _domainInfoValidGauge.getValue(); }
+
+  /**
+   * Updates whether this instance has valid domain info for the cluster's topology configuration.
+   * @param isValid true if domain info is correctly populated, false otherwise
+   */
+  public synchronized void updateDomainInfoValid(boolean isValid) {
+    _domainInfoValidGauge.updateValue(isValid ? 1L : 0L);
+  }
 
   /**
    * Get the current duration in ENABLE operation (in milliseconds)

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -559,6 +559,78 @@ public class TestClusterStatusMonitor {
     Assert.assertEquals(_server.getAttribute(type2ObjectName, "AvailableThreadGauge"), 29L);
   }
 
+  @Test
+  public void testUpdateInstanceDomainInfoValidity() throws Exception {
+    String clusterName = "TestCluster_DomainInfo";
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
+    monitor.active();
+
+    ObjectName clusterMonitorObjName = monitor.getObjectName(monitor.clusterBeanName());
+    Assert.assertTrue(_server.isRegistered(clusterMonitorObjName));
+
+    int numInstances = 5;
+    Set<String> instanceSet = Sets.newHashSet();
+    for (int i = 0; i < numInstances; i++) {
+      instanceSet.add("instance_" + i);
+    }
+
+    // Register instance monitors via setClusterInstanceStatus
+    monitor.setClusterInstanceStatus(instanceSet, instanceSet, Collections.emptySet(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+
+    // All instances should default to valid (1)
+    for (String instance : instanceSet) {
+      ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
+      Assert.assertTrue(_server.isRegistered(objName));
+      Object value = _server.getAttribute(objName, "DomainInfoValidGauge");
+      Assert.assertTrue(value instanceof Long);
+      Assert.assertEquals((long) value, 1L,
+          "Instance " + instance + " should default to valid domain info");
+    }
+
+    // Mark some instances as invalid
+    Set<String> invalidInstances = Sets.newHashSet();
+    invalidInstances.add("instance_1");
+    invalidInstances.add("instance_3");
+    monitor.updateInstanceDomainInfoValidity(invalidInstances);
+
+    // Verify invalid instances have gauge = 0, valid instances have gauge = 1
+    for (String instance : instanceSet) {
+      ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
+      Object value = _server.getAttribute(objName, "DomainInfoValidGauge");
+      long expected = invalidInstances.contains(instance) ? 0L : 1L;
+      Assert.assertEquals((long) value, expected,
+          "Instance " + instance + " DomainInfoValidGauge mismatch");
+    }
+
+    // Update again with a different set of invalid instances
+    Set<String> newInvalidInstances = Sets.newHashSet();
+    newInvalidInstances.add("instance_0");
+    monitor.updateInstanceDomainInfoValidity(newInvalidInstances);
+
+    // instance_1 and instance_3 should now be valid (1), instance_0 should be invalid (0)
+    for (String instance : instanceSet) {
+      ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
+      Object value = _server.getAttribute(objName, "DomainInfoValidGauge");
+      long expected = newInvalidInstances.contains(instance) ? 0L : 1L;
+      Assert.assertEquals((long) value, expected,
+          "Instance " + instance + " DomainInfoValidGauge mismatch after update");
+    }
+
+    // Update with empty set — all should be valid
+    monitor.updateInstanceDomainInfoValidity(Collections.emptySet());
+    for (String instance : instanceSet) {
+      ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
+      Object value = _server.getAttribute(objName, "DomainInfoValidGauge");
+      Assert.assertEquals((long) value, 1L,
+          "Instance " + instance + " should be valid when no invalid instances");
+    }
+
+    monitor.reset();
+    Assert.assertFalse(_server.isRegistered(clusterMonitorObjName));
+  }
+
   private void verifyCapacityMetrics(ClusterStatusMonitor monitor, Map<String, Double> maxUsageMap,
       Map<String, Map<String, Integer>> instanceCapacityMap)
       throws MalformedObjectNameException, IOException, AttributeNotFoundException, MBeanException,

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
@@ -449,6 +449,36 @@ public class TestInstanceMonitor {
   }
 
   @Test
+  public void testDomainInfoValidGauge() throws JMException {
+    String testCluster = "testCluster";
+    String testInstance = "testInstance";
+    String testDomain = "testDomain:key=value";
+    InstanceMonitor monitor =
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+
+    // Default should be valid (1)
+    Assert.assertEquals(monitor.getDomainInfoValid(), 1L);
+
+    // Mark domain info as invalid
+    monitor.updateDomainInfoValid(false);
+    Assert.assertEquals(monitor.getDomainInfoValid(), 0L);
+
+    // Mark domain info as valid again
+    monitor.updateDomainInfoValid(true);
+    Assert.assertEquals(monitor.getDomainInfoValid(), 1L);
+
+    // Toggle multiple times
+    monitor.updateDomainInfoValid(false);
+    Assert.assertEquals(monitor.getDomainInfoValid(), 0L);
+    monitor.updateDomainInfoValid(false);
+    Assert.assertEquals(monitor.getDomainInfoValid(), 0L);
+    monitor.updateDomainInfoValid(true);
+    Assert.assertEquals(monitor.getDomainInfoValid(), 1L);
+
+    monitor.unregister();
+  }
+
+  @Test
   public void testPartitionCountEdgeCases() throws JMException {
     String testCluster = "testCluster";
     String testInstance = "testInstance";


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Add metrics infrastructure to detect instances with incorrectly populated domain info when `allowParticipantAutoJoin` is enabled. This is PR 1 of 2 — PR 2 will add the validation logic in `ReadClusterDataStage` that uses these metrics.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

**What:** Adds a new per-instance JMX gauge `DomainInfoValidGauge` to `InstanceMonitor` and a bulk update method `updateInstanceDomainInfoValidity()` to `ClusterStatusMonitor`.

**Why:** When `allowParticipantAutoJoin` is enabled, instances can join a cluster without proper domain info (fault zone, topology keys). This can silently cause:
- Rebalance pipeline failures for enabled instances with completely empty domain info
- Instances being silently dropped from the topology tree (getting no partitions) when the fault zone key is missing

Currently there is no metric to detect this — only warn-level logs that are easy to miss. This gauge provides continuous observability so operators can alert on `DomainInfoValidGauge == 0`.

**How:**
- Added `DOMAIN_INFO_VALID_GAUGE("DomainInfoValidGauge")` to `InstanceMonitor.InstanceMonitorMetric` enum
- Added `SimpleDynamicMetric<Long> _domainInfoValidGauge` field, initialized to `1L` (valid by default)
- Added `updateDomainInfoValid(boolean)` method to `InstanceMonitor`
- Added `updateInstanceDomainInfoValidity(Set<String> invalidInstances)` to `ClusterStatusMonitor` which iterates all registered instance monitors and sets the gauge to 0 for invalid instances, 1 for all others
- Follows existing gauge conventions (e.g., `Enabled`, `Online`, `AllPartitionsDisabled`) — uses `SimpleDynamicMetric<Long>` with `Gauge` suffix for Observe/InGraphs compatibility

### Tests

- [ ] The following tests are written for this issue:

- `TestInstanceMonitor.testDomainInfoValidGauge` — verifies default value is 1, toggle to 0/1, idempotent updates
- `TestClusterStatusMonitor.testUpdateInstanceDomainInfoValidity` — registers instances via `setClusterInstanceStatus`, verifies default is 1 via JMX MBeanServer, marks subset as invalid, verifies via JMX, updates with different invalid set, verifies state flips correctly, verifies empty set resets all to valid

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.712 s - in TestSuite [INFO] [INFO] Results: [INFO] [INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0 [INFO] [INFO] BUILD SUCCESS
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
