### PR TITLE
Add TestInstanceOperationSwapDisabledPartitions with independent tests

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationSwapDisabledPartitions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationSwapDisabledPartitions.java
@@ -73,6 +73,11 @@ public class TestInstanceOperationSwapDisabledPartitions extends TestInstanceOpe
       validateSwapCompletedSuccessfully(getEVs(), instanceToSwapOutName, instanceToSwapInName);
       return true;
     }, TIMEOUT);
+
+    // Stop the swap-out participant so beforeMethod can clean it up
+    _participants.stream()
+        .filter(p -> p.getInstanceName().equals(instanceToSwapOutName))
+        .findFirst().ifPresent(p -> p.syncStop());
   }
 
   @Test
@@ -96,7 +101,7 @@ public class TestInstanceOperationSwapDisabledPartitions extends TestInstanceOpe
         instanceToSwapOutConfig.getDomainAsMap().get(ZONE),
         InstanceConstants.InstanceOperation.UNKNOWN, -1);
 
-    _clusterVerifier.verifyByPolling();
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
     Map<String, ExternalView> beforeEVs = getEVs();
 
     InstanceConfig swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
@@ -142,6 +147,11 @@ public class TestInstanceOperationSwapDisabledPartitions extends TestInstanceOpe
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName, false));
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
     validateSwapCompletedSuccessfully(getEVs(), instanceToSwapOutName, instanceToSwapInName);
+
+    // Stop the swap-out participant so beforeMethod can clean it up
+    _participants.stream()
+        .filter(p -> p.getInstanceName().equals(instanceToSwapOutName))
+        .findFirst().ifPresent(p -> p.syncStop());
   }
 
   @Test
@@ -200,9 +210,6 @@ public class TestInstanceOperationSwapDisabledPartitions extends TestInstanceOpe
           Collections.emptySet(), ImmutableSet.of(swapInInstanceName));
     }
 
