### PR TITLE
Add TestInstanceOperationEvacuation with independent evacuation tests

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuation.java
@@ -27,6 +27,7 @@ public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
     createDBInSemiAuto(_gSetupTool, CLUSTER_NAME, semiAutoDB,
         _participants.stream().map(ZKHelixManager::getInstanceName).collect(Collectors.toList()),
         BuiltInStateModelDefinitions.OnlineOffline.name(), 1, _participants.size());
+    _allDBs.add(semiAutoDB);
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     Map<String, ExternalView> assignment = getEVs();
@@ -34,6 +35,11 @@ public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
       Assert.assertTrue(
           getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
     }
+
+    // Remove semiAutoDB from _allDBs before evacuation: SEMI_AUTO resources use fixed
+    // preference lists and don't participate in evacuation, so the strict-match verifier
+    // cannot converge if it includes them.
+    _allDBs.remove(semiAutoDB);
 
     String instanceToEvacuate = _participants.get(0).getInstanceName();
     _gSetupTool.getClusterManagementTool()
@@ -59,7 +65,6 @@ public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
     _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, semiAutoDB);
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     Assert.assertEquals(getEVs(), assignment);
   }
 
@@ -118,6 +123,7 @@ public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
     _gSetupTool.getClusterManagementTool()
         .setInstanceOperation(CLUSTER_NAME, mockNewInstance,
             InstanceConstants.InstanceOperation.EVACUATE);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, mockNewInstance, true);
 
@@ -160,7 +166,7 @@ public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
     String instanceToEvacuate = _participants.get(0).getInstanceName();
     String customizedDB = "CustomizedTestDB";
     Map<Integer, String> partitionInstanceMap = new HashMap<>();
-    partitionInstanceMap.put(Integer.valueOf(0), _participants.get(0).getInstanceName());
+    partitionInstanceMap.put(0, _participants.get(0).getInstanceName());
     createResourceInCustomizedMode(_gSetupTool, CLUSTER_NAME, customizedDB, partitionInstanceMap);
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
@@ -192,8 +198,8 @@ public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
     String instanceToEvacuate = _participants.get(0).getInstanceName();
     String customizedDB = "CustomizedTestDB";
     Map<Integer, String> partitionInstanceMap = new HashMap<>();
-    partitionInstanceMap.put(Integer.valueOf(0), _participants.get(0).getInstanceName());
-    partitionInstanceMap.put(Integer.valueOf(1), _participants.get(0).getInstanceName());
+    partitionInstanceMap.put(0, _participants.get(0).getInstanceName());
+    partitionInstanceMap.put(1, _participants.get(0).getInstanceName());
     createResourceInCustomizedMode(_gSetupTool, CLUSTER_NAME, customizedDB, partitionInstanceMap);
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
@@ -208,8 +214,8 @@ public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
         .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
     Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
 
