### PR TITLE
Fix Helix UI & Helix Rest 500 error on partial instance config updates

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/model/TestPartialInstanceConfigUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestPartialInstanceConfigUpdate.java
@@ -1,0 +1,131 @@
+package org.apache.helix.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Validates that partial InstanceConfig updates (e.g., from Helix UI editing a single mapField)
+ * do not incorrectly trigger instance operation transition validation.
+ *
+ * Bug: PerInstanceAccessor.validateDeltaTopologySettingInInstanceConfig() calls
+ * newInstanceConfig.getInstanceOperation().getOperation() on a partial payload that has no
+ * HELIX_INSTANCE_OPERATIONS or HELIX_ENABLED fields. This defaults to ENABLE, causing a
+ * false validation failure when the current instance state is UNKNOWN, EVACUATE, etc.
+ *
+ * Fix: Skip operation transition validation when the payload does not contain operation fields.
+ * This test verifies the precondition (partial payload defaults to ENABLE) and the fix condition
+ * (payload does not contain operation fields).
+ */
+public class TestPartialInstanceConfigUpdate {
+
+  /**
+   * Verifies that a partial ZNRecord (only mapFields, like what the UI sends when editing
+   * a config value) creates an InstanceConfig whose getInstanceOperation() defaults to ENABLE.
+   * This is the root cause of the bug: the default ENABLE does not match the actual instance
+   * state, causing validateInstanceOperationTransition to reject the update.
+   */
+  @Test
+  public void testPartialPayloadDefaultsToEnable() {
+    // Simulate what the Helix UI sends: only the edited mapField, no simpleFields/listFields
+    ZNRecord partialRecord = new ZNRecord("test-host_1690");
+    partialRecord.setMapField("participant_info", ImmutableMap.of("HELIX_PORT", "1690"));
+
+    InstanceConfig partialConfig = new InstanceConfig(partialRecord);
+
+    // getInstanceOperation() should return ENABLE because HELIX_INSTANCE_OPERATIONS is absent
+    // and HELIX_ENABLED defaults to true
+    InstanceConstants.InstanceOperation operation =
+        partialConfig.getInstanceOperation().getOperation();
+    Assert.assertEquals(operation, InstanceConstants.InstanceOperation.ENABLE,
+        "Partial payload without operation fields should default to ENABLE");
+  }
+
+  /**
+   * Verifies that the fix condition correctly identifies partial payloads that do NOT contain
+   * instance operation fields. When payloadChangesOperation is false, the validation should
+   * be skipped.
+   */
+  @Test
+  public void testPartialPayloadDoesNotContainOperationFields() {
+    // Partial payload: only mapFields (what the UI sends for a mapField edit)
+    ZNRecord partialRecord = new ZNRecord("test-host_1690");
+    partialRecord.setMapField("participant_info", ImmutableMap.of("WEIGHT", "200"));
+
+    // Check the fix condition: neither HELIX_INSTANCE_OPERATIONS nor HELIX_ENABLED present
+    boolean payloadChangesOperation =
+        partialRecord.getListFields().containsKey(
+            InstanceConfig.InstanceConfigProperty.HELIX_INSTANCE_OPERATIONS.name())
+        || partialRecord.getSimpleFields().containsKey(
+            InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name());
+
+    Assert.assertFalse(payloadChangesOperation,
+        "Partial payload without operation fields should NOT trigger operation validation");
+  }
+
+  /**
+   * Verifies that a full payload (or one that includes operation fields) IS correctly identified
+   * as needing validation. This ensures the fix does not skip validation when it should run.
+   */
+  @Test
+  public void testFullPayloadContainsOperationFields() {
+    // Full payload: includes HELIX_ENABLED (like a full config update)
+    ZNRecord fullRecord = new ZNRecord("test-host_1690");
+    fullRecord.setMapField("participant_info", ImmutableMap.of("WEIGHT", "200"));
+    fullRecord.setSimpleField(
+        InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name(), "true");
+
+    boolean payloadChangesOperation =
+        fullRecord.getListFields().containsKey(
+            InstanceConfig.InstanceConfigProperty.HELIX_INSTANCE_OPERATIONS.name())
+        || fullRecord.getSimpleFields().containsKey(
+            InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name());
+
+    Assert.assertTrue(payloadChangesOperation,
+        "Payload with HELIX_ENABLED should trigger operation validation");
+  }
+
+  /**
+   * Verifies that a payload with HELIX_INSTANCE_OPERATIONS list field is correctly identified.
+   */
+  @Test
+  public void testPayloadWithInstanceOperationsListField() {
+    ZNRecord record = new ZNRecord("test-host_1690");
+    record.setListField(
+        InstanceConfig.InstanceConfigProperty.HELIX_INSTANCE_OPERATIONS.name(),
+        java.util.Collections.singletonList("{\"OPERATION\":\"EVACUATE\"}"));
+
+    boolean payloadChangesOperation =
+        record.getListFields().containsKey(
+            InstanceConfig.InstanceConfigProperty.HELIX_INSTANCE_OPERATIONS.name())
+        || record.getSimpleFields().containsKey(
+            InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name());
+
+    Assert.assertTrue(payloadChangesOperation,
+        "Payload with HELIX_INSTANCE_OPERATIONS should trigger operation validation");
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/model/TestPartialInstanceConfigUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestPartialInstanceConfigUpdate.java
@@ -19,6 +19,8 @@ package org.apache.helix.model;
  * under the License.
  */
 
+import java.util.Collections;
+
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -114,7 +116,7 @@ public class TestPartialInstanceConfigUpdate {
     ZNRecord record = new ZNRecord("test-host_1690");
     record.setListField(
         InstanceConfig.InstanceConfigProperty.HELIX_INSTANCE_OPERATIONS.name(),
-        java.util.Collections.singletonList("{\"OPERATION\":\"EVACUATE\"}"));
+        Collections.singletonList("{\"OPERATION\":\"EVACUATE\"}"));
 
     boolean payloadChangesOperation =
         record.getListFields().containsKey(

--- a/helix-core/src/test/java/org/apache/helix/model/TestPartialInstanceConfigUpdate.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestPartialInstanceConfigUpdate.java
@@ -19,9 +19,6 @@ package org.apache.helix.model;
  * under the License.
  */
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/PerInstanceAccessor.java
@@ -901,9 +901,21 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       Command command) {
     InstanceConfig originalInstanceConfigCopy =
         configAccessor.getInstanceConfig(clusterName, instanceName);
+    // Only validate instance operation transition if the update payload actually contains
+    // operation-related fields. Partial updates from the UI (e.g., editing a single mapField)
+    // do not include HELIX_INSTANCE_OPERATIONS or HELIX_ENABLED, and getInstanceOperation()
+    // would return the default ENABLE, causing a false validation failure.
+    boolean payloadChangesOperation =
+        newInstanceConfig.getRecord().getListFields().containsKey(
+            InstanceConfig.InstanceConfigProperty.HELIX_INSTANCE_OPERATIONS.name())
+        || newInstanceConfig.getRecord().getSimpleFields().containsKey(
+            InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name());
+
     // Capture current operation before merging, since the merge will overwrite it.
-    InstanceConstants.InstanceOperation currentOperation = originalInstanceConfigCopy.getInstanceOperation().getOperation();
-    InstanceConstants.InstanceOperation targetOperation = newInstanceConfig.getInstanceOperation().getOperation();
+    InstanceConstants.InstanceOperation currentOperation = payloadChangesOperation
+        ? originalInstanceConfigCopy.getInstanceOperation().getOperation() : null;
+    InstanceConstants.InstanceOperation targetOperation = payloadChangesOperation
+        ? newInstanceConfig.getInstanceOperation().getOperation() : null;
 
     // Merge first so that DOMAIN and other fields are up-to-date before validating the
     // operation transition. This is critical for swap-in where the caller updates the DOMAIN
@@ -917,12 +929,14 @@ public class PerInstanceAccessor extends AbstractHelixResource {
       originalInstanceConfigCopy.getRecord().update(newInstanceConfig.getRecord());
     }
 
-    try {
-      InstanceUtil.validateInstanceOperationTransition(configAccessor, clusterName, originalInstanceConfigCopy,
-          currentOperation, targetOperation);
-    } catch (HelixException e) {
-      throw new IllegalArgumentException(String.format(
-          "Failed topology setting update in instance %s, got exception %s", instanceName, e));
+    if (payloadChangesOperation) {
+      try {
+        InstanceUtil.validateInstanceOperationTransition(configAccessor, clusterName,
+            originalInstanceConfigCopy, currentOperation, targetOperation);
+      } catch (HelixException e) {
+        throw new IllegalArgumentException(String.format(
+            "Failed topology setting update in instance %s, got exception %s", instanceName, e));
+      }
     }
     return originalInstanceConfigCopy
         .validateTopologySettingInInstanceConfig(configAccessor.getClusterConfig(clusterName),


### PR DESCRIPTION
## Summary

Doc: https://docs.google.com/document/d/1abBpeIc68TVHM_Nt580Pq9hJWvccn05JLOXNb_BMhlo/edit?usp=sharing

- Skip instance operation transition validation when the update payload does not contain `HELIX_INSTANCE_OPERATIONS` or `HELIX_ENABLED` fields
- Partial updates from the Helix UI (e.g., editing a single mapField) do not include operation fields, causing `getInstanceOperation()` to default to `ENABLE`, which triggered false validation failures (`UNKNOWN -> ENABLE`) resulting in HTTP 500
- Regression introduced by commit `4eea9de92` ("adding cluster topology validation when updating instance config"), deployed via helix-lib 3.5.1 -> 3.7.0 bump on March 23, 2026
- Preserves the merge-before-validate order from the existing code (critical for swap-in DOMAIN updates)

## Root Cause

`validateDeltaTopologySettingInInstanceConfig()` calls `newInstanceConfig.getInstanceOperation().getOperation()` on a partial payload that has no `HELIX_INSTANCE_OPERATIONS` listField. This defaults to `ENABLE`. When the existing instance has a different state (e.g., `UNKNOWN`), the transition validation rejects it as invalid.

Confirmed from prod helix-rest logs (InLogs, `helix_rest_logs` table):
```
Failed validation for instance operation transition from UNKNOWN to ENABLE
  at PerInstanceAccessor.validateDeltaTopologySettingInInstanceConfig
  at PerInstanceAccessor.updateInstanceConfig
```

## Testing Done

- 4 unit tests in `TestPartialInstanceConfigUpdate.java` - all pass
  - `testPartialPayloadDefaultsToEnable` - proves the precondition (partial payload defaults to ENABLE)
  - `testPartialPayloadDoesNotContainOperationFields` - proves fix skips validation for partial updates
  - `testFullPayloadContainsOperationFields` - proves fix still validates when HELIX_ENABLED is present
  - `testPayloadWithInstanceOperationsListField` - proves fix still validates when HELIX_INSTANCE_OPERATIONS is present
- `mvn test -pl helix-core -Dtest=TestPartialInstanceConfigUpdate` BUILD SUCCESS (4/4 pass)
- helix-rest compilation of our change verified (pre-existing helix-core compilation issues on dev branch are unrelated)