### PR TITLE
Add TestInstanceOperationSwapBasic with independent swap validation tests

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuation.java
@@ -41,6 +41,7 @@ public class TestInstanceOperationEvacuation extends TestInstanceOperationBase {
     // cannot converge if it includes them.
     _allDBs.remove(semiAutoDB);
 
+
     String instanceToEvacuate = _participants.get(0).getInstanceName();
     _gSetupTool.getClusterManagementTool()
         .setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationSwapBasic.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationSwapBasic.java
@@ -1,0 +1,169 @@
+package org.apache.helix.integration.rebalancer;
+
+import java.util.Date;
+
+import org.apache.helix.HelixException;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestInstanceOperationSwapBasic extends TestInstanceOperationBase {
+
+  @Test
+  public void testNodeSwapNoTopologySetup() throws Exception {
+    System.out.println("START TestInstanceOperationSwapBasic.testNodeSwapNoTopologySetup() at "
+        + new Date(System.currentTimeMillis()));
+
+    String instanceToSwapOutName = _participants.get(0).getInstanceName();
+
+    // Add instance with InstanceOperation set to SWAP_IN as default.
+    // The instance will be added with UNKNOWN because the logicalId will not match the
+    // swap out instance since the topology configs are not set.
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    InstanceConfig instanceToSwapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
+    addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.SWAP_IN, -1);
+
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool()
+            .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
+  }
+
+  @Test
+  public void testAddingNodeWithEnableInstanceOperation() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationSwapBasic.testAddingNodeWithEnableInstanceOperation() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    String instanceToSwapOutName = _participants.get(0).getInstanceName();
+    InstanceConfig instanceToSwapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
+
+    // Add instance with InstanceOperation set to ENABLE.
+    // The instance should be added with UNKNOWN since there is already an instance with
+    // the same logicalId in the cluster and this instance is not being set to SWAP_IN when
+    // added.
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.ENABLE, -1);
+
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool()
+            .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
+  }
+
+  @Test
+  public void testNodeSwapWithNoSwapOutNode() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationSwapBasic.testNodeSwapWithNoSwapOutNode() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    // Add new instance with InstanceOperation set to SWAP_IN.
+    // The instance should be added with UNKNOWN since there is not an instance with a matching
+    // logicalId in the cluster to swap with.
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(instanceToSwapInName, "1000", "zone_1000",
+        InstanceConstants.InstanceOperation.SWAP_IN, -1);
+
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool()
+            .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
+  }
+
+  @Test
+  public void testNodeSwapSwapInNodeNoInstanceOperationEnabled() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationSwapBasic.testNodeSwapSwapInNodeNoInstanceOperationEnabled() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    String instanceToSwapOutName = _participants.get(0).getInstanceName();
+    InstanceConfig instanceToSwapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
+
+    // Add instance with same logicalId with InstanceOperation unset, this is the same as default
+    // which is ENABLE.
+    // The instance should be set to UNKNOWN since there is already a matching logicalId in the
+    // cluster.
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE), null, -1);
+
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool()
+            .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
+
+    // Setting the InstanceOperation to SWAP_IN should work because there is a matching logicalId
+    // in the cluster and the InstanceCapacityWeights and FaultZone match.
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToSwapInName,
+        InstanceConstants.InstanceOperation.SWAP_IN);
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool()
+            .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName)
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.SWAP_IN);
+
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
+        .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName, false));
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
+
+  @Test(expectedExceptions = HelixException.class)
+  public void testNodeSwapSwapInNodeWithAlreadySwappingPair() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationSwapBasic.testNodeSwapSwapInNodeWithAlreadySwappingPair() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    String instanceToSwapOutName = _participants.get(0).getInstanceName();
+    InstanceConfig instanceToSwapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
+
+    // Add instance with InstanceOperation set to SWAP_IN
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.SWAP_IN, -1);
+
+    // Add another instance with InstanceOperation set to SWAP_IN with same logicalId as
+    // previously added SWAP_IN instance.
+    String secondInstanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(secondInstanceToSwapInName,
+        instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.SWAP_IN, -1);
+
+    // Instance should be UNKNOWN since there was already a swapping pair.
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool()
+            .getInstanceConfig(CLUSTER_NAME, secondInstanceToSwapInName)
+            .getInstanceOperation().getOperation(),
+        InstanceConstants.InstanceOperation.UNKNOWN);
+
+    // Try to set the InstanceOperation to SWAP_IN, it should throw an exception since there is
+    // already a swapping pair.
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceOperation(CLUSTER_NAME, secondInstanceToSwapInName,
+            InstanceConstants.InstanceOperation.SWAP_IN);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationSwapBasic.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationSwapBasic.java
@@ -125,6 +125,8 @@ public class TestInstanceOperationSwapBasic extends TestInstanceOperationBase {
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName, false));
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    validateSwapCompletedSuccessfully(getEVs(), instanceToSwapOutName, instanceToSwapInName);
   }
 
   @Test(expectedExceptions = HelixException.class)


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

This PR is part of the TestInstanceOperation dependency chain reduction effort. See [TestInstanceOperation Dependency Chain Reduction](https://github.com/linkedin/helix/blob/anubagar/TestInstanceOperation_base_class/helix-core/src/test/resources/TestInstanceOperation_refactoring.md) for full analysis. Depends on  #149.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Add `TestInstanceOperationSwapBasic` extending `TestInstanceOperationBase` with 5 swap-related validation tests extracted from `TestInstanceOperation`:

- `testNodeSwapNoTopologySetup` — validates SWAP_IN is rejected (set to UNKNOWN) when topology configs are not set
- `testAddingNodeWithEnableInstanceOperation` — validates adding an ENABLE instance with a duplicate logicalId is set to UNKNOWN
- `testNodeSwapWithNoSwapOutNode` — validates SWAP_IN with no matching logicalId in the cluster is set to UNKNOWN
- `testNodeSwapSwapInNodeNoInstanceOperationEnabled` — validates adding instance with null operation (same logicalId) gets UNKNOWN, then manual SWAP_IN succeeds and swap completes
- `testNodeSwapSwapInNodeWithAlreadySwappingPair` — validates adding a second SWAP_IN with an existing swapping pair throws HelixException

All tests run independently with no `dependsOnMethods` chains. Tests requiring topology-aware rebalance call `enabledTopologyAwareRebalance()` explicitly; the `@BeforeMethod` from the base class disables topology as the default clean baseline. `TestInstanceOperation` is not modified.

### Tests

- [ ] The following tests are written for this issue:
  - `TestInstanceOperationSwapBasic.testNodeSwapNoTopologySetup`
  - `TestInstanceOperationSwapBasic.testAddingNodeWithEnableInstanceOperation`
  - `TestInstanceOperationSwapBasic.testNodeSwapWithNoSwapOutNode`
  - `TestInstanceOperationSwapBasic.testNodeSwapSwapInNodeNoInstanceOperationEnabled`
  - `TestInstanceOperationSwapBasic.testNodeSwapSwapInNodeWithAlreadySwappingPair`

- The following is the result of the "mvn test" command on the appropriate module:
```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 65.207 s - in org.apache.helix.integration.rebalancer.TestInstanceOperationSwapBasic Results: Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 BUILD SUCCESS Total time: 01:10 min
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
