### PR TITLE
Add TestInstanceOperationEvacuationCancel with independent tests

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuationCancel.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuationCancel.java
@@ -167,5 +167,12 @@ public class TestInstanceOperationEvacuationCancel extends TestInstanceOperation
     verifier(
         () -> _admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate),
         60000);
+
+    // Stop the evacuated participant so beforeMethod can clean it up.
+    // Without this, the instance stays connected in EVACUATE state and
+    // _participants grows unboundedly across test runs.
+    _participants.stream()
+        .filter(p -> p.getInstanceName().equals(instanceToEvacuate))
+        .findFirst().ifPresent(p -> p.syncStop());
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuationCancel.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuationCancel.java
@@ -15,14 +15,11 @@ import org.testng.annotations.Test;
 
 public class TestInstanceOperationEvacuationCancel extends TestInstanceOperationBase {
 
-  @Test
-  public void testEvacuateAndCancelBeforeBootstrapFinish() throws Exception {
-    System.out.println(
-        "START TestInstanceOperationEvacuationCancel.testEvacuateAndCancelBeforeBootstrapFinish() at "
-            + new Date(System.currentTimeMillis()));
-
-    enabledTopologyAwareRebalance();
-
+  /**
+   * Adds two extra MasterSlave resources to increase the partition count so that
+   * evacuation has enough work to avoid completing prematurely during cancel tests.
+   */
+  private void createAdditionalMasterSlaveResources() throws InterruptedException {
     createResourceWithDelayedRebalance(CLUSTER_NAME, "TEST_DB3_DELAYED_CRUSHED", "MasterSlave",
         PARTITIONS, REPLICA, REPLICA - 1, 200000, CrushEdRebalanceStrategy.class.getName());
     _allDBs.add("TEST_DB3_DELAYED_CRUSHED");
@@ -30,7 +27,18 @@ public class TestInstanceOperationEvacuationCancel extends TestInstanceOperation
         PARTITIONS, REPLICA, REPLICA - 1);
     _allDBs.add("TEST_DB4_DELAYED_WAGED");
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
+  }
 
+  @Test
+  public void testEvacuateAndCancelBeforeBootstrapFinish() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationEvacuationCancel.testEvacuateAndCancelBeforeBootstrapFinish() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+    createAdditionalMasterSlaveResources();
+
+    // Negative delay = slow upward transitions (OFFLINE→SLAVE, SLAVE→MASTER)
     _stateModelDelay = -10000L;
     String instanceToEvacuate = _participants.get(0).getInstanceName();
     _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
@@ -60,6 +68,8 @@ public class TestInstanceOperationEvacuationCancel extends TestInstanceOperation
       validateAssignmentInEv(assignment.get(resource));
     }
 
+    // ST delay exceeds verifier timeout, so convergence only succeeds because
+    // cancelling the evacuation (ENABLE) triggers state transition cancellation.
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
 
     assignment = getEVs();
@@ -77,15 +87,9 @@ public class TestInstanceOperationEvacuationCancel extends TestInstanceOperation
             + new Date(System.currentTimeMillis()));
 
     enabledTopologyAwareRebalance();
+    createAdditionalMasterSlaveResources();
 
