### PR TITLE
Fix MalformedObjectNameException for URN-style resource names in JMX MBeans

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
@@ -68,6 +69,8 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   static final String JOB_TYPE_DN_KEY = "jobType";
   static final String DEFAULT_WORKFLOW_JOB_TYPE = "DEFAULT";
   public static final String DEFAULT_TAG = "DEFAULT";
+
+  static final Pattern JMX_SPECIAL_CHARS = Pattern.compile("[,:=*?]");
 
   private final String _clusterName;
   private final MBeanServer _beanServer;
@@ -1135,7 +1138,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     // Quote the resource name only when it contains such characters to avoid
     // MalformedObjectNameException (e.g. URN-style names like urn:li:foo:bar),
     // while leaving normal resource names unchanged in the MBean key.
-    String safeResourceName = resourceName.matches(".*[,:=*?].*")
+    String safeResourceName = JMX_SPECIAL_CHARS.matcher(resourceName).find()
         ? ObjectName.quote(resourceName) : resourceName;
     return String.format("%s,%s=%s", clusterBeanName(), RESOURCE_DN_KEY, safeResourceName);
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -1131,7 +1131,13 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
    * @return resource bean name
    */
   protected String getResourceBeanName(String resourceName) {
-    return String.format("%s,%s=%s", clusterBeanName(), RESOURCE_DN_KEY, resourceName);
+    // JMX ObjectName values cannot contain ':', '=', ',', '*', or '?' unquoted.
+    // Quote the resource name only when it contains such characters to avoid
+    // MalformedObjectNameException (e.g. URN-style names like urn:li:foo:bar),
+    // while leaving normal resource names unchanged in the MBean key.
+    String safeResourceName = resourceName.matches(".*[,:=*?].*")
+        ? ObjectName.quote(resourceName) : resourceName;
+    return String.format("%s,%s=%s", clusterBeanName(), RESOURCE_DN_KEY, safeResourceName);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/PerInstanceResourceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/PerInstanceResourceMonitor.java
@@ -98,9 +98,11 @@ public class PerInstanceResourceMonitor extends DynamicMBeanProvider {
 
     @Override
     public String toString() {
+      String safeResourceName = ClusterStatusMonitor.JMX_SPECIAL_CHARS.matcher(_resourceName).find()
+          ? ObjectName.quote(_resourceName) : _resourceName;
       return ClusterStatusMonitor.CLUSTER_DN_KEY + "=" + _clusterName + ","
           + ClusterStatusMonitor.INSTANCE_DN_KEY + "=" + _instanceName + ","
-          + ClusterStatusMonitor.RESOURCE_DN_KEY + "=" + _resourceName;
+          + ClusterStatusMonitor.RESOURCE_DN_KEY + "=" + safeResourceName;
     }
   }
 


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fixes a `MalformedObjectNameException` that occurs when a resource name contains JMX-reserved characters (e.g. URN-style names like `urn:li:foo:bar` which contain `:`).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

`Fail to register resource mbean, resource: ModelCloudWorkflowType-TENANT_LAUNCH-urn:li:modelCloudTenantVersion:2094_ASSIGN_CRT_DEPLOYMENT_PATH`

**What:** `ClusterStatusMonitor.getResourceBeanName()` previously interpolated the raw `resourceName` directly into the JMX `ObjectName` string without escaping. JMX `ObjectName` values cannot contain unquoted characters `:`, `=`, `,`, `*`, or `?` in key-value pairs, which causes a `MalformedObjectNameException` for URN-style resource names.

**Why:** Helix clusters can have resources named using URN conventions (e.g. `urn:li:dataset:foo`). These names are valid Helix resource identifiers but violate JMX naming rules when used verbatim in an `ObjectName`.

**How:** Added a guard in `getResourceBeanName()` that calls `ObjectName.quote(resourceName)` only when the resource name contains one of the problematic characters (`:`, `,`, `=`, `*`, `?`). Normal resource names (no special characters) pass through unchanged, preserving backward compatibility with existing monitoring dashboards.

```java
String safeResourceName = resourceName.matches(".*[,:=*?].*")
    ? ObjectName.quote(resourceName) : resourceName;
return String.format("%s,%s=%s", clusterBeanName(), RESOURCE_DN_KEY, safeResourceName);
```

### Tests

- [ ] The following tests are written for this issue:

No new unit tests added in this PR. The fix is minimal and self-contained. Existing tests in `helix-core` continue to pass — resource names without special characters are unaffected since the quoting branch is not taken.

- The following is the result of the "mvn test" command on the appropriate module:

```
mvn test -pl helix-core -Dtest=ClusterStatusMonitorTest
```
(Tests pass locally; CI results pending)

### Changes that Break Backward Compatibility (Optional)

- Resources whose names contain JMX-reserved characters (`:`, `,`, `=`, `*`, `?`) will now have their MBean key value quoted (e.g. `Resource="urn:li:foo:bar"` instead of `Resource=urn:li:foo:bar`). This changes the `ObjectName` string for such resources. Monitoring tools or dashboards that previously failed to register/query these MBeans are unaffected in practice (they would have received an exception before). No existing well-named resources are impacted.

### Documentation (Optional)

N/A — this is a bug fix with no new public API.

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml

Made with [Cursor](https://cursor.com)