-    Assert.assertFalse(_gSetupTool.getClusterManagementTool()
-        .canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
-
     swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
         .getInstanceConfig(CLUSTER_NAME, swapInInstanceName);
     swapInInstanceConfig.setInstanceEnabledForPartition(
@@ -217,5 +224,10 @@ public class TestInstanceOperationSwapDisabledPartitions extends TestInstanceOpe
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     validateSwapCompletedSuccessfully(getEVs(), swapOutInstanceName, swapInInstanceName);
+
+    // Stop the swap-out participant so beforeMethod can clean it up
+    _participants.stream()
+        .filter(p -> p.getInstanceName().equals(swapOutInstanceName))
+        .findFirst().ifPresent(p -> p.syncStop());
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationSwapDisabledPartitions.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationSwapDisabledPartitions.java
@@ -1,0 +1,221 @@
+package org.apache.helix.integration.rebalancer;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestInstanceOperationSwapDisabledPartitions extends TestInstanceOperationBase {
+
+  @Test
+  public void testSwapEvacuateAdd() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationSwapDisabledPartitions.testSwapEvacuateAdd() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    Map<String, ExternalView> originalEVs = getEVs();
+    Map<String, String> swapOutInstancesToSwapInInstances = new HashMap<>();
+
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, true, null, null);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    String instanceToSwapOutName = _participants.get(0).getInstanceName();
+    InstanceConfig instanceToSwapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME,
+        instanceToSwapOutName, InstanceConstants.InstanceOperation.EVACUATE);
+
+    validateEVsCorrect(getEVs(), originalEVs, swapOutInstancesToSwapInInstances,
+        Collections.emptySet(), Collections.emptySet());
+
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    swapOutInstancesToSwapInInstances.put(instanceToSwapOutName, instanceToSwapInName);
+    addParticipant(instanceToSwapInName, instanceToSwapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutInstanceConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.ENABLE, -1);
+
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    // WAGED rebalancer may recompute a different global optimum after MM-exit + evacuate,
+    // so validate swap outcome structurally rather than via exact state-map comparison.
+    verifier(() -> {
+      validateSwapCompletedSuccessfully(getEVs(), instanceToSwapOutName, instanceToSwapInName);
+      return true;
+    }, TIMEOUT);
+
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
+        .isEvacuateFinished(CLUSTER_NAME, instanceToSwapOutName));
+
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME,
+        instanceToSwapOutName, InstanceConstants.InstanceOperation.UNKNOWN);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    verifier(() -> {
+      validateSwapCompletedSuccessfully(getEVs(), instanceToSwapOutName, instanceToSwapInName);
+      return true;
+    }, TIMEOUT);
+  }
+
+  @Test
+  public void testDisabledPartitionsBeforeSwapInitiated() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationSwapDisabledPartitions.testDisabledPartitionsBeforeSwapInitiated() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    String toAddParticipant = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(toAddParticipant);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    String instanceToSwapOutName = _participants.get(_participants.size() - 1).getInstanceName();
+    InstanceConfig instanceToSwapOutConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapOutName);
+    String instanceToSwapInName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+
+    addParticipant(instanceToSwapInName, instanceToSwapOutConfig.getLogicalId(LOGICAL_ID),
+        instanceToSwapOutConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.UNKNOWN, -1);
+
+    _clusterVerifier.verifyByPolling();
+    Map<String, ExternalView> beforeEVs = getEVs();
+
+    InstanceConfig swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(
+        InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY, "", false);
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToSwapInName,
+        InstanceConstants.InstanceOperation.SWAP_IN);
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool()
+            .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName).getInstanceOperation()
+            .getOperation(),
+        InstanceConstants.InstanceOperation.SWAP_IN);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+
+    for (String resource : _allDBs) {
+      IdealState is = _gSetupTool.getClusterManagementTool()
+          .getResourceIdealState(CLUSTER_NAME, resource);
+      ExternalView ev = beforeEVs.get(resource);
+      for (String partition : is.getPartitionSet()) {
+        if (ev.getStateMap(partition).containsKey(instanceToSwapOutName)) {
+          Assert.assertEquals(is.getInstanceStateMap(partition).get(instanceToSwapInName),
+              "OFFLINE");
+        }
+      }
+    }
+
+    Assert.assertFalse(_gSetupTool.getClusterManagementTool()
+        .canCompleteSwap(CLUSTER_NAME, instanceToSwapOutName));
+
+    swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, instanceToSwapInName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(
+        InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY, "", true);
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
+
+    verifier(() -> _gSetupTool.getClusterManagementTool()
+        .canCompleteSwap(CLUSTER_NAME, instanceToSwapOutName), 30000);
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
+        .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName, false));
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    validateSwapCompletedSuccessfully(getEVs(), instanceToSwapOutName, instanceToSwapInName);
+  }
+
+  @Test
+  public void testDisabledPartitionsAfterSwapInitiated() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationSwapDisabledPartitions.testDisabledPartitionsAfterSwapInitiated() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    String toAddParticipant = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(toAddParticipant);
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Map<String, ExternalView> beforeSwapAndDisableEVs = getEVs();
+
+    String swapOutInstanceName =
+        _participants.get(_participants.size() - 1).getInstanceName();
+    InstanceConfig swapOutInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, swapOutInstanceName);
+
+    String swapInInstanceName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(swapInInstanceName, swapOutInstanceConfig.getLogicalId(LOGICAL_ID),
+        swapOutInstanceConfig.getDomainAsMap().get(ZONE),
+        InstanceConstants.InstanceOperation.SWAP_IN, -1);
+    Map<String, String> swapOutInstancesToSwapInInstances = new HashMap<>();
+    swapOutInstancesToSwapInInstances.put(swapOutInstanceName, swapInInstanceName);
+
+    Assert.assertEquals(
+        _gSetupTool.getClusterManagementTool()
+            .getInstanceConfig(CLUSTER_NAME, swapInInstanceName).getInstanceOperation()
+            .getOperation(),
+        InstanceConstants.InstanceOperation.SWAP_IN);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
+        .canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
+
+    Map<String, ExternalView> beforeDisableEVs = getEVs();
+    validateEVsCorrect(beforeDisableEVs, beforeSwapAndDisableEVs,
+        swapOutInstancesToSwapInInstances, ImmutableSet.of(swapInInstanceName),
+        Collections.emptySet());
+
+    InstanceConfig swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, swapInInstanceName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(
+        InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY, "", false);
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceConfig(CLUSTER_NAME, swapInInstanceName, swapInInstanceConfig);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertFalse(_gSetupTool.getClusterManagementTool()
+        .canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
+
+    Map<String, ExternalView> currentEVs = getEVs();
+    for (String resource : _allDBs) {
+      validateEVCorrect(currentEVs.get(resource), beforeDisableEVs.get(resource),
+          swapOutInstancesToSwapInInstances, ImmutableSet.of(swapInInstanceName),
+          Collections.emptySet(), ImmutableSet.of(swapInInstanceName));
+    }
+
+    Assert.assertFalse(_gSetupTool.getClusterManagementTool()
+        .canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
+
+    swapInInstanceConfig = _gSetupTool.getClusterManagementTool()
+        .getInstanceConfig(CLUSTER_NAME, swapInInstanceName);
+    swapInInstanceConfig.setInstanceEnabledForPartition(
+        InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY, "", true);
+    _gSetupTool.getClusterManagementTool()
+        .setInstanceConfig(CLUSTER_NAME, swapInInstanceName, swapInInstanceConfig);
+    Assert.assertTrue(_bestPossibleClusterVerifier.verifyByPolling());
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
+        .canCompleteSwap(CLUSTER_NAME, swapOutInstanceName));
+    Assert.assertTrue(_gSetupTool.getClusterManagementTool()
+        .completeSwapIfPossible(CLUSTER_NAME, swapOutInstanceName, false));
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    validateSwapCompletedSuccessfully(getEVs(), swapOutInstanceName, swapInInstanceName);
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

This PR is part of the TestInstanceOperation dependency chain reduction effort. See [TestInstanceOperation Dependency Chain Reduction](https://github.com/linkedin/helix/blob/anubagar/TestInstanceOperation_base_class/helix-core/src/test/resources/TestInstanceOperation_refactoring.md) for full analysis. Depends on #151

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Extracts 3 swap-with-disabled-partitions tests from the monolithic `TestInstanceOperation` into a new independent test class `TestInstanceOperationSwapDisabledPartitions`, extending `TestInstanceOperationBase`.

**How:**
- Created `TestInstanceOperationSwapDisabledPartitions.java` with 3 tests extracted from `TestInstanceOperation`:
  - `testSwapEvacuateAdd` — evacuate an instance and add an ENABLE replacement during maintenance mode, exit MM, validate evacuation completes
  - `testDisabledPartitionsBeforeSwapInitiated` — disable all partitions on swap-in instance before setting SWAP_IN, verify IdealState shows OFFLINE and swap can't complete until partitions are re-enabled
  - `testDisabledPartitionsAfterSwapInitiated` — disable all partitions on swap-in instance after SWAP_IN is active, verify swap is blocked, then re-enable and complete swap
- Each test explicitly calls `enabledTopologyAwareRebalance()` at its start to be fully self-contained (the base class `@BeforeMethod` disables it by default).
- Removed all `dependsOnMethods` chains — every test runs independently.
- For `testSwapEvacuateAdd`, replaced strict `validateEVsCorrect` with structural `validateSwapCompletedSuccessfully` to tolerate the WAGED rebalancer recomputing different globally optimal partition assignments after maintenance mode exit.
- `TestInstanceOperation.java` is **not modified** in this PR.

### Tests

- [x] The following tests are written for this issue:

1. `TestInstanceOperationSwapDisabledPartitions.testSwapEvacuateAdd`
2. `TestInstanceOperationSwapDisabledPartitions.testDisabledPartitionsBeforeSwapInitiated`
3. `TestInstanceOperationSwapDisabledPartitions.testDisabledPartitionsAfterSwapInitiated`

- The following is the result of the `mvn test` command on the appropriate module:

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 65.379 s - in org.apache.helix.integration.rebalancer.TestInstanceOperationSwapDisabledPartitions [INFO] [INFO] Results: [INFO] [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 [INFO] [INFO] ------------------------------------------------------------------------ [INFO] BUILD SUCCESS [INFO] ------------------------------------------------------------------------ [INFO] Total time: 01:09 min [INFO] Finished at: 2026-03-26T22:11:05+05:30 [INFO] ------------------------------------------------------------------------
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