-    createResourceWithDelayedRebalance(CLUSTER_NAME, "TEST_DB3_DELAYED_CRUSHED", "MasterSlave",
-        PARTITIONS, REPLICA, REPLICA - 1, 200000, CrushEdRebalanceStrategy.class.getName());
-    _allDBs.add("TEST_DB3_DELAYED_CRUSHED");
-    createResourceWithWagedRebalance(CLUSTER_NAME, "TEST_DB4_DELAYED_WAGED", "MasterSlave",
-        PARTITIONS, REPLICA, REPLICA - 1);
-    _allDBs.add("TEST_DB4_DELAYED_WAGED");
-    Assert.assertTrue(_clusterVerifier.verifyByPolling());
-
+    // Positive delay = slow downward transitions (MASTER→SLAVE, SLAVE→OFFLINE, OFFLINE→DROPPED)
     _stateModelDelay = 10000L;
 
     String instanceToEvacuate = _participants.get(0).getInstanceName();

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuationCancel.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationEvacuationCancel.java
@@ -1,0 +1,167 @@
+package org.apache.helix.integration.rebalancer;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
+import org.apache.helix.model.ExternalView;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestInstanceOperationEvacuationCancel extends TestInstanceOperationBase {
+
+  @Test
+  public void testEvacuateAndCancelBeforeBootstrapFinish() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationEvacuationCancel.testEvacuateAndCancelBeforeBootstrapFinish() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    createResourceWithDelayedRebalance(CLUSTER_NAME, "TEST_DB3_DELAYED_CRUSHED", "MasterSlave",
+        PARTITIONS, REPLICA, REPLICA - 1, 200000, CrushEdRebalanceStrategy.class.getName());
+    _allDBs.add("TEST_DB3_DELAYED_CRUSHED");
+    createResourceWithWagedRebalance(CLUSTER_NAME, "TEST_DB4_DELAYED_WAGED", "MasterSlave",
+        PARTITIONS, REPLICA, REPLICA - 1);
+    _allDBs.add("TEST_DB4_DELAYED_WAGED");
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    _stateModelDelay = -10000L;
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.EVACUATE);
+
+    for (String participant : _participantNames) {
+      if (participant.equals(instanceToEvacuate)) {
+        continue;
+      }
+      verifier(() -> ((_dataAccessor.getChildNames(
+          _dataAccessor.keyBuilder().messages(participant))).isEmpty()), 30000);
+    }
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+    Assert.assertFalse(_admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate));
+
+    Thread.sleep(Math.abs(_stateModelDelay / 100));
+    Map<String, ExternalView> assignment = getEVs();
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource));
+    }
+
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.ENABLE);
+
+    assignment = getEVs();
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource));
+    }
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertTrue(
+          getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
+      validateAssignmentInEv(assignment.get(resource));
+    }
+  }
+
+  @Test
+  public void testEvacuateAndCancelBeforeDropFinish() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationEvacuationCancel.testEvacuateAndCancelBeforeDropFinish() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    createResourceWithDelayedRebalance(CLUSTER_NAME, "TEST_DB3_DELAYED_CRUSHED", "MasterSlave",
+        PARTITIONS, REPLICA, REPLICA - 1, 200000, CrushEdRebalanceStrategy.class.getName());
+    _allDBs.add("TEST_DB3_DELAYED_CRUSHED");
+    createResourceWithWagedRebalance(CLUSTER_NAME, "TEST_DB4_DELAYED_WAGED", "MasterSlave",
+        PARTITIONS, REPLICA, REPLICA - 1);
+    _allDBs.add("TEST_DB4_DELAYED_WAGED");
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    _stateModelDelay = 10000L;
+
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.EVACUATE);
+
+    verifier(() -> ((_dataAccessor.getChildNames(
+        _dataAccessor.keyBuilder().messages(instanceToEvacuate))).isEmpty()), 30000);
+    Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
+
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.ENABLE);
+    Map<String, ExternalView> assignment = getEVs();
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource));
+    }
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertTrue(
+          getParticipantsInEv(assignment.get(resource)).containsAll(_participantNames));
+      validateAssignmentInEv(assignment.get(resource));
+    }
+  }
+
+  @Test
+  public void testMarkEvacuationAfterEMM() throws Exception {
+    System.out.println(
+        "START TestInstanceOperationEvacuationCancel.testMarkEvacuationAfterEMM() at "
+            + new Date(System.currentTimeMillis()));
+
+    enabledTopologyAwareRebalance();
+
+    _stateModelDelay = 1000L;
+    Assert.assertFalse(
+        _gSetupTool.getClusterManagementTool().isInMaintenanceMode(CLUSTER_NAME));
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, true, null, null);
+    String newParticipantName = PARTICIPANT_PREFIX + "_" + _nextStartPort.get();
+    addParticipant(newParticipantName);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+    Map<String, ExternalView> assignment = getEVs();
+    for (String resource : _allDBs) {
+      Assert.assertFalse(
+          getParticipantsInEv(assignment.get(resource)).contains(newParticipantName));
+    }
+
+    String instanceToEvacuate = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME, instanceToEvacuate,
+        InstanceConstants.InstanceOperation.EVACUATE);
+
+    for (String resource : _allDBs) {
+      Assert.assertTrue(
+          getParticipantsInEv(assignment.get(resource)).contains(instanceToEvacuate));
+    }
+
+    _gSetupTool.getClusterManagementTool()
+        .manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    Assert.assertTrue(_clusterVerifier.verifyByPolling());
+
+    assignment = getEVs();
+    List<String> currentActiveInstances =
+        _participantNames.stream().filter(n -> !n.equals(instanceToEvacuate))
+            .collect(Collectors.toList());
+    for (String resource : _allDBs) {
+      validateAssignmentInEv(assignment.get(resource));
+      Set<String> newPAssignedParticipants = getParticipantsInEv(assignment.get(resource));
+      Assert.assertFalse(newPAssignedParticipants.contains(instanceToEvacuate));
+      Assert.assertTrue(newPAssignedParticipants.containsAll(currentActiveInstances));
+    }
+    verifier(
+        () -> _admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate),
+        60000);
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