-    partitionInstanceMap.put(Integer.valueOf(0), _participants.get(1).getInstanceName());
-    partitionInstanceMap.put(Integer.valueOf(1), _participants.get(1).getInstanceName());
+    partitionInstanceMap.put(0, _participants.get(1).getInstanceName());
+    partitionInstanceMap.put(1, _participants.get(1).getInstanceName());
     IdealState newIdealState =
         createCustomizedResourceIdealState(customizedDB, partitionInstanceMap);
     _gSetupTool.getClusterManagementTool()

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuation.java
@@ -1,0 +1,223 @@
+package org.apache.helix.integration.rebalancer;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.manager.zk.ZKHelixManager;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
+
+  @Test
+  public void testEvacuate() throws Exception {
+    System.out.println("START TestInstanceOperationEvacuation.testEvacuate() at "
+        + new Date(System.currentTimeMillis()));
+
+    String semiAutoDB = "SemiAutoTestDB_1";
+    createDBInSemiAuto(_gSetupTool, CLUSTER_NAME, semiAutoDB,
+        _participants.stream().map(ZKHelixManager::getInstanceName).collect(Collectors.toList()),
+        BuiltInStateModelDefinitions.OnlineOffline.name(), 1, _participants.size());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    Map<String, ExternalView> assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertTrue(
+          getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
+    }
+
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+            InstanceConstants.InstanceOperation.EVACUATE);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    assignment = getEVs();
+    List<String> currentActiveInstances =
+        _participantNames.stream().filter(n -> !n.equals(instanceToEvacuate))
+            .collect(Collectors.toList());
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource));
+      Set<String> newPAssignedParticipants = getParticipantsInEv(assignment.get(resource));
+      Assert.assertFalse(newPAssignedParticipants.contains(instanceToEvacuate));
+      Assert.assertTrue(newPAssignedParticipants.containsAll(currentActiveInstances));
+    }
+
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+    Assert.assertTrue(_admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate));
+
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, semiAutoDB);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertEquals(getEVs(), assignment);
+  }
+
+  @Test
+  public void testRevertEvacuation() throws Exception {
+    System.out.println("START TestInstanceOperationEvacuation.testRevertEvacuation() at "
+        + new Date(System.currentTimeMillis()));
+
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+
+    // First evacuate the instance so we can test reverting it
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+            InstanceConstants.InstanceOperation.EVACUATE);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+
+    // Now revert the evacuation
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.ENABLE);
+
+    Assert.assertTrue(
+        _gSetupTool.getClusterManagementTool().getInstanceConfig(CLUSTER_NAME, instanceToEvacuate)
+            .getInstanceEnabled());
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    Map<String, ExternalView> assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertTrue(
+          getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
+      validateAssignmentInEv(assignment.get(resource));
+    }
+  }
+
+  @Test
+  public void testAddingNodeWithEvacuationTag() throws Exception {
+    System.out.println("START TestInstanceOperationEvacuation.testAddingNodeWithEvacuationTag() at "
+        + new Date(System.currentTimeMillis()));
+
+    String mockNewInstance = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool()
+        .enableInstance(CLUSTER_NAME, mockNewInstance, false);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    Map<String, ExternalView> assignment = getEVs();
+    List<String> currentActiveInstances =
+        _participantNames.stream().filter(n -> !n.equals(mockNewInstance))
+            .collect(Collectors.toList());
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource), REPLICA - 1);
+      Set<String> newPAssignedParticipants = getParticipantsInEv(assignment.get(resource));
+      Assert.assertFalse(newPAssignedParticipants.contains(mockNewInstance));
+      Assert.assertTrue(newPAssignedParticipants.containsAll(currentActiveInstances));
+    }
+
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, mockNewInstance,
+            InstanceConstants.InstanceOperation.EVACUATE);
+
+    _gSetupTool.getClusterManagementTool().enableInstance(CLUSTER_NAME, mockNewInstance, true);
+
+    assignment = getEVs();
+    currentActiveInstances =
+        _participantNames.stream().filter(n -> !n.equals(mockNewInstance))
+            .collect(Collectors.toList());
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource), REPLICA - 1);
+      Set<String> newPAssignedParticipants = getParticipantsInEv(assignment.get(resource));
+      Assert.assertFalse(newPAssignedParticipants.contains(mockNewInstance));
+      Assert.assertTrue(newPAssignedParticipants.containsAll(currentActiveInstances));
+    }
+
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, mockNewInstance,
+            InstanceConstants.InstanceOperation.ENABLE);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertTrue(
+          getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
+      validateAssignmentInEv(assignment.get(resource));
+    }
+  }
+
+  @Test
+  public void testEvacuateWithCustomizedResource() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationEvacuation.testEvacuateWithCustomizedResource() at "
+            + new Date(System.currentTimeMillis()));
+
+    for (String resource : _allDBs) {
+      _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, resource);
+    }
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    String customizedDB = "CustomizedTestDB";
+    Map<Integer, String> partitionInstanceMap = new HashMap<>();
+    partitionInstanceMap.put(Integer.valueOf(0), _participants.get(0).getInstanceName());
+    createResourceInCustomizedMode(_gSetupTool, CLUSTER_NAME, customizedDB, partitionInstanceMap);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, true, null, null);
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+            InstanceConstants.InstanceOperation.EVACUATE);
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, customizedDB);
+    createTestDBs(DEFAULT_RESOURCE_DELAY_TIME);
+  }
+
+  @Test
+  public void testEvacuateWithCustomizedResourceOfflineInstance() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationEvacuation.testEvacuateWithCustomizedResourceOfflineInstance() at "
+            + new Date(System.currentTimeMillis()));
+
+    for (String resource : _allDBs) {
+      _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, resource);
+    }
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    String customizedDB = "CustomizedTestDB";
+    Map<Integer, String> partitionInstanceMap = new HashMap<>();
+    partitionInstanceMap.put(Integer.valueOf(0), _participants.get(0).getInstanceName());
+    partitionInstanceMap.put(Integer.valueOf(1), _participants.get(0).getInstanceName());
+    createResourceInCustomizedMode(_gSetupTool, CLUSTER_NAME, customizedDB, partitionInstanceMap);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    _participants.get(0).syncStop();
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, true, null, null);
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+            InstanceConstants.InstanceOperation.EVACUATE);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+
+    partitionInstanceMap.put(Integer.valueOf(0), _participants.get(1).getInstanceName());
+    partitionInstanceMap.put(Integer.valueOf(1), _participants.get(1).getInstanceName());
+    IdealState newIdealState =
+        createCustomizedResourceIdealState(customizedDB, partitionInstanceMap);
+    _gSetupTool.getClusterManagementTool()
+        .setResourceIdealState(CLUSTER_NAME, customizedDB, newIdealState);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Assert.assertTrue(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+
+    _gSetupTool.dropResourceFromCluster(CLUSTER_NAME, customizedDB);
+    createTestDBs(DEFAULT_RESOURCE_DELAY_TIME);
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

This PR is part of the TestInstanceOperation dependency chain reduction effort. See [TestInstanceOperation Dependency Chain Reduction](https://docs.google.com/document/d/1e0xMJ0MZgdx5QyceSm3p69jmW6DjrY14Vo837rCxB58/edit?tab=t.0) for full analysis. Depends on #148.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add `TestInstanceOperationEvacuation` extending `TestInstanceOperationBase` with 5 evacuation-focused tests extracted from `TestInstanceOperation`:

- `testEvacuate`
- `testRevertEvacuation` (made self-contained: sets up its own evacuation before reverting)
- `testAddingNodeWithEvacuationTag`
- `testEvacuateWithCustomizedResource`
- `testEvacuateWithCustomizedResourceOfflineInstance`

All tests run independently with no `dependsOnMethods` chains. The enhanced `@BeforeMethod` from the base class provides full isolation between tests. `TestInstanceOperation` is not modified.

### Tests

- [x] The following tests are written for this issue:

- `TestInstanceOperationEvacuation.testEvacuate`
- `TestInstanceOperationEvacuation.testRevertEvacuation`
- `TestInstanceOperationEvacuation.testAddingNodeWithEvacuationTag`
- `TestInstanceOperationEvacuation.testEvacuateWithCustomizedResource`
- `TestInstanceOperationEvacuation.testEvacuateWithCustomizedResourceOfflineInstance`

- The following is the result of the "mvn test" command on the appropriate module:

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 82.775 s - in org.apache.helix.integration.rebalancer.TestInstanceOperationEvacuation
Results:
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
Total time:  01:27 min
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
