### PR TITLE
Add async domain info validation in ReadClusterDataStage

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -124,7 +124,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
       asyncExecute(dataProvider.getAsyncTasksThreadPool(), new Callable<Object>() {
         @Override
         public Object call() {
-          validateAndUpdateInstanceDomainInfoStatus(clusterConfig, dataProvider, clusterStatusMonitor);
+          validateAndReportInstanceDomainInfo(clusterConfig, dataProvider, clusterStatusMonitor);
           return null;
         }
       });
@@ -151,7 +151,7 @@ public class ReadClusterDataStage extends AbstractBaseStage {
    * - Missing fault zone type key in the domain map
    * - Missing zone ID when using legacy (non-custom) topology
    */
-  static void validateAndUpdateInstanceDomainInfoStatus(ClusterConfig clusterConfig,
+  static void validateAndReportInstanceDomainInfo(ClusterConfig clusterConfig,
       BaseControllerDataProvider dataProvider, ClusterStatusMonitor clusterStatusMonitor) {
     if (clusterStatusMonitor == null || clusterConfig == null) {
       return;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +36,7 @@ import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
 import org.apache.helix.controller.pipeline.StageException;
+import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.InstanceConfig;
@@ -118,6 +120,14 @@ public class ReadClusterDataStage extends AbstractBaseStage {
           return null;
         }
       });
+
+      asyncExecute(dataProvider.getAsyncTasksThreadPool(), new Callable<Object>() {
+        @Override
+        public Object call() {
+          validateAndUpdateInstanceDomainInfoStatus(clusterConfig, dataProvider, clusterStatusMonitor);
+          return null;
+        }
+      });
     } else {
       asyncExecute(dataProvider.getAsyncTasksThreadPool(), new Callable<Object>() {
         @Override
@@ -129,6 +139,45 @@ public class ReadClusterDataStage extends AbstractBaseStage {
         }
       });
     }
+  }
+
+  /**
+   * Validates domain info for all instances against the cluster's topology configuration and
+   * updates the DomainInfoValidGauge metric. Only runs when allowParticipantAutoJoin is enabled.
+   *
+   * An instance is considered invalid if {@link InstanceConfig#validateTopologySettingInInstanceConfig}
+   * throws, which covers:
+   * - Empty or missing domain info on an instance when topology-aware is enabled
+   * - Missing fault zone type key in the domain map
+   * - Missing zone ID when using legacy (non-custom) topology
+   */
+  static void validateAndUpdateInstanceDomainInfoStatus(ClusterConfig clusterConfig,
+      BaseControllerDataProvider dataProvider, ClusterStatusMonitor clusterStatusMonitor) {
+    if (clusterStatusMonitor == null || clusterConfig == null) {
+      return;
+    }
+
+    String autoJoin = clusterConfig.getRecord()
+        .getSimpleField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN);
+    if (!Boolean.parseBoolean(autoJoin)) {
+      return;
+    }
+
+    Set<String> invalidInstances = new HashSet<>();
+    Map<String, InstanceConfig> instanceConfigMap = dataProvider.getInstanceConfigMap();
+    for (Map.Entry<String, InstanceConfig> entry : instanceConfigMap.entrySet()) {
+      String instanceName = entry.getKey();
+      InstanceConfig instanceConfig = entry.getValue();
+      try {
+        instanceConfig.validateTopologySettingInInstanceConfig(clusterConfig, instanceName);
+      } catch (Exception e) {
+        invalidInstances.add(instanceName);
+        logger.warn("Instance {} has invalid domain info for cluster topology configuration",
+            instanceName, e);
+      }
+    }
+
+    clusterStatusMonitor.updateInstanceDomainInfoValidity(invalidInstances);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStageDomainValidation.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStageDomainValidation.java
@@ -1,0 +1,214 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+
+import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
+import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
+import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+
+
+public class TestReadClusterDataStageDomainValidation {
+  private static final String CLUSTER_NAME = "TestCluster_DomainValidation";
+  private static final MBeanServerConnection _server = ManagementFactory.getPlatformMBeanServer();
+
+  private ClusterStatusMonitor _monitor;
+  private ClusterConfig _clusterConfig;
+  private BaseControllerDataProvider _dataProvider;
+
+  @BeforeMethod
+  public void beforeMethod() throws Exception {
+    _monitor = new ClusterStatusMonitor(CLUSTER_NAME);
+    _monitor.active();
+
+    _clusterConfig = new ClusterConfig(CLUSTER_NAME);
+    _dataProvider = Mockito.mock(BaseControllerDataProvider.class);
+  }
+
+  @AfterMethod
+  public void afterMethod() {
+    _monitor.reset();
+  }
+
+  @Test
+  public void testSkipsWhenAutoJoinDisabled() throws Exception {
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+    instanceConfigMap.put("instance_0", new InstanceConfig("instance_0"));
+    when(_dataProvider.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+
+    registerInstances(instanceConfigMap);
+
+    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+        _clusterConfig, _dataProvider, _monitor);
+
+    assertDomainInfoValidGauge("instance_0", 1L);
+  }
+
+  @Test
+  public void testSkipsWhenMonitorIsNull() {
+    _clusterConfig.getRecord().setSimpleField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
+
+    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+        _clusterConfig, _dataProvider, null);
+  }
+
+  @Test
+  public void testSkipsWhenClusterConfigIsNull() {
+    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+        null, _dataProvider, _monitor);
+  }
+
+  @Test
+  public void testAllValidWhenTopologyAwareDisabled() throws Exception {
+    _clusterConfig.getRecord().setSimpleField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
+
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+    InstanceConfig config = new InstanceConfig("instance_0");
+    instanceConfigMap.put("instance_0", config);
+    when(_dataProvider.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+
+    registerInstances(instanceConfigMap);
+
+    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+        _clusterConfig, _dataProvider, _monitor);
+
+    assertDomainInfoValidGauge("instance_0", 1L);
+  }
+
+  @Test
+  public void testDetectsInvalidDomainWithTopologyAware() throws Exception {
+    _clusterConfig.getRecord().setSimpleField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
+    _clusterConfig.setTopologyAwareEnabled(true);
+    _clusterConfig.setTopology("/zone/rack/host/instance");
+    _clusterConfig.setFaultZoneType("zone");
+
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+
+    InstanceConfig validConfig = new InstanceConfig("instance_valid");
+    validConfig.setDomain("zone=us-west-1,rack=rack1,host=host1,instance=instance_valid");
+    instanceConfigMap.put("instance_valid", validConfig);
+
+    InstanceConfig invalidConfig = new InstanceConfig("instance_invalid");
+    invalidConfig.setDomain("rack=rack2,host=host2,instance=instance_invalid");
+    instanceConfigMap.put("instance_invalid", invalidConfig);
+
+    InstanceConfig emptyDomainConfig = new InstanceConfig("instance_empty");
+    instanceConfigMap.put("instance_empty", emptyDomainConfig);
+
+    when(_dataProvider.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+
+    registerInstances(instanceConfigMap);
+
+    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+        _clusterConfig, _dataProvider, _monitor);
+
+    assertDomainInfoValidGauge("instance_valid", 1L);
+    assertDomainInfoValidGauge("instance_invalid", 0L);
+    assertDomainInfoValidGauge("instance_empty", 0L);
+  }
+
+  @Test
+  public void testDetectsInvalidWithLegacyTopology() throws Exception {
+    _clusterConfig.getRecord().setSimpleField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
+    _clusterConfig.setTopologyAwareEnabled(true);
+
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+
+    InstanceConfig validConfig = new InstanceConfig("instance_with_zone");
+    validConfig.setZoneId("us-west-1");
+    instanceConfigMap.put("instance_with_zone", validConfig);
+
+    InstanceConfig invalidConfig = new InstanceConfig("instance_no_zone");
+    instanceConfigMap.put("instance_no_zone", invalidConfig);
+
+    when(_dataProvider.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+
+    registerInstances(instanceConfigMap);
+
+    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+        _clusterConfig, _dataProvider, _monitor);
+
+    assertDomainInfoValidGauge("instance_with_zone", 1L);
+    assertDomainInfoValidGauge("instance_no_zone", 0L);
+  }
+
+  @Test
+  public void testRecoveryFromInvalidToValid() throws Exception {
+    _clusterConfig.getRecord().setSimpleField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
+    _clusterConfig.setTopologyAwareEnabled(true);
+    _clusterConfig.setTopology("/zone/instance");
+    _clusterConfig.setFaultZoneType("zone");
+
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+
+    InstanceConfig config = new InstanceConfig("instance_0");
+    config.setDomain("instance=instance_0");
+    instanceConfigMap.put("instance_0", config);
+    when(_dataProvider.getInstanceConfigMap()).thenReturn(instanceConfigMap);
+
+    registerInstances(instanceConfigMap);
+
+    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+        _clusterConfig, _dataProvider, _monitor);
+    assertDomainInfoValidGauge("instance_0", 0L);
+
+    config.setDomain("zone=us-west-1,instance=instance_0");
+
+    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+        _clusterConfig, _dataProvider, _monitor);
+    assertDomainInfoValidGauge("instance_0", 1L);
+  }
+
+  private void registerInstances(Map<String, InstanceConfig> instanceConfigMap) {
+    _monitor.setClusterInstanceStatus(
+        instanceConfigMap.keySet(), instanceConfigMap.keySet(),
+        Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap());
+  }
+
+  private void assertDomainInfoValidGauge(String instanceName, long expectedValue)
+      throws Exception {
+    ObjectName objName = new ObjectName(String.format("%s:cluster=%s,instanceName=%s",
+        MonitorDomainNames.ClusterStatus.name(), CLUSTER_NAME, instanceName));
+    Assert.assertTrue(_server.isRegistered(objName),
+        "MBean not registered for " + instanceName);
+    Object value = _server.getAttribute(objName, "DomainInfoValidGauge");
+    Assert.assertTrue(value instanceof Long);
+    Assert.assertEquals((long) value, expectedValue,
+        "DomainInfoValidGauge mismatch for " + instanceName);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStageDomainValidation.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStageDomainValidation.java
@@ -71,7 +71,7 @@ public class TestReadClusterDataStageDomainValidation {
 
     registerInstances(instanceConfigMap);
 
-    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+    ReadClusterDataStage.validateAndReportInstanceDomainInfo(
         _clusterConfig, _dataProvider, _monitor);
 
     assertDomainInfoValidGauge("instance_0", 1L);
@@ -81,13 +81,13 @@ public class TestReadClusterDataStageDomainValidation {
   public void testSkipsWhenMonitorIsNull() {
     _clusterConfig.getRecord().setSimpleField(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, "true");
 
-    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+    ReadClusterDataStage.validateAndReportInstanceDomainInfo(
         _clusterConfig, _dataProvider, null);
   }
 
   @Test
   public void testSkipsWhenClusterConfigIsNull() {
-    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+    ReadClusterDataStage.validateAndReportInstanceDomainInfo(
         null, _dataProvider, _monitor);
   }
 
@@ -102,7 +102,7 @@ public class TestReadClusterDataStageDomainValidation {
 
     registerInstances(instanceConfigMap);
 
-    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+    ReadClusterDataStage.validateAndReportInstanceDomainInfo(
         _clusterConfig, _dataProvider, _monitor);
 
     assertDomainInfoValidGauge("instance_0", 1L);
@@ -132,7 +132,7 @@ public class TestReadClusterDataStageDomainValidation {
 
     registerInstances(instanceConfigMap);
 
-    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+    ReadClusterDataStage.validateAndReportInstanceDomainInfo(
         _clusterConfig, _dataProvider, _monitor);
 
     assertDomainInfoValidGauge("instance_valid", 1L);
@@ -158,7 +158,7 @@ public class TestReadClusterDataStageDomainValidation {
 
     registerInstances(instanceConfigMap);
 
-    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+    ReadClusterDataStage.validateAndReportInstanceDomainInfo(
         _clusterConfig, _dataProvider, _monitor);
 
     assertDomainInfoValidGauge("instance_with_zone", 1L);
@@ -181,13 +181,13 @@ public class TestReadClusterDataStageDomainValidation {
 
     registerInstances(instanceConfigMap);
 
-    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+    ReadClusterDataStage.validateAndReportInstanceDomainInfo(
         _clusterConfig, _dataProvider, _monitor);
     assertDomainInfoValidGauge("instance_0", 0L);
 
     config.setDomain("zone=us-west-1,instance=instance_0");
 
-    ReadClusterDataStage.validateAndUpdateInstanceDomainInfoStatus(
+    ReadClusterDataStage.validateAndReportInstanceDomainInfo(
         _clusterConfig, _dataProvider, _monitor);
     assertDomainInfoValidGauge("instance_0", 1L);
   }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

(This is Part 2 of the instance domain info validation metrics work. Part 1: #146)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When `allowParticipantAutoJoin` is enabled, instances can join a cluster without pre-registration, meaning their domain info may not be properly configured for the cluster's topology settings. This can lead to silent rebalance failures or instances being dropped from the topology tree.

This PR adds an asynchronous validation step in `ReadClusterDataStage` that runs on every resource pipeline execution:

1. **Guard condition**: Only runs when `allowParticipantAutoJoin` is `true` in the cluster config.
2. **Validation**: Iterates through all instance configs and calls `InstanceConfig.validateTopologySettingInInstanceConfig()` to check domain info alignment with cluster topology.
3. **Metric update**: Calls `ClusterStatusMonitor.updateInstanceDomainInfoValidity()` (added in PR1) with the set of invalid instances, updating the per-instance `DomainInfoValidGauge` (1 = valid, 0 = invalid).
4. **Async execution**: Runs in the existing shared `_asyncTasksThreadPool` via `asyncExecute()` — no new threads created.

Detects:
- Empty or missing domain info when topology-aware is enabled
- Missing fault zone type key in the domain map
- Missing zone ID in legacy (non-custom) topology mode

### Tests

- [x] The following tests are written for this issue:

`TestReadClusterDataStageDomainValidation` (7 tests):
- `testSkipsWhenAutoJoinDisabled`
- `testSkipsWhenMonitorIsNull`
- `testSkipsWhenClusterConfigIsNull`
- `testAllValidWhenTopologyAwareDisabled`
- `testDetectsInvalidDomainWithTopologyAware`
- `testDetectsInvalidWithLegacyTopology`
- `testRecoveryFromInvalidToValid`

The following is the result of the "mvn test" command on the appropriate module:
```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
