### PR TITLE
Fix stale maintenance/paused metrics after controller leadership change

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -798,6 +798,8 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       _disabledPartitions.clear();
       _oldDisabledPartitions.clear();
       _rebalanceFailure = false;
+      _inMaintenance = false;
+      _paused = false;
       _maxInstanceMsgQueueSize.set(0L);
       _totalPastDueMsgSize.set(0L);
       _totalMsgQueueSize.set(0L);

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -765,4 +765,25 @@ public class TestClusterStatusMonitor {
 
     monitor.reset();
   }
+
+  @Test()
+  public void testResetClearsMaintenanceAndPausedState() throws Exception {
+    String clusterName = "TestCluster_resetMaintenance";
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
+
+    // Set maintenance and paused to true
+    monitor.setMaintenance(true);
+    monitor.setPaused(true);
+    Assert.assertEquals(monitor.getMaintenance(), 1L,
+        "Maintenance metric should be 1 after setMaintenance(true)");
+    Assert.assertEquals(monitor.getPaused(), 1L,
+        "Paused metric should be 1 after setPaused(true)");
+
+    // Reset should clear both flags
+    monitor.reset();
+    Assert.assertEquals(monitor.getMaintenance(), 0L,
+        "Maintenance metric should be 0 after reset()");
+    Assert.assertEquals(monitor.getPaused(), 0L,
+        "Paused metric should be 0 after reset()");
+  }
 }


### PR DESCRIPTION
## Summary
- `ClusterStatusMonitor.reset()` missed clearing `_inMaintenance` and `_paused` fields, causing stale JMX metrics after controller leadership transitions ([thread](https://linkedin-randd.slack.com/archives/C0640TBEL1L/p1775776036282059))
- Added the two missing field resets and a test to verify the fix

### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes the root cause of recurring false [SLA-0 alerts for "Cluster in Maintenance Mode" (Ambry-video)](https://linkedin-randd.slack.com/archives/C0640TBEL1L/p1775776036282059).

### Description

- [x] Here are some details about my PR:

`ClusterStatusMonitor.reset()` clears most fields (`_rebalanceFailure`, `_liveInstances`, `_instances`, `_disabledInstances`, counters, etc.) but missed `_inMaintenance` and `_paused`.

When a distributed controller loses leadership (LEADER -> STANDBY), `GenericHelixController.onControllerChange()` calls `enableClusterStatusMonitor(false)` which calls `reset()`. Since `_inMaintenance` is not cleared, when the host re-gains leadership and the JMX MBean is re-registered, `getMaintenance()` returns the stale value from the previous leadership period.

**Production impact**: Host `lor1-app52940.prod.linkedin.com` was continuously emitting `Maintenance=1` for the Ambry-video cluster even though the cluster was not in maintenance mode. Confirmed via heap dump analysis showing `_isMaintenanceModeEnabled=true` with non-null `MaintenanceSignal` in `BaseControllerDataProvider` for Ambry-video and Ambry-delivery. Same bug occurred in November 2025.

**Fix**: Add `_inMaintenance = false` and `_paused = false` to `ClusterStatusMonitor.reset()`.

### Tests

- [x] The following tests are written for this issue:

`TestClusterStatusMonitor.testResetClearsMaintenanceAndPausedState` — verifies that `getMaintenance()` and `getPaused()` return 0 after `reset()` when previously set to true.

- The following is the result of the "mvn test" command on the appropriate module:

```
$ mvn test -pl helix-core -Dtest=TestClusterStatusMonitor#testResetClearsMaintenanceAndPausedState
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Testing Done
- [x] Unit test added: `testResetClearsMaintenanceAndPausedState`
- [x] `mvn test -pl helix-core -Dtest=TestClusterStatusMonitor#testResetClearsMaintenanceAndPausedState` passes
- [x] Root cause confirmed via production heap dump analysis 

### Changes that Break Backward Compatibility (Optional)

None. This is a bug fix — `reset()` now correctly clears two fields that were previously missed.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines.

### Code Quality

- [x] My diff has been formatted using helix-style.xml