### PR TITLE
Enrich helix rest error responses

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -44,6 +44,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MaintenanceSignal;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.model.OperationCheckResult;
 
 /*
  * Helix cluster management
@@ -848,6 +849,19 @@ public interface HelixAdmin {
   }
 
   /**
+   * Check to see if swapping between two instances can be completed and return detailed
+   * results including specific blockers if the swap cannot complete. Either the swapOut
+   * or swapIn instance can be passed in.
+   *
+   * @param clusterName  The cluster name
+   * @param instanceName The instance that is being swapped out or swapped in
+   * @return OperationCheckResult containing whether the swap can complete and any blockers.
+   */
+  default OperationCheckResult canCompleteSwapWithDetails(String clusterName, String instanceName) {
+    throw new UnsupportedOperationException("canCompleteSwapWithDetails is not implemented.");
+  }
+
+  /**
    * Check to see if swapping between two instances is ready to be completed and complete it if
    * possible. Either the swapOut or swapIn instance can be passed in.
    *
@@ -860,6 +874,21 @@ public interface HelixAdmin {
   default boolean completeSwapIfPossible(String clusterName, String instanceName,
       boolean forceComplete) {
     throw new UnsupportedOperationException("completeSwapIfPossible is not implemented.");
+  }
+
+  /**
+   * Check to see if swapping between two instances is ready to be completed and complete it if
+   * possible, returning detailed results including blockers if the swap cannot complete.
+   * Either the swapOut or swapIn instance can be passed in.
+   *
+   * @param clusterName  The cluster name
+   * @param instanceName The instance that is being swapped out or swapped in
+   * @param forceComplete Whether to force complete the swap without checking if it is ready
+   * @return OperationCheckResult containing whether the swap completed and any blockers.
+   */
+  default OperationCheckResult completeSwapIfPossibleWithDetails(String clusterName,
+      String instanceName, boolean forceComplete) {
+    throw new UnsupportedOperationException("completeSwapIfPossibleWithDetails is not implemented.");
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -532,7 +532,7 @@ public class ZKHelixAdmin implements HelixAdmin {
    * @param swapInInstanceName  The instance that is being swapped in
    * @return OperationCheckResult with completion status and any blockers.
    */
-  private OperationCheckResult canCompleteSwapWithDetails(String clusterName, String swapOutInstanceName,
+  private OperationCheckResult canCompleteSwap(String clusterName, String swapOutInstanceName,
       String swapInInstanceName) {
     OperationCheckResult.Builder resultBuilder = new OperationCheckResult.Builder();
     BaseDataAccessor<ZNRecord> baseAccessor = _baseDataAccessor;
@@ -696,15 +696,6 @@ public class ZKHelixAdmin implements HelixAdmin {
     return resultBuilder.build();
   }
 
-  /**
-   * Backward-compatible boolean wrapper around canCompleteSwapWithDetails.
-   */
-  private boolean canCompleteSwap(String clusterName, String swapOutInstanceName,
-      String swapInInstanceName) {
-    return canCompleteSwapWithDetails(clusterName, swapOutInstanceName, swapInInstanceName)
-        .isSuccessful();
-  }
-
   private static List<String> safeGetChildNames(BaseDataAccessor<ZNRecord> baseAccessor,
       String path) {
     List<String> children = baseAccessor.getChildNames(path, 0);
@@ -746,7 +737,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     // Check if the swap is ready to be completed.
     return canCompleteSwap(clusterName, swapOutInstanceConfig.getInstanceName(),
-        swapInInstanceConfig.getInstanceName());
+        swapInInstanceConfig.getInstanceName()).isSuccessful();
   }
 
   @Override
@@ -779,7 +770,7 @@ public class ZKHelixAdmin implements HelixAdmin {
               instanceName, clusterName)));
     }
 
-    return canCompleteSwapWithDetails(clusterName, swapOutInstanceConfig.getInstanceName(),
+    return canCompleteSwap(clusterName, swapOutInstanceConfig.getInstanceName(),
         swapInInstanceConfig.getInstanceName());
   }
 
