### PR TITLE
Add LZD-PratyushBhatt and PranaviAncha to CODEOWNERS reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default reviewers for all PRs.
 # At least one approval from a code owner is required before merging.
 # GitHub will automatically exclude the PR author from the reviewer list.
-* @kabragaurav @thestreak101 @ngngwr @Chr0nicl3 @proud-parselmouth @laxman-ch
+* @kabragaurav @thestreak101 @ngngwr @Chr0nicl3 @proud-parselmouth @laxman-ch @LZD-PratyushBhatt @PranaviAncha


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

N/A - This is a minor config change to add new code reviewers.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add @LZD-PratyushBhatt and @PranaviAncha as code owners/reviewers in `.github/CODEOWNERS`. This ensures they are automatically requested for review on all PRs.

### Tests

- [x] The following tests are written for this issue:

N/A - No code changes, only CODEOWNERS config update.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"
