### PR TITLE
Simplify Helix Versioning + Sync Helix Version With Latest Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ out/
 #this directory will be part of release process
 helix-dev-release/
 .shelf/
+.flattened-pom.xml
+pom.xml.versionsBackup

--- a/helix-agent/pom.xml
+++ b/helix-agent/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>helix-agent</artifactId>
   <packaging>bundle</packaging>

--- a/helix-common/pom.xml
+++ b/helix-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/helix-lock/pom.xml
+++ b/helix-lock/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -43,7 +43,6 @@
   </organization>
 
   <properties>
-    <revision>1.4.4-SNAPSHOT</revision>
     <osgi.import>
       org.apache.helix*,
       org.apache.commons.cli*,
@@ -61,7 +60,7 @@
     <dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>metadata-store-directory-common</artifactId>
-      <version>${revision}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/helix-view-aggregator/pom.xml
+++ b/helix-view-aggregator/pom.xml
@@ -21,7 +21,7 @@ under the License.
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/meta-client/pom.xml
+++ b/meta-client/pom.xml
@@ -21,7 +21,7 @@ under the License.
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/metrics-common/pom.xml
+++ b/metrics-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.apache.helix</groupId>
   <artifactId>helix</artifactId>
-  <version>1.4.4-SNAPSHOT</version>
+  <version>1.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Helix</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.apache.helix</groupId>
   <artifactId>helix</artifactId>
-  <version>1.6.1-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <name>Apache Helix</name>
 
@@ -427,7 +427,7 @@
   </ciManagement>
 
   <properties>
-    <revision>1.1.1-SNAPSHOT</revision>
+    <revision>1.6.1-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>1738132755</project.build.outputTimestamp>
 
@@ -689,6 +689,31 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.5.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>

--- a/recipes/distributed-lock-manager/pom.xml
+++ b/recipes/distributed-lock-manager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.helix.recipes</groupId>
     <artifactId>recipes</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>distributed-lock-manager</artifactId>

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <groupId>org.apache.helix.recipes</groupId>
   <artifactId>recipes</artifactId>

--- a/recipes/rabbitmq-consumer-group/pom.xml
+++ b/recipes/rabbitmq-consumer-group/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.helix.recipes</groupId>
     <artifactId>recipes</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>rabbitmq-consumer-group</artifactId>

--- a/recipes/rsync-replicated-file-system/pom.xml
+++ b/recipes/rsync-replicated-file-system/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.helix.recipes</groupId>
     <artifactId>recipes</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>rsync-replicated-file-system</artifactId>

--- a/recipes/service-discovery/pom.xml
+++ b/recipes/service-discovery/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.helix.recipes</groupId>
     <artifactId>recipes</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>service-discovery</artifactId>

--- a/recipes/task-execution/pom.xml
+++ b/recipes/task-execution/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.helix.recipes</groupId>
     <artifactId>recipes</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>task-execution</artifactId>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.helix</groupId>
     <artifactId>helix</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

Changing the version to match latest release 1.6.1-dev-202603111247

  **Commit 1 — "Sync Helix pom version" (7a70c1e9e)**
  Only updated root pom.xml: changed the <revision> property from 1.1.1-SNAPSHOT → 1.6.1-SNAPSHOT. Child module poms still had hardcoded 1.4.4-SNAPSHOT as parent version. This is what triggered the CI failure — the first commit  
  was a partial/intermediate change.


  **Commit 2 — "Use CI-friendly ${revision} for Helix project versioning" (83b1d2dee)**                                                                                                                                                  
  The actual, complete fix. It solves two problems at once:                                                                                                                                                                          
                                                           
  **Problem 1** — Version maintenance: Previously, bumping the project version required manually editing every child pom.xml. This changes to Maven's https://maven.apache.org/maven-ci-friendly.html pattern so only one line needs to  
  change (<revision> in root pom.xml).                                                                                                                                                                                               
                                                                                                                                                                                                                                     
  **Problem 2** — CI failure from commit 1: Child modules were left referencing a hardcoded 1.4.4-SNAPSHOT that no longer matched the root.                                                                                              
                            
  **Changes:**                                                                                                                                                                                                                           
  - pom.xml (root): version becomes ${revision}, adds flatten-maven-plugin to substitute ${revision} in published artifacts (so downstream consumers see a real version, not the variable)
  - All 16 child/recipe pom.xml files: <parent><version> changes from 1.4.4-SNAPSHOT → ${revision}                                                                                                                                   
  - helix-rest/pom.xml: removes its redundant local <revision> property, switches its metadata-store-directory-common dependency to ${project.version}
  - .gitignore: adds .flattened-pom.xml and pom.xml.versionsBackup (artifacts produced by the flatten plugin during local builds)                                                                                                    
                                                                                                                                                                                                                                     
  Net effect: Future version bumps require editing exactly one line in root pom.xml. CI and local builds stay consistent regardless of local Maven cache state. 


### Tests

Build Verified

