### PR TITLE
Fix NPE in TopStateHandoffReportStage when partition state is null during handoff

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/TopStateHandoffReportStage.java
@@ -533,9 +533,16 @@ public class TopStateHandoffReportStage extends AbstractAsyncBaseStage {
     long toTopStateUserLatency = DEFAULT_HANDOFF_USER_LATENCY;
     Map<String, LiveInstance> liveInstances = cache.getLiveInstances();
     for (String instanceName : stateMap.keySet()) {
+      if (!liveInstances.containsKey(instanceName)) {
+        continue;
+      }
       CurrentState currentState =
           cache.getCurrentState(instanceName, liveInstances.get(instanceName).getEphemeralOwner())
               .get(resourceName);
+      if (currentState == null || currentState.getState(partition.getPartitionName()) == null) {
+        // Current state may be transiently unavailable (e.g., transition in-flight), skip instance
+        continue;
+      }
       if (currentState.getState(partition.getPartitionName()).equalsIgnoreCase(topState)) {
         if (currentState.getEndTime(partition.getPartitionName()) <= handOffEndTime) {
           handOffEndTime = currentState.getEndTime(partition.getPartitionName());


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Fixes a `NullPointerException` in `TopStateHandoffReportStage` that manifests as:
> Cannot invoke "String.equalsIgnoreCase(String)" because the return value of "org.apache.helix.model.CurrentState.getState(String)" is null

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In `reportTopStateComesBack()`, the code iterates over all instances in `stateMap` (from `currentStateOutput`) to find the earliest end-time for the top state transition. For each instance it fetches the raw `CurrentState` from the ZK cache and calls `currentState.getState(partitionName)`.

This returns `null` when:
1. An instance in `stateMap` is no longer present in `liveInstances` (died between pipeline stages).
2. The ZK-cached `CurrentState` for that instance does not yet have a state recorded for the partition — e.g., a state transition is in-flight and the participant hasn't written the new state to ZK yet, causing a transient lag between the computed `currentStateOutput` and the raw ZK data.

Calling `.equalsIgnoreCase()` on the `null` return value throws the NPE, causing `TopStateHandoffReportStage` to fail asynchronously on every pipeline run until the transient condition resolves.

**Fix:** Added null-safety guards at the top of the loop:
- Skip instances not present in `liveInstances`.
- Skip instances whose `CurrentState` object is null or whose `getState(partitionName)` returns null (transient in-flight state).

### Tests

- [ ] The following tests are written for this issue:

No new tests added; the fix is a defensive null-check for a transient race condition that is difficult to reproduce deterministically in a unit test.

- Existing tests in `TestTopStateHandoffMetrics` continue to pass.

### Changes that Break Backward Compatibility (Optional)

None. This is a pure defensive fix with no behavioral change for the normal (non-null) code path.

### Documentation (Optional)

N/A

### Commits

- Fix NPE in TopStateHandoffReportStage when current state is null

### Code Quality

- [x] Diff formatted using helix-style.xml

Made with [Cursor](https://cursor.com)