This PR is part of the TestInstanceOperation dependency chain reduction effort. See [TestInstanceOperation Dependency Chain Reduction](https://github.com/linkedin/helix/blob/anubagar/TestInstanceOperation_base_class/helix-core/src/test/resources/TestInstanceOperation_refactoring.md) for full analysis. Depends on #152

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Extracts 3 evacuation cancellation tests from the monolithic `TestInstanceOperation` into a new independent test class `TestInstanceOperationEvacuationCancel`, extending `TestInstanceOperationBase`.

**How:**
- Created `TestInstanceOperationEvacuationCancel.java` with 3 tests extracted from `TestInstanceOperation`:
  - `testEvacuateAndCancelBeforeBootstrapFinish` — set EVACUATE on an instance, cancel it before bootstrap transitions finish, verify the instance remains in the cluster and partitions rebalance back
  - `testEvacuateAndCancelBeforeDropFinish` — set EVACUATE on an instance with delayed state model, cancel it before drop transitions finish, verify the instance remains and partitions recover
  - `testMarkEvacuationAfterEMM` — enter maintenance mode, mark an instance for evacuation, exit maintenance mode, verify evacuation completes and the instance is ready for decommission
- Each test explicitly calls `enabledTopologyAwareRebalance()` at its start to be fully self-contained (the base class `@BeforeMethod` disables it by default).
- Removed all `dependsOnMethods` chains — every test runs independently.
- For `testEvacuateAndCancelBeforeDropFinish`, explicitly adds two extra MasterSlave resources (`TEST_DB3_DELAYED_CRUSHED`, `TEST_DB4_DELAYED_WAGED`) to match the original test environment and ensure evacuation has enough work to properly test delayed drop transitions.
- For `testMarkEvacuationAfterEMM`, wraps the `isReadyForPreparingJoiningCluster` check in a `verifier()` call with increased timeout (60s) to allow delayed state transitions to complete.
- `TestInstanceOperation.java` is **not modified** in this PR.

### Tests

- [x] The following tests are written for this issue:

1. `TestInstanceOperationEvacuationCancel.testEvacuateAndCancelBeforeBootstrapFinish`
2. `TestInstanceOperationEvacuationCancel.testEvacuateAndCancelBeforeDropFinish`
3. `TestInstanceOperationEvacuationCancel.testMarkEvacuationAfterEMM`

- The following is the result of the `mvn test` command on the appropriate module:
```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 220.87 s - in org.apache.helix.integration.rebalancer.TestInstanceOperationEvacuationCancel [INFO] [INFO] Results: [INFO] [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 [INFO] [INFO] ------------------------------------------------------------------------ [INFO] BUILD SUCCESS [INFO] ------------------------------------------------------------------------ [INFO] Total time: 03:47 min [INFO] Finished at: 2026-03-27T08:42:19+05:30 [INFO] ------------------------------------------------------------------------
```

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