@@ -822,7 +813,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
     // Skip the readiness check when forceComplete is true; otherwise require it to pass.
     if (!forceComplete) {
-      OperationCheckResult swapCheck = canCompleteSwapWithDetails(clusterName,
+      OperationCheckResult swapCheck = canCompleteSwap(clusterName,
           swapOutInstanceConfig.getInstanceName(), swapInInstanceConfig.getInstanceName());
       if (!swapCheck.isSuccessful()) {
         return swapCheck;

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -620,7 +620,7 @@ public class ZKHelixAdmin implements HelixAdmin {
       return resultBuilder.build();
     }
 
-    // 5. Check partition states on swap-in match swap-out.
+    // 5. Collect a list of all partitions that have a current state on swapOutInstance
     String swapOutLastActiveSession = swapOutLiveInstance.getEphemeralOwner();
     String swapInActiveSession = swapInLiveInstance.getEphemeralOwner();
 
@@ -629,6 +629,7 @@ public class ZKHelixAdmin implements HelixAdmin {
         PropertyPathBuilder.instanceCurrentState(clusterName, swapOutInstanceName,
             swapOutLastActiveSession));
     for (String swapOutResource : swapOutResources) {
+      // Get the topState and secondTopStates for the stateModelDef used by the resource.
       IdealState idealState = accessor.getProperty(keyBuilder.idealStates(swapOutResource));
       if (idealState == null) {
         // Resource may have been dropped; skip.
@@ -658,6 +659,7 @@ public class ZKHelixAdmin implements HelixAdmin {
       CurrentState swapInResourceCurrentState = accessor.getProperty(
           keyBuilder.currentState(swapInInstanceName, swapInActiveSession, swapOutResource));
 
+      // Check to make sure swapInInstance has a current state for the resource
       if (swapInResourceCurrentState == null) {
         String blocker = String.format(
             "SwapOutInstance %s has current state for resource %s but SwapInInstance %s does not."
@@ -668,10 +670,17 @@ public class ZKHelixAdmin implements HelixAdmin {
         continue;
       }
 
+      // Iterate over all partitions in the swapOutInstance's current state for the resource
+      // and ensure that the swapInInstance has the correct state for the partition.
       for (String partitionName : swapOutResourceCurrentState.getPartitionStateMap().keySet()) {
         String swapOutPartitionState = swapOutResourceCurrentState.getState(partitionName);
         String swapInPartitionState = swapInResourceCurrentState.getState(partitionName);
 
+        // SwapInInstance should have the correct state for the partition.
+        // All states should match except for the case where the topState is not ALL_REPLICAS
+        // or ALL_CANDIDATE_NODES or the swap-out partition is ERROR state.
+        // When the topState is not ALL_REPLICAS or ALL_CANDIDATE_NODES, the swap-in partition
+        // should be in a secondTopStates.
         if (!(swapOutPartitionState.equals(HelixDefinedState.ERROR.name()) || (
             topState.equals(swapOutPartitionState) && (
                 swapOutPartitionState.equals(swapInPartitionState) ||
@@ -704,40 +713,7 @@ public class ZKHelixAdmin implements HelixAdmin {
 
   @Override
   public boolean canCompleteSwap(String clusterName, String instanceName) {
-    InstanceConfig instanceConfig = getInstanceConfig(clusterName, instanceName);
-    if (instanceConfig == null) {
-      logger.warn(
-          "Instance {} in cluster {} does not exist. Cannot determine if the swap is complete.",
-          instanceName, clusterName);
-      return false;
-    }
-
-    List<InstanceConfig> swappingInstances =
-        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, clusterName,
-            instanceConfig);
-    if (swappingInstances.size() != 1) {
-      logger.warn(
-          "Instance {} in cluster {} is not swapping with any other instance. Cannot determine if the swap is complete.",
-          instanceName, clusterName);
-      return false;
-    }
-
-    InstanceConfig swapOutInstanceConfig = !instanceConfig.getInstanceOperation().getOperation()
-        .equals(InstanceConstants.InstanceOperation.SWAP_IN)
-            ? instanceConfig : swappingInstances.get(0);
-    InstanceConfig swapInInstanceConfig = instanceConfig.getInstanceOperation().getOperation()
-        .equals(InstanceConstants.InstanceOperation.SWAP_IN) ? instanceConfig
-        : swappingInstances.get(0);
-    if (swapOutInstanceConfig == null || swapInInstanceConfig == null) {
-      logger.warn(
-          "Instance {} in cluster {} is not swapping with any other instance. Cannot determine if the swap is complete.",
-          instanceName, clusterName);
-      return false;
-    }
-
-    // Check if the swap is ready to be completed.
-    return canCompleteSwap(clusterName, swapOutInstanceConfig.getInstanceName(),
-        swapInInstanceConfig.getInstanceName()).isSuccessful();
+    return canCompleteSwapWithDetails(clusterName, instanceName).isSuccessful();
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -96,6 +96,7 @@ import org.apache.helix.model.ParticipantHistory;
 import org.apache.helix.model.PauseSignal;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
+import org.apache.helix.model.OperationCheckResult;
 import org.apache.helix.msdcommon.exception.InvalidRoutingDataException;
 import org.apache.helix.tools.DefaultIdealStateCalculator;
 import org.apache.helix.util.ConfigStringUtil;
@@ -518,20 +519,22 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   /**
-   * Check to see if swapping between two instances is ready to be completed. Checks: 1. Both
-   * instances must be alive. 2. Both instances must only have one session and not be carrying over
-   * from a previous session. 3. Both instances must have no pending messages. 4. Both instances
-   * cannot have partitions in the ERROR state 5. SwapIn instance must have correct state for all
-   * partitions that are currently assigned to the SwapOut instance.
-   * TODO: We may want to make this a public API in the future.
+   * Check to see if swapping between two instances is ready to be completed and return
+   * detailed results including specific blockers. Checks:
+   * 1. Both instances must be alive.
+   * 2. Both instances must only have one session and not be carrying over from a previous session.
+   * 3. Both instances must have no pending messages.
+   * 4. Both instances cannot have partitions in the ERROR state.
+   * 5. SwapIn instance must have correct state for all partitions assigned to SwapOut instance.
    *
    * @param clusterName         The cluster name
    * @param swapOutInstanceName The instance that is being swapped out
    * @param swapInInstanceName  The instance that is being swapped in
-   * @return True if the swap is ready to be completed, false otherwise.
+   * @return OperationCheckResult with completion status and any blockers.
    */
-  private boolean canCompleteSwap(String clusterName, String swapOutInstanceName,
+  private OperationCheckResult canCompleteSwapWithDetails(String clusterName, String swapOutInstanceName,
       String swapInInstanceName) {
+    OperationCheckResult.Builder resultBuilder = new OperationCheckResult.Builder();
     BaseDataAccessor<ZNRecord> baseAccessor = _baseDataAccessor;
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, baseAccessor);
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
@@ -544,13 +547,16 @@ public class ZKHelixAdmin implements HelixAdmin {
     InstanceConfig swapOutInstanceConfig = getInstanceConfig(clusterName, swapOutInstanceName);
     InstanceConfig swapInInstanceConfig = getInstanceConfig(clusterName, swapInInstanceName);
     if (swapInLiveInstance == null) {
-      logger.warn(
-          "SwapOutInstance {} is {} + {} and SwapInInstance {} is OFFLINE + {} for cluster {}. Swap will"
-              + " not complete unless SwapInInstance instance is ONLINE.",
+      String blocker = String.format(
+          "SwapOutInstance %s is %s (operation=%s) and SwapInInstance %s is OFFLINE (operation=%s)."
+              + " Swap will not complete unless SwapInInstance is ONLINE.",
           swapOutInstanceName, swapOutLiveInstance != null ? "ONLINE" : "OFFLINE",
-          swapOutInstanceConfig.getInstanceOperation().getOperation(), swapInInstanceName,
-          swapInInstanceConfig.getInstanceOperation().getOperation(), clusterName);
-      return false;
+          swapOutInstanceConfig.getInstanceOperation().getOperation(),
+          swapInInstanceName, swapInInstanceConfig.getInstanceOperation().getOperation());
+      logger.warn(blocker + " cluster={}", clusterName);
+      resultBuilder.addBlocker(blocker);
+      // Cannot proceed with further checks if swap-in is offline
+      return resultBuilder.build();
     }
 
     // 2. Check that both instances only have one session and are not carrying any over.
@@ -560,40 +566,61 @@ public class ZKHelixAdmin implements HelixAdmin {
         PropertyPathBuilder.instanceCurrentState(clusterName, swapOutInstanceName));
     List<String> swapInSessions = safeGetChildNames(baseAccessor,
         PropertyPathBuilder.instanceCurrentState(clusterName, swapInInstanceName));
-    if (swapOutSessions.size() > 1 || swapInSessions.size() > 1) {
-      logger.warn(
-          "SwapOutInstance {} is carrying over from prev session and SwapInInstance {} is carrying over from prev session for cluster {}."
+    if (swapOutSessions.size() > 1) {
+      String blocker = String.format(
+          "SwapOutInstance %s is carrying over from a previous session (%d sessions found)."
               + " Swap will not complete unless both instances have only one session.",
-          swapOutInstanceName, swapInInstanceName, clusterName);
-      return false;
+          swapOutInstanceName, swapOutSessions.size());
+      logger.warn(blocker + " cluster={}", clusterName);
+      resultBuilder.addBlocker(blocker);
+    }
+    if (swapInSessions.size() > 1) {
+      String blocker = String.format(
+          "SwapInInstance %s is carrying over from a previous session (%d sessions found)."
+              + " Swap will not complete unless both instances have only one session.",
+          swapInInstanceName, swapInSessions.size());
+      logger.warn(blocker + " cluster={}", clusterName);
+      resultBuilder.addBlocker(blocker);
+    }
+    if (resultBuilder.hasBlockers()) {
+      return resultBuilder.build();
     }
 
-    // 3. Check that the swapOutInstance has no pending messages.
+    // 3. Check that instances have no pending messages.
     List<Message> swapOutMessages =
         accessor.getChildValues(keyBuilder.messages(swapOutInstanceName), true);
     int swapOutPendingMessageCount = swapOutMessages != null ? swapOutMessages.size() : 0;
     List<Message> swapInMessages =
         accessor.getChildValues(keyBuilder.messages(swapInInstanceName), true);
     int swapInPendingMessageCount = swapInMessages != null ? swapInMessages.size() : 0;
-    if ((swapOutLiveInstance != null && swapOutPendingMessageCount > 0)
-        || swapInPendingMessageCount > 0) {
-      logger.warn(
-          "SwapOutInstance {} has {} pending messages and SwapInInstance {} has {} pending messages for cluster {}."
-              + " Swap will not complete unless both SwapOutInstance(only when live)"
-              + " and SwapInInstance have no pending messages unless.",
-          swapOutInstanceName, swapOutPendingMessageCount, swapInInstanceName,
-          swapInPendingMessageCount, clusterName);
-      return false;
+    if (swapOutLiveInstance != null && swapOutPendingMessageCount > 0) {
+      String blocker = String.format(
+          "SwapOutInstance %s has %d pending messages."
+              + " Swap will not complete unless SwapOutInstance (when live) has no pending messages.",
+          swapOutInstanceName, swapOutPendingMessageCount);
+      logger.warn(blocker + " cluster={}", clusterName);
+      resultBuilder.addBlocker(blocker);
+    }
+    if (swapInPendingMessageCount > 0) {
+      String blocker = String.format(
+          "SwapInInstance %s has %d pending messages."
+              + " Swap will not complete unless SwapInInstance has no pending messages.",
+          swapInInstanceName, swapInPendingMessageCount);
+      logger.warn(blocker + " cluster={}", clusterName);
+      resultBuilder.addBlocker(blocker);
+    }
+    if (resultBuilder.hasBlockers()) {
+      return resultBuilder.build();
     }
 
-    // 4. If the swap-out instance is not alive or is disabled, we return true without checking
-    // the current states on the swap-in instance.
+    // 4. If the swap-out instance is not alive or is disabled, we can complete without
+    // checking current states on the swap-in instance.
     if (swapOutLiveInstance == null || swapOutInstanceConfig.getInstanceOperation().getOperation()
         .equals(InstanceConstants.InstanceOperation.DISABLE)) {
-      return true;
+      return resultBuilder.build();
     }
 
-    // 5. Collect a list of all partitions that have a current state on swapOutInstance
+    // 5. Check partition states on swap-in match swap-out.
     String swapOutLastActiveSession = swapOutLiveInstance.getEphemeralOwner();
     String swapInActiveSession = swapInLiveInstance.getEphemeralOwner();
 
@@ -602,7 +629,6 @@ public class ZKHelixAdmin implements HelixAdmin {
         PropertyPathBuilder.instanceCurrentState(clusterName, swapOutInstanceName,
             swapOutLastActiveSession));
     for (String swapOutResource : swapOutResources) {
-      // Get the topState and secondTopStates for the stateModelDef used by the resource.
       IdealState idealState = accessor.getProperty(keyBuilder.idealStates(swapOutResource));
       if (idealState == null) {
         // Resource may have been dropped; skip.
@@ -612,10 +638,12 @@ public class ZKHelixAdmin implements HelixAdmin {
           accessor.getProperty(keyBuilder.stateModelDef(idealState.getStateModelDefRef()));
       if (stateModelDefinition == null) {
         // State model missing; be conservative.
-        logger.warn(
-            "StateModelDefinition is null for resource {} in cluster {}. Cannot verify swap correctness.",
+        String blocker = String.format(
+            "StateModelDefinition is null for resource %s in cluster %s. Cannot verify swap correctness.",
             swapOutResource, clusterName);
-        return false;
+        logger.warn(blocker);
+        resultBuilder.addBlocker(blocker);
+        continue;
       }
       String topState = stateModelDefinition.getTopState();
       Set<String> secondTopStates = stateModelDefinition.getSecondTopStates();
@@ -630,25 +658,20 @@ public class ZKHelixAdmin implements HelixAdmin {
       CurrentState swapInResourceCurrentState = accessor.getProperty(
           keyBuilder.currentState(swapInInstanceName, swapInActiveSession, swapOutResource));
 
-      // Check to make sure swapInInstance has a current state for the resource
       if (swapInResourceCurrentState == null) {
-        logger.warn(
-            "SwapOutInstance {} has current state for resource {} but SwapInInstance {} does not for cluster {}."
+        String blocker = String.format(
+            "SwapOutInstance %s has current state for resource %s but SwapInInstance %s does not."
                 + " Swap will not complete unless both instances have current states for all resources.",
-            swapOutInstanceName, swapOutResource, swapInInstanceName, clusterName);
-        return false;
+            swapOutInstanceName, swapOutResource, swapInInstanceName);
+        logger.warn(blocker + " cluster={}", clusterName);
+        resultBuilder.addBlocker(blocker);
+        continue;
       }
 
-      // Iterate over all partitions in the swapOutInstance's current state for the resource
-      // and ensure that the swapInInstance has the correct state for the partition.
       for (String partitionName : swapOutResourceCurrentState.getPartitionStateMap().keySet()) {
         String swapOutPartitionState = swapOutResourceCurrentState.getState(partitionName);
         String swapInPartitionState = swapInResourceCurrentState.getState(partitionName);
 
-        // SwapInInstance should have the correct state for the partition.
-        // All states should match except for the case where the topState is not ALL_REPLICAS or ALL_CANDIDATE_NODES
-        // or the swap-out partition is ERROR state.
-        // When the topState is not ALL_REPLICAS or ALL_CANDIDATE_NODES, the swap-in partition should be in a secondTopStates.
         if (!(swapOutPartitionState.equals(HelixDefinedState.ERROR.name()) || (
             topState.equals(swapOutPartitionState) && (
                 swapOutPartitionState.equals(swapInPartitionState) ||
@@ -658,17 +681,28 @@ public class ZKHelixAdmin implements HelixAdmin {
                             stateModelDefinition.getTopState())) && secondTopStates.contains(
                         swapInPartitionState))) || swapOutPartitionState.equals(
             swapInPartitionState))) {
-          logger.warn(
-              "SwapOutInstance {} has partition {} in {} but SwapInInstance {} has partition {} in state {} for cluster {}."
+          String blocker = String.format(
+              "SwapOutInstance %s has partition %s in state %s but SwapInInstance %s has partition %s in state %s for resource %s."
                   + " Swap will not complete unless SwapInInstance has partition in correct states.",
-              swapOutInstanceName, partitionName, swapOutPartitionState, swapInInstanceName,
-              partitionName, swapInPartitionState, clusterName);
-          return false;
+              swapOutInstanceName, partitionName, swapOutPartitionState,
+              swapInInstanceName, partitionName, swapInPartitionState != null ? swapInPartitionState : "MISSING",
+              swapOutResource);
+          logger.warn(blocker + " cluster={}", clusterName);
+          resultBuilder.addBlocker(blocker);
         }
       }
     }
 
-    return true;
+    return resultBuilder.build();
+  }
+
+  /**
+   * Backward-compatible boolean wrapper around canCompleteSwapWithDetails.
+   */
+  private boolean canCompleteSwap(String clusterName, String swapOutInstanceName,
+      String swapInInstanceName) {
+    return canCompleteSwapWithDetails(clusterName, swapOutInstanceName, swapInInstanceName)
+        .isSuccessful();
   }
 
   private static List<String> safeGetChildNames(BaseDataAccessor<ZNRecord> baseAccessor,
@@ -716,24 +750,21 @@ public class ZKHelixAdmin implements HelixAdmin {
   }
 
   @Override
-  public boolean completeSwapIfPossible(String clusterName, String instanceName,
-      boolean forceComplete) {
+  public OperationCheckResult canCompleteSwapWithDetails(String clusterName, String instanceName) {
     InstanceConfig instanceConfig = getInstanceConfig(clusterName, instanceName);
     if (instanceConfig == null) {
-      logger.warn(
-          "Instance {} in cluster {} does not exist. Cannot determine if the swap is complete.",
-          instanceName, clusterName);
-      return false;
+      return OperationCheckResult.failed(Collections.singletonList(
+          String.format("Instance %s does not exist in cluster %s.", instanceName, clusterName)));
     }
 
     List<InstanceConfig> swappingInstances =
         InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, clusterName,
             instanceConfig);
     if (swappingInstances.size() != 1) {
-      logger.warn(
-          "Instance {} in cluster {} is not swapping with any other instance. Cannot determine if the swap is complete.",
-          instanceName, clusterName);
-      return false;
+      return OperationCheckResult.failed(Collections.singletonList(
+          String.format("Instance %s in cluster %s is not swapping with exactly one other instance "
+              + "(found %d matching instances).", instanceName, clusterName,
+              swappingInstances.size())));
     }
 
     InstanceConfig swapOutInstanceConfig = !instanceConfig.getInstanceOperation().getOperation()
@@ -743,16 +774,59 @@ public class ZKHelixAdmin implements HelixAdmin {
         .equals(InstanceConstants.InstanceOperation.SWAP_IN) ? instanceConfig
         : swappingInstances.get(0);
     if (swapOutInstanceConfig == null || swapInInstanceConfig == null) {
-      logger.warn(
-          "Instance {} in cluster {} is not swapping with any other instance. Cannot determine if the swap is complete.",
-          instanceName, clusterName);
-      return false;
+      return OperationCheckResult.failed(Collections.singletonList(
+          String.format("Could not determine swap-out/swap-in pair for instance %s in cluster %s.",
+              instanceName, clusterName)));
+    }
+
+    return canCompleteSwapWithDetails(clusterName, swapOutInstanceConfig.getInstanceName(),
+        swapInInstanceConfig.getInstanceName());
+  }
+
+  @Override
+  public boolean completeSwapIfPossible(String clusterName, String instanceName,
+      boolean forceComplete) {
+    return completeSwapIfPossibleWithDetails(clusterName, instanceName, forceComplete).isSuccessful();
+  }
+
+  @Override
+  public OperationCheckResult completeSwapIfPossibleWithDetails(String clusterName,
+      String instanceName, boolean forceComplete) {
+    InstanceConfig instanceConfig = getInstanceConfig(clusterName, instanceName);
+    if (instanceConfig == null) {
+      return OperationCheckResult.failed(String.format(
+          "Instance %s in cluster %s does not exist. Cannot determine if the swap is complete.",
+          instanceName, clusterName));
+    }
+
+    List<InstanceConfig> swappingInstances =
+        InstanceUtil.findInstancesWithMatchingLogicalId(_baseDataAccessor, clusterName,
+            instanceConfig);
+    if (swappingInstances.size() != 1) {
+      return OperationCheckResult.failed(String.format(
+          "Instance %s in cluster %s is not swapping with exactly one other instance (found %d matching instances).",
+          instanceName, clusterName, swappingInstances.size()));
+    }
+
+    InstanceConfig swapOutInstanceConfig = !instanceConfig.getInstanceOperation().getOperation()
+        .equals(InstanceConstants.InstanceOperation.SWAP_IN)
+            ? instanceConfig : swappingInstances.get(0);
+    InstanceConfig swapInInstanceConfig = instanceConfig.getInstanceOperation().getOperation()
+        .equals(InstanceConstants.InstanceOperation.SWAP_IN) ? instanceConfig
+        : swappingInstances.get(0);
+    if (swapOutInstanceConfig == null || swapInInstanceConfig == null) {
+      return OperationCheckResult.failed(String.format(
+          "Instance %s in cluster %s is not swapping with any other instance.",
+          instanceName, clusterName));
     }
 
     // Skip the readiness check when forceComplete is true; otherwise require it to pass.
-    if (!forceComplete && !canCompleteSwap(clusterName, swapOutInstanceConfig.getInstanceName(),
-        swapInInstanceConfig.getInstanceName())) {
-      return false;
+    if (!forceComplete) {
+      OperationCheckResult swapCheck = canCompleteSwapWithDetails(clusterName,
+          swapOutInstanceConfig.getInstanceName(), swapInInstanceConfig.getInstanceName());
+      if (!swapCheck.isSuccessful()) {
+        return swapCheck;
+      }
     }
 
     BaseDataAccessor<ZNRecord> baseAccessor = new ZkBaseDataAccessor<>(_zkClient);
@@ -787,7 +861,12 @@ public class ZKHelixAdmin implements HelixAdmin {
       return config.getRecord();
     });
 
-    return baseAccessor.multiSet(updaterMap);
+    if (!baseAccessor.multiSet(updaterMap)) {
+      return OperationCheckResult.failed(String.format(
+          "Failed to update instance configs for swap completion in cluster %s. "
+              + "The ZooKeeper update did not succeed.", clusterName));
+    }
+    return OperationCheckResult.success();
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -672,6 +672,9 @@ public class ZKHelixAdmin implements HelixAdmin {
 
       // Iterate over all partitions in the swapOutInstance's current state for the resource
       // and ensure that the swapInInstance has the correct state for the partition.
+      int mismatchCount = 0;
+      int totalPartitions = swapOutResourceCurrentState.getPartitionStateMap().size();
+      String firstMismatchExample = null;
       for (String partitionName : swapOutResourceCurrentState.getPartitionStateMap().keySet()) {
         String swapOutPartitionState = swapOutResourceCurrentState.getState(partitionName);
         String swapInPartitionState = swapInResourceCurrentState.getState(partitionName);
@@ -690,15 +693,22 @@ public class ZKHelixAdmin implements HelixAdmin {
                             stateModelDefinition.getTopState())) && secondTopStates.contains(
                         swapInPartitionState))) || swapOutPartitionState.equals(
             swapInPartitionState))) {
-          String blocker = String.format(
-              "SwapOutInstance %s has partition %s in state %s but SwapInInstance %s has partition %s in state %s for resource %s."
-                  + " Swap will not complete unless SwapInInstance has partition in correct states.",
-              swapOutInstanceName, partitionName, swapOutPartitionState,
-              swapInInstanceName, partitionName, swapInPartitionState != null ? swapInPartitionState : "MISSING",
-              swapOutResource);
-          logger.warn(blocker + " cluster={}", clusterName);
-          resultBuilder.addBlocker(blocker);
+          mismatchCount++;
+          if (firstMismatchExample == null) {
+            firstMismatchExample = String.format("%s: expected %s, got %s",
+                partitionName, swapOutPartitionState,
+                swapInPartitionState != null ? swapInPartitionState : "MISSING");
+          }
         }
+      }
+      if (mismatchCount > 0) {
+        String blocker = String.format(
+            "SwapInInstance %s has %d/%d partitions in incorrect state for resource %s (e.g., %s)."
+                + " Swap will not complete unless SwapInInstance has all partitions in correct states.",
+            swapInInstanceName, mismatchCount, totalPartitions, swapOutResource,
+            firstMismatchExample);
+        logger.warn(blocker + " cluster={}", clusterName);
+        resultBuilder.addBlocker(blocker);
       }
     }
 

--- a/helix-core/src/main/java/org/apache/helix/model/OperationCheckResult.java
+++ b/helix-core/src/main/java/org/apache/helix/model/OperationCheckResult.java
@@ -1,0 +1,102 @@
+package org.apache.helix.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result of an operation readiness or validation check. Contains whether the operation
+ * succeeded and, if not, the specific reasons (blockers) preventing success.
+ */
+public class OperationCheckResult {
+
+  private final boolean _successful;
+  private final List<String> _blockers;
+
+  private OperationCheckResult(boolean successful, List<String> blockers) {
+    _successful = successful;
+    _blockers = blockers != null ? Collections.unmodifiableList(blockers) : Collections.emptyList();
+  }
+
+  /**
+   * Create a successful result.
+   */
+  public static OperationCheckResult success() {
+    return new OperationCheckResult(true, Collections.emptyList());
+  }
+
+  /**
+   * Create a failed result with a single blocker reason.
+   *
+   * @param blocker The human-readable reason why the operation failed.
+   */
+  public static OperationCheckResult failed(String blocker) {
+    return new OperationCheckResult(false, Collections.singletonList(blocker));
+  }
+
+  /**
+   * Create a failed result with the list of blockers preventing the operation.
+   *
+   * @param blockers The list of human-readable reasons why the operation failed.
+   */
+  public static OperationCheckResult failed(List<String> blockers) {
+    return new OperationCheckResult(false, blockers);
+  }
+
+  /**
+   * @return True if the operation succeeded or is ready, false otherwise.
+   */
+  public boolean isSuccessful() {
+    return _successful;
+  }
+
+  /**
+   * @return An unmodifiable list of reasons why the operation failed.
+   *         Empty if the operation succeeded.
+   */
+  public List<String> getBlockers() {
+    return _blockers;
+  }
+
+  /**
+   * Builder for collecting blockers during operation checks.
+   */
+  public static class Builder {
+    private final List<String> _blockers = new ArrayList<>();
+
+    public Builder addBlocker(String blocker) {
+      _blockers.add(blocker);
+      return this;
+    }
+
+    public boolean hasBlockers() {
+      return !_blockers.isEmpty();
+    }
+
+    public OperationCheckResult build() {
+      if (_blockers.isEmpty()) {
+        return OperationCheckResult.success();
+      }
+      return OperationCheckResult.failed(new ArrayList<>(_blockers));
+    }
+  }
+}

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -37,6 +37,7 @@ import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.OperationCheckResult;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
@@ -48,37 +49,53 @@ public class InstanceUtil {
 
   // Validators for instance operation transitions
   private static final InstanceOperationValidator ALWAYS_ALLOWED =
-      (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> true;
+      (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> OperationCheckResult.success();
   private static final InstanceOperationValidator ALL_MATCHES_ARE_UNKNOWN =
       (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> {
         List<InstanceConfig> matchingInstances =
             findInstancesWithMatchingLogicalId(baseDataAccessor, configAccessor, clusterName,
                 instanceConfig);
-        return matchingInstances.isEmpty() || matchingInstances.stream().allMatch(
+        if (matchingInstances.isEmpty() || matchingInstances.stream().allMatch(
             instance -> instance.getInstanceOperation().getOperation()
-                .equals(InstanceConstants.InstanceOperation.UNKNOWN));
+                .equals(InstanceConstants.InstanceOperation.UNKNOWN))) {
+          return OperationCheckResult.success();
+        }
+        return OperationCheckResult.failed(
+            "All matching logical ID instances must be in UNKNOWN state. Matching instances: "
+                + formatMatchingInstances(matchingInstances));
       };
   private static final InstanceOperationValidator ALL_MATCHES_ARE_UNKNOWN_OR_EVACUATE =
       (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> {
         List<InstanceConfig> matchingInstances =
             findInstancesWithMatchingLogicalId(baseDataAccessor, configAccessor, clusterName,
                 instanceConfig);
-        return matchingInstances.isEmpty() || matchingInstances.stream().allMatch(instance ->
+        if (matchingInstances.isEmpty() || matchingInstances.stream().allMatch(instance ->
             instance.getInstanceOperation().getOperation()
                 .equals(InstanceConstants.InstanceOperation.UNKNOWN)
                 || instance.getInstanceOperation().getOperation()
-                .equals(InstanceConstants.InstanceOperation.EVACUATE));
+                .equals(InstanceConstants.InstanceOperation.EVACUATE))) {
+          return OperationCheckResult.success();
+        }
+        return OperationCheckResult.failed(
+            "All matching logical ID instances must be in UNKNOWN or EVACUATE state. Matching instances: "
+                + formatMatchingInstances(matchingInstances));
       };
   private static final InstanceOperationValidator ANY_MATCH_ENABLE_OR_DISABLE =
       (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> {
         List<InstanceConfig> matchingInstances =
             findInstancesWithMatchingLogicalId(baseDataAccessor, configAccessor, clusterName,
                 instanceConfig);
-        return !matchingInstances.isEmpty() && matchingInstances.stream().anyMatch(instance ->
+        if (!matchingInstances.isEmpty() && matchingInstances.stream().anyMatch(instance ->
             instance.getInstanceOperation().getOperation()
                 .equals(InstanceConstants.InstanceOperation.ENABLE)
                 || instance.getInstanceOperation().getOperation()
-                .equals(InstanceConstants.InstanceOperation.DISABLE));
+                .equals(InstanceConstants.InstanceOperation.DISABLE))) {
+          return OperationCheckResult.success();
+        }
+        return OperationCheckResult.failed(matchingInstances.isEmpty()
+            ? "No matching logical ID instances found. At least one must be in ENABLE or DISABLE state."
+            : "At least one matching logical ID instance must be in ENABLE or DISABLE state. Matching instances: "
+                + formatMatchingInstances(matchingInstances));
       };
 
   // Validator map for valid instance operation transitions <currentOperation>:<targetOperation>:<validator>
@@ -159,17 +176,24 @@ public class InstanceUtil {
         VALID_INSTANCE_OPERATION_TRANSITIONS.get(currentOperation);
 
     if (transitionMap == null || !transitionMap.containsKey(targetOperation)) {
+      String validTransitions = transitionMap != null ? transitionMap.keySet().toString() : "none";
       throw new HelixException(
           "Invalid instance operation transition from " + currentOperation + " to "
-              + targetOperation);
+              + targetOperation + " for instance " + instanceConfig.getInstanceName()
+              + ". Valid transitions from " + currentOperation + ": " + validTransitions
+              + ". Current operation source: " + instanceConfig.getInstanceOperation().getSource()
+              + ", reason: " + instanceConfig.getInstanceOperation().getReason());
     }
 
     InstanceOperationValidator validator = transitionMap.get(targetOperation);
-    if (validator == null || !validator.validate(baseDataAccessor, configAccessor, clusterName,
-        instanceConfig)) {
+    OperationCheckResult validationResult = validator != null
+        ? validator.validate(baseDataAccessor, configAccessor, clusterName, instanceConfig)
+        : OperationCheckResult.failed("No validator found for transition");
+    if (!validationResult.isSuccessful()) {
       throw new HelixException(
           "Failed validation for instance operation transition from " + currentOperation + " to "
-              + targetOperation);
+              + targetOperation + " for instance " + instanceConfig.getInstanceName()
+              + ". " + String.join("; ", validationResult.getBlockers()));
     }
   }
 
@@ -282,12 +306,26 @@ public class InstanceUtil {
 
     if (!succeeded) {
       throw new HelixException(
-          "Failed to update instance operation. Please check if instance is disabled.");
+          "Failed to update instance operation for instance " + instanceName + " in cluster "
+              + clusterName + " (target operation: "
+              + (instanceOperation != null ? instanceOperation.getOperation() : "ENABLE")
+              + "). The ZooKeeper update did not succeed.");
     }
   }
 
+  private static String formatMatchingInstances(List<InstanceConfig> matchingInstances) {
+    return matchingInstances.stream()
+        .map(ic -> ic.getInstanceName() + " (operation="
+            + ic.getInstanceOperation().getOperation() + ")")
+        .collect(Collectors.joining(", "));
+  }
+
+  /**
+   * Validates an instance operation transition. Returns a successful OperationCheckResult if valid,
+   * or a failed OperationCheckResult with descriptive blockers if invalid.
+   */
   private interface InstanceOperationValidator {
-    boolean validate(@Nullable BaseDataAccessor<ZNRecord> baseDataAccessor,
+    OperationCheckResult validate(@Nullable BaseDataAccessor<ZNRecord> baseDataAccessor,
         @Nullable ConfigAccessor configAccessor, String clusterName, InstanceConfig instanceConfig);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -20,6 +20,7 @@ package org.apache.helix.util;
  */
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -37,7 +38,6 @@ import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.ClusterTopologyConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.helix.model.OperationCheckResult;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
@@ -47,9 +47,10 @@ public class InstanceUtil {
   private InstanceUtil() {
   }
 
-  // Validators for instance operation transitions
+  // Validators for instance operation transitions.
+  // Return Optional.empty() for success, or Optional.of(reason) for failure.
   private static final InstanceOperationValidator ALWAYS_ALLOWED =
-      (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> OperationCheckResult.success();
+      (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> Optional.empty();
   private static final InstanceOperationValidator ALL_MATCHES_ARE_UNKNOWN =
       (baseDataAccessor, configAccessor, clusterName, instanceConfig) -> {
         List<InstanceConfig> matchingInstances =
@@ -58,9 +59,9 @@ public class InstanceUtil {
         if (matchingInstances.isEmpty() || matchingInstances.stream().allMatch(
             instance -> instance.getInstanceOperation().getOperation()
                 .equals(InstanceConstants.InstanceOperation.UNKNOWN))) {
-          return OperationCheckResult.success();
+          return Optional.empty();
         }
-        return OperationCheckResult.failed(
+        return Optional.of(
             "All matching logical ID instances must be in UNKNOWN state. Matching instances: "
                 + formatMatchingInstances(matchingInstances));
       };
@@ -74,9 +75,9 @@ public class InstanceUtil {
                 .equals(InstanceConstants.InstanceOperation.UNKNOWN)
                 || instance.getInstanceOperation().getOperation()
                 .equals(InstanceConstants.InstanceOperation.EVACUATE))) {
-          return OperationCheckResult.success();
+          return Optional.empty();
         }
-        return OperationCheckResult.failed(
+        return Optional.of(
             "All matching logical ID instances must be in UNKNOWN or EVACUATE state. Matching instances: "
                 + formatMatchingInstances(matchingInstances));
       };
@@ -90,9 +91,9 @@ public class InstanceUtil {
                 .equals(InstanceConstants.InstanceOperation.ENABLE)
                 || instance.getInstanceOperation().getOperation()
                 .equals(InstanceConstants.InstanceOperation.DISABLE))) {
-          return OperationCheckResult.success();
+          return Optional.empty();
         }
-        return OperationCheckResult.failed(matchingInstances.isEmpty()
+        return Optional.of(matchingInstances.isEmpty()
             ? "No matching logical ID instances found. At least one must be in ENABLE or DISABLE state."
             : "At least one matching logical ID instance must be in ENABLE or DISABLE state. Matching instances: "
                 + formatMatchingInstances(matchingInstances));
@@ -186,14 +187,14 @@ public class InstanceUtil {
     }
 
     InstanceOperationValidator validator = transitionMap.get(targetOperation);
-    OperationCheckResult validationResult = validator != null
+    Optional<String> blocker = validator != null
         ? validator.validate(baseDataAccessor, configAccessor, clusterName, instanceConfig)
-        : OperationCheckResult.failed("No validator found for transition");
-    if (!validationResult.isSuccessful()) {
+        : Optional.of("No validator found for transition");
+    if (blocker.isPresent()) {
       throw new HelixException(
           "Failed validation for instance operation transition from " + currentOperation + " to "
               + targetOperation + " for instance " + instanceConfig.getInstanceName()
-              + ". " + String.join("; ", validationResult.getBlockers()));
+              + ". " + blocker.get());
     }
   }
 
@@ -321,11 +322,11 @@ public class InstanceUtil {
   }
 
   /**
-   * Validates an instance operation transition. Returns a successful OperationCheckResult if valid,
-   * or a failed OperationCheckResult with descriptive blockers if invalid.
+   * Validates an instance operation transition. Returns Optional.empty() if valid,
+   * or Optional.of(reason) if invalid.
    */
   private interface InstanceOperationValidator {
-    OperationCheckResult validate(@Nullable BaseDataAccessor<ZNRecord> baseDataAccessor,
+    Optional<String> validate(@Nullable BaseDataAccessor<ZNRecord> baseDataAccessor,
         @Nullable ConfigAccessor configAccessor, String clusterName, InstanceConfig instanceConfig);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/model/TestOperationCheckResult.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestOperationCheckResult.java
@@ -1,0 +1,112 @@
+package org.apache.helix.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestOperationCheckResult {
+
+  @Test
+  public void testSuccess() {
+    OperationCheckResult result = OperationCheckResult.success();
+    Assert.assertTrue(result.isSuccessful());
+    Assert.assertTrue(result.getBlockers().isEmpty());
+  }
+
+  @Test
+  public void testFailedWithSingleBlocker() {
+    OperationCheckResult result = OperationCheckResult.failed("instance is offline");
+    Assert.assertFalse(result.isSuccessful());
+    Assert.assertEquals(result.getBlockers().size(), 1);
+    Assert.assertEquals(result.getBlockers().get(0), "instance is offline");
+  }
+
+  @Test
+  public void testFailedWithMultipleBlockers() {
+    List<String> blockers = Arrays.asList("blocker1", "blocker2", "blocker3");
+    OperationCheckResult result = OperationCheckResult.failed(blockers);
+    Assert.assertFalse(result.isSuccessful());
+    Assert.assertEquals(result.getBlockers().size(), 3);
+    Assert.assertEquals(result.getBlockers().get(0), "blocker1");
+    Assert.assertEquals(result.getBlockers().get(2), "blocker3");
+  }
+
+  @Test
+  public void testFailedWithEmptyBlockerList() {
+    OperationCheckResult result = OperationCheckResult.failed(Collections.emptyList());
+    Assert.assertFalse(result.isSuccessful());
+    Assert.assertTrue(result.getBlockers().isEmpty());
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testBlockersListIsUnmodifiable() {
+    OperationCheckResult result = OperationCheckResult.failed("blocker");
+    result.getBlockers().add("should not be allowed");
+  }
+
+  @Test
+  public void testBuilderWithNoBlockers() {
+    OperationCheckResult.Builder builder = new OperationCheckResult.Builder();
+    Assert.assertFalse(builder.hasBlockers());
+    OperationCheckResult result = builder.build();
+    Assert.assertTrue(result.isSuccessful());
+    Assert.assertTrue(result.getBlockers().isEmpty());
+  }
+
+  @Test
+  public void testBuilderWithBlockers() {
+    OperationCheckResult.Builder builder = new OperationCheckResult.Builder();
+    builder.addBlocker("blocker1");
+    builder.addBlocker("blocker2");
+    Assert.assertTrue(builder.hasBlockers());
+
+    OperationCheckResult result = builder.build();
+    Assert.assertFalse(result.isSuccessful());
+    Assert.assertEquals(result.getBlockers().size(), 2);
+    Assert.assertEquals(result.getBlockers().get(0), "blocker1");
+    Assert.assertEquals(result.getBlockers().get(1), "blocker2");
+  }
+
+  @Test
+  public void testBuilderChaining() {
+    OperationCheckResult result = new OperationCheckResult.Builder()
+        .addBlocker("a")
+        .addBlocker("b")
+        .build();
+    Assert.assertFalse(result.isSuccessful());
+    Assert.assertEquals(result.getBlockers().size(), 2);
+  }
+
+  @Test
+  public void testBuilderResultIsIsolatedFromBuilder() {
+    OperationCheckResult.Builder builder = new OperationCheckResult.Builder();
+    builder.addBlocker("blocker1");
+    OperationCheckResult result = builder.build();
+
+    // Adding more blockers to builder should not affect the already-built result
+    builder.addBlocker("blocker2");
+    Assert.assertEquals(result.getBlockers().size(), 1);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/util/TestInstanceUtilValidation.java
+++ b/helix-core/src/test/java/org/apache/helix/util/TestInstanceUtilValidation.java
@@ -1,0 +1,156 @@
+package org.apache.helix.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixException;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for enriched error messages in InstanceUtil.validateInstanceOperationTransition.
+ * These test the "invalid transition" path which does not require ZK access.
+ */
+public class TestInstanceUtilValidation {
+
+  private static final String TEST_CLUSTER = "testCluster";
+  private static final String TEST_INSTANCE = "testInstance";
+
+  @DataProvider
+  Object[][] invalidTransitions() {
+    return new Object[][] {
+        // {currentOperation, targetOperation}
+        {InstanceConstants.InstanceOperation.ENABLE, InstanceConstants.InstanceOperation.SWAP_IN},
+        {InstanceConstants.InstanceOperation.DISABLE, InstanceConstants.InstanceOperation.SWAP_IN},
+        {InstanceConstants.InstanceOperation.SWAP_IN, InstanceConstants.InstanceOperation.ENABLE},
+        {InstanceConstants.InstanceOperation.SWAP_IN, InstanceConstants.InstanceOperation.DISABLE},
+        {InstanceConstants.InstanceOperation.SWAP_IN, InstanceConstants.InstanceOperation.EVACUATE},
+        {InstanceConstants.InstanceOperation.EVACUATE, InstanceConstants.InstanceOperation.SWAP_IN},
+    };
+  }
+
+  @Test(dataProvider = "invalidTransitions")
+  public void testInvalidTransitionIncludesValidTransitions(
+      InstanceConstants.InstanceOperation currentOp,
+      InstanceConstants.InstanceOperation targetOp) {
+    InstanceConfig instanceConfig = createInstanceConfig(currentOp, "ADMIN", "test reason");
+
+    try {
+      InstanceUtil.validateInstanceOperationTransition((ConfigAccessor) null, TEST_CLUSTER, instanceConfig,
+          currentOp, targetOp);
+      Assert.fail("Expected HelixException for invalid transition from " + currentOp + " to " + targetOp);
+    } catch (HelixException e) {
+      String msg = e.getMessage();
+      // Should include instance name
+      Assert.assertTrue(msg.contains(TEST_INSTANCE),
+          "Error should contain instance name. Got: " + msg);
+      // Should include current and target operations
+      Assert.assertTrue(msg.contains(currentOp.name()),
+          "Error should contain current operation. Got: " + msg);
+      Assert.assertTrue(msg.contains(targetOp.name()),
+          "Error should contain target operation. Got: " + msg);
+      // Should include valid transitions
+      Assert.assertTrue(msg.contains("Valid transitions from"),
+          "Error should list valid transitions. Got: " + msg);
+      // Should include source and reason
+      Assert.assertTrue(msg.contains("ADMIN"),
+          "Error should contain operation source. Got: " + msg);
+      Assert.assertTrue(msg.contains("test reason"),
+          "Error should contain operation reason. Got: " + msg);
+    }
+  }
+
+  @DataProvider
+  Object[][] alwaysAllowedTransitions() {
+    return new Object[][] {
+        // Transitions that use ALWAYS_ALLOWED validator (no ZK access needed)
+        {InstanceConstants.InstanceOperation.ENABLE, InstanceConstants.InstanceOperation.ENABLE},
+        {InstanceConstants.InstanceOperation.ENABLE, InstanceConstants.InstanceOperation.DISABLE},
+        {InstanceConstants.InstanceOperation.ENABLE, InstanceConstants.InstanceOperation.EVACUATE},
+        {InstanceConstants.InstanceOperation.ENABLE, InstanceConstants.InstanceOperation.UNKNOWN},
+        {InstanceConstants.InstanceOperation.DISABLE, InstanceConstants.InstanceOperation.DISABLE},
+        {InstanceConstants.InstanceOperation.DISABLE, InstanceConstants.InstanceOperation.ENABLE},
+        {InstanceConstants.InstanceOperation.DISABLE, InstanceConstants.InstanceOperation.EVACUATE},
+        {InstanceConstants.InstanceOperation.DISABLE, InstanceConstants.InstanceOperation.UNKNOWN},
+        {InstanceConstants.InstanceOperation.SWAP_IN, InstanceConstants.InstanceOperation.SWAP_IN},
+        {InstanceConstants.InstanceOperation.SWAP_IN, InstanceConstants.InstanceOperation.UNKNOWN},
+        {InstanceConstants.InstanceOperation.EVACUATE, InstanceConstants.InstanceOperation.EVACUATE},
+        {InstanceConstants.InstanceOperation.EVACUATE, InstanceConstants.InstanceOperation.UNKNOWN},
+        {InstanceConstants.InstanceOperation.UNKNOWN, InstanceConstants.InstanceOperation.UNKNOWN},
+    };
+  }
+
+  @Test(dataProvider = "alwaysAllowedTransitions")
+  public void testAlwaysAllowedTransitionsPass(
+      InstanceConstants.InstanceOperation currentOp,
+      InstanceConstants.InstanceOperation targetOp) {
+    InstanceConfig instanceConfig = createInstanceConfig(currentOp, "ADMIN", "test");
+
+    // Should not throw — these transitions use ALWAYS_ALLOWED and need no ZK
+    InstanceUtil.validateInstanceOperationTransition((ConfigAccessor) null, TEST_CLUSTER, instanceConfig,
+        currentOp, targetOp);
+  }
+
+  @Test
+  public void testInvalidTransitionErrorMessageFormat() {
+    InstanceConfig instanceConfig = createInstanceConfig(
+        InstanceConstants.InstanceOperation.ENABLE,
+        "AUTOMATION", "scheduled maintenance");
+
+    try {
+      InstanceUtil.validateInstanceOperationTransition((ConfigAccessor) null, TEST_CLUSTER, instanceConfig,
+          InstanceConstants.InstanceOperation.ENABLE,
+          InstanceConstants.InstanceOperation.SWAP_IN);
+      Assert.fail("Expected HelixException");
+    } catch (HelixException e) {
+      String msg = e.getMessage();
+      // Verify all enriched fields are present
+      Assert.assertTrue(msg.contains("Invalid instance operation transition from ENABLE to SWAP_IN"),
+          "Should contain transition description. Got: " + msg);
+      Assert.assertTrue(msg.contains("for instance " + TEST_INSTANCE),
+          "Should contain instance name. Got: " + msg);
+      Assert.assertTrue(msg.contains("Valid transitions from ENABLE:"),
+          "Should list valid transitions. Got: " + msg);
+      Assert.assertTrue(msg.contains("DISABLE"),
+          "Valid transitions should include DISABLE. Got: " + msg);
+      Assert.assertTrue(msg.contains("EVACUATE"),
+          "Valid transitions should include EVACUATE. Got: " + msg);
+      Assert.assertTrue(msg.contains("Current operation source: AUTOMATION"),
+          "Should contain operation source. Got: " + msg);
+      Assert.assertTrue(msg.contains("reason: scheduled maintenance"),
+          "Should contain operation reason. Got: " + msg);
+    }
+  }
+
+  private InstanceConfig createInstanceConfig(InstanceConstants.InstanceOperation operation,
+      String source, String reason) {
+    InstanceConfig config = new InstanceConfig(TEST_INSTANCE);
+    config.setInstanceOperation(
+        new InstanceConfig.InstanceOperation.Builder()
+            .setOperation(operation)
+            .setSource(InstanceConstants.InstanceOperationSource.valueOf(source))
+            .setReason(reason)
+            .build());
+    return config;
+  }
+}

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -62,6 +62,7 @@ import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
+import org.apache.helix.model.OperationCheckResult;
 import org.apache.helix.model.ParticipantHistory;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.rest.clusterMaintenanceService.HealthCheck;
@@ -463,11 +464,16 @@ public class PerInstanceAccessor extends AbstractHelixResource {
                   .build());
           break;
         case canCompleteSwap:
-          return OK(OBJECT_MAPPER.writeValueAsString(
-              ImmutableMap.of("successful", admin.canCompleteSwap(clusterId, instanceName))));
+          OperationCheckResult swapCheckResult = admin.canCompleteSwapWithDetails(clusterId, instanceName);
+          return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of(
+              "successful", swapCheckResult.isSuccessful(),
+              "blockers", swapCheckResult.getBlockers())));
         case completeSwapIfPossible:
-          return OK(OBJECT_MAPPER.writeValueAsString(
-              ImmutableMap.of("successful", admin.completeSwapIfPossible(clusterId, instanceName, force))));
+          OperationCheckResult completeSwapResult =
+              admin.completeSwapIfPossibleWithDetails(clusterId, instanceName, force);
+          return OK(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of(
+              "successful", completeSwapResult.isSuccessful(),
+              "blockers", completeSwapResult.getBlockers())));
         case addInstanceTag:
           if (!validInstance(node, instanceName)) {
             return badRequest("Instance names are not match!");

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestCanSwapCompleteAPI.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestCanSwapCompleteAPI.java
@@ -1,6 +1,7 @@
 package org.apache.helix.rest.server;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.ws.rs.client.Entity;
 
@@ -308,20 +309,34 @@ public class TestCanSwapCompleteAPI extends AbstractTestClass {
   }
 
   /**
-   * Verifies the canCompleteSwap API response.
+   * Verifies the canCompleteSwap API response includes successful field and blockers list.
    */
   private void verifyCanCompleteSwap(String instanceName, Entity<String> empty, boolean expectedResult) throws JsonProcessingException {
-    Response canComplete = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=canCompleteSwap")
-        .format(CLUSTER_NAME, instanceName).post(this, empty);
-    Assert.assertEquals(canComplete.getStatus(), Response.Status.OK.getStatusCode());
-
-    Map<String, Object> canCompleteMap = (Map<String, Object>) OBJECT_MAPPER.readValue(canComplete.readEntity(String.class), Map.class);
+    Map<String, Object> canCompleteMap = getCanCompleteSwapResponse(instanceName, empty);
     Assert.assertEquals((boolean) canCompleteMap.get("successful"), expectedResult,
         "canCompleteSwap should return " + expectedResult);
+    // Verify blockers field is always present
+    Assert.assertNotNull(canCompleteMap.get("blockers"), "Response should contain 'blockers' field");
+    List<String> blockers = (List<String>) canCompleteMap.get("blockers");
+    if (expectedResult) {
+      Assert.assertTrue(blockers.isEmpty(), "Successful result should have empty blockers");
+    } else {
+      Assert.assertFalse(blockers.isEmpty(), "Failed result should have non-empty blockers");
+    }
   }
 
   /**
-   * Verifies the completeSwapIfPossible API response.
+   * Gets the canCompleteSwap response as a map.
+   */
+  private Map<String, Object> getCanCompleteSwapResponse(String instanceName, Entity<String> empty) throws JsonProcessingException {
+    Response canComplete = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=canCompleteSwap")
+        .format(CLUSTER_NAME, instanceName).post(this, empty);
+    Assert.assertEquals(canComplete.getStatus(), Response.Status.OK.getStatusCode());
+    return (Map<String, Object>) OBJECT_MAPPER.readValue(canComplete.readEntity(String.class), Map.class);
+  }
+
+  /**
+   * Verifies the completeSwapIfPossible API response includes successful field and blockers list.
    */
   private void verifyCompleteSwapIfPossible(String instanceName, Entity<String> empty, boolean expectedResult) throws JsonProcessingException {
     Response complete = new JerseyUriRequestBuilder("clusters/{}/instances/{}?command=completeSwapIfPossible")
@@ -331,6 +346,8 @@ public class TestCanSwapCompleteAPI extends AbstractTestClass {
     Map<String, Object> completeMap = (Map<String, Object>) OBJECT_MAPPER.readValue(complete.readEntity(String.class), Map.class);
     Assert.assertEquals((boolean) completeMap.get("successful"), expectedResult,
         "completeSwapIfPossible should return " + expectedResult);
+    // Verify blockers field is always present
+    Assert.assertNotNull(completeMap.get("blockers"), "Response should contain 'blockers' field");
   }
 
   private void clearMessages(String instance) {


### PR DESCRIPTION
### Issues

This PR addresses a systemic gap where Helix REST mutation endpoints return boolean results or generic error messages, making it difficult for clients (e.g., ACM) to diagnose why operations fail.

### Description

**What:** Enrich Helix REST error responses for `canCompleteSwap` and `completeSwapIfPossible` endpoints with detailed failure context. Introduce `OperationCheckResult` as a reusable result type for any operation readiness check.

**Why:** Currently, `canCompleteSwap` returns `{"successful": false}` with no explanation — all 5 diagnostic checks log warnings server-side but return nothing to the caller. Similarly, `setInstanceOperation` failures return generic messages like "Invalid instance operation transition from ENABLE to SWAP_IN" without telling the caller what transitions ARE valid or what state blocking instances are in. This forces operators to dig through Helix server logs to debug stuck operations.

**How:**
  - New `OperationCheckResult` model class with `isSuccessful()` boolean, `getBlockers()` list, and a `Builder` for collecting multiple blockers. Reusable across swap checks, operation validators, and future operation checks.
  - Refactored `ZKHelixAdmin.canCompleteSwap` (private) to return `OperationCheckResult` and collect all blockers instead of returning false at the first failure. Each of the 5 checks (swap-in liveness, session carryover, pending messages, disabled state, partition state matching) produces a specific, human-readable blocker message preserving the original warning message style.
  - Added `HelixAdmin.canCompleteSwapWithDetails` and `completeSwapIfPossibleWithDetails` returning `OperationCheckResult` — boolean `canCompleteSwap` and `completeSwapIfPossible` are preserved as thin wrappers delegating to the `WithDetails` variants for backward compatibility.
  - Changed `InstanceOperationValidator` to return `OperationCheckResult` instead of `boolean`, so validators report *why* a transition is invalid using data they already fetched, eliminating redundant `findInstancesWithMatchingLogicalId` ZK calls.
  - Enriched `InstanceUtil.validateInstanceOperationTransition` error messages to include valid transitions from current state, current operation source/reason, and matching logical ID instance states.
  - Updated `PerInstanceAccessor` REST handlers:
    - `canCompleteSwap` now returns: `{"successful": false, "blockers": ["SwapOutInstance lor1-app123 is ONLINE (operation=EVACUATE) and SwapInInstance lor1-app456 is OFFLINE (operation=SWAP_IN). Swap will not complete unless SwapInInstance is ONLINE."]}`
    - `completeSwapIfPossible` returns blockers when swap cannot complete, including swap readiness check failures and ZK update failures

### Tests

  - The following tests are written for this issue:

  - `TestOperationCheckResult` (new, 9 tests) — tests success, failed with single/multiple blockers, empty blocker list, unmodifiable blockers list, builder with/without blockers, builder chaining, builder isolation from built result.
  - `TestInstanceUtilValidation` (new, 20 tests) — tests invalid transitions include valid transitions list, instance name, operation source, and reason in error messages; tests all always-allowed transitions pass without ZK access; tests specific error message format.
  - `TestCanSwapCompleteAPI` (modified) — updated to verify `blockers` field is present in REST responses, empty on success, non-empty on failure.

  - The following is the result of the "mvn test" command on the appropriate module:

  ```
  $ mvn test -pl helix-core -Dtest=TestOperationCheckResult
  Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS

  $ mvn test -pl helix-core -Dtest=TestInstanceUtilValidation
  Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS
  ```

### Changes that Break Backward Compatibility (Optional)

  - `canCompleteSwap` REST response now includes an additional `blockers` field alongside the existing `successful` field. Clients reading only `successful` are unaffected.
  - `completeSwapIfPossible` REST response now includes a `blockers` field. Clients reading only `successful` are unaffected.
  - `HelixException` messages from `InstanceUtil.validateInstanceOperationTransition` and `setInstanceOperation` are now longer and more detailed. Clients that parse exception message strings may need adjustment.
  - New `HelixAdmin.canCompleteSwapWithDetails` and `completeSwapIfPossibleWithDetails` default methods added — no impact on existing implementations.

### Documentation (Optional)

- N/A

### Commits

- Enrich Helix REST error responses with detailed failure context
- Refactor: make private canCompleteSwap return OperationCheckResult directly
- Overload swap functions (boolean delegates to WithDetails)
- Add tests for OperationCheckResult, InstanceUtil validation, and swap API blockers

### Code Quality

- My diff has been formatted using helix-style.xml
(helix-style-intellij.xml if IntelliJ IDE is used)
