### PR TITLE
Replace remote Codecov script execution and reduce CI token permissions

### DIFF
--- a/.github/workflows/Helix-CI.yml
+++ b/.github/workflows/Helix-CI.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run All Tests
       run: mvn -q -fae test
     - name: Upload to Codecov
-      uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
       if: ${{ github.repository == 'apache/helix' && github.event_name == 'push' && (success() || failure()) }}
     - name: Generate Test Report
       uses: dorny/test-reporter@v1

--- a/.github/workflows/Helix-CI.yml
+++ b/.github/workflows/Helix-CI.yml
@@ -5,7 +5,10 @@ on:
   schedule:
     - cron: '0 */12 * * *'
 
-permissions: write-all
+permissions:
+  contents: read
+  checks: write
+  issues: write
 
 jobs:
   Merge_PR_CI:
@@ -25,7 +28,7 @@ jobs:
     - name: Run All Tests
       run: mvn -q -fae test
     - name: Upload to Codecov
-      run: bash <(curl -s https://codecov.io/bash)
+      uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695
       if: ${{ github.repository == 'apache/helix' && github.event_name == 'push' && (success() || failure()) }}
     - name: Generate Test Report
       uses: dorny/test-reporter@v1


### PR DESCRIPTION
## Summary
- Replace runtime `bash <(curl -s https://codecov.io/bash)` with `codecov/codecov-action` pinned to a full commit SHA.
- Reduce workflow-level permissions from `write-all` to the minimal scopes used by this job.
- Keep existing job flow and conditions, including Apache-only upload and failure handling paths.

## Testing Done
- [x] Verified workflow diff only changes Codecov upload and permission declarations.
- [x] Confirmed the pinned Codecov action SHA resolves from upstream tags.
- [ ] CI run validation in upstream repository by maintainers.