### PR TITLE
Fix misleading resource name in StateTransitionStatMonitor sensor name

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/StateTransitionStatMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/StateTransitionStatMonitor.java
@@ -89,8 +89,13 @@ public class StateTransitionStatMonitor extends DynamicMBeanProvider {
   }
 
   public String getSensorName() {
-    return String.format("StateTransitionStat.%s.%s.%s", _context.getClusterName(),
-        _context.getResourceName(), _context.getTransition());
+    // The underlying MBean is keyed by (cluster, transition) only and aggregates data
+    // points across all resources, so the sensor name must reflect that granularity.
+    // Including the resource name here would be misleading: it would surface whichever
+    // resource happened to trigger MBean creation first, while the counters/gauges
+    // actually reflect every resource going through this transition on this cluster.
+    return String.format("StateTransitionStat.%s.%s", _context.getClusterName(),
+        _context.getTransition());
   }
 
   public void addDataPoint(StateTransitionDataPoint data) {

--- a/helix-core/src/test/java/org/apache/helix/monitoring/TestParticipantMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/TestParticipantMonitor.java
@@ -41,6 +41,7 @@ import org.apache.helix.monitoring.mbeans.ClusterMBeanObserver;
 import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
 import org.apache.helix.monitoring.mbeans.ParticipantMessageMonitor;
 import org.apache.helix.monitoring.mbeans.ParticipantStatusMonitor;
+import org.apache.helix.monitoring.mbeans.StateTransitionStatMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -174,6 +175,31 @@ public class TestParticipantMonitor {
     monitorListener.disconnect();
 
     System.out.println("END TestParticipantStateTransitionMonitor");
+  }
+
+  @Test()
+  public void testStateTransitionStatMonitorSensorNameOmitsResource() throws Exception {
+    // The MBean aggregates data across all resources for a given (cluster, transition),
+    // so the sensor name must not include resource. Two contexts differing only by
+    // resource must produce identical sensor names that exclude both resource values.
+    String cluster = TestHelper.getTestClassName() + "_sensorName";
+    String transition = "OFFLINE-ONLINE";
+
+    StateTransitionContext cxt1 = new StateTransitionContext(cluster, "instance", "db_1", transition);
+    StateTransitionContext cxt2 = new StateTransitionContext(cluster, "instance", "db_2", transition);
+
+    StateTransitionStatMonitor m1 =
+        new StateTransitionStatMonitor(cxt1, new ObjectName("dom:k=v1"));
+    StateTransitionStatMonitor m2 =
+        new StateTransitionStatMonitor(cxt2, new ObjectName("dom:k=v2"));
+
+    String expected = String.format("StateTransitionStat.%s.%s", cluster, transition);
+    Assert.assertEquals(m1.getSensorName(), expected);
+    Assert.assertEquals(m2.getSensorName(), expected);
+    Assert.assertFalse(m1.getSensorName().contains("db_1"),
+        "sensor name must not include resource name");
+    Assert.assertFalse(m2.getSensorName().contains("db_2"),
+        "sensor name must not include resource name");
   }
 
   @Test()


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

This PR fixes a long-standing correctness/UX bug in `StateTransitionStatMonitor`'s sensor name. No upstream Apache Helix issue number is filed yet; will create one if requested by reviewers.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** `StateTransitionStatMonitor.getSensorName()` returned `StateTransitionStat.<cluster>.<resource>.<transition>`, but the underlying MBean is keyed only on `(cluster, transition)` and aggregates data points across **all** resources on the cluster going through that transition. The resource segment was whichever resource happened to trigger MBean creation first.

**Why:** Anything derived from the sensor name (RRD paths, InGraphs paths, OTel `Sensor.Name` dimensions) claimed per-resource granularity while the counters actually reflected every resource. Operators querying paths such as

```
Sensor_StateTransitionStat_<cluster>_<resourceA>_<transition>/TotalStateTransitionCounter
```

reasonably believed they were seeing transitions for `<resourceA>` only, while in reality they were seeing aggregated transitions for **all** resources. This led to incorrect conclusions in dashboards and operational reviews.

**How:** Drop the resource segment from `getSensorName()` so the name reflects the granularity the MBean actually enforces. No change to MBean cardinality, attribute names, counter/gauge values, or the JMX `ObjectName`.

```java
// before
return String.format("StateTransitionStat.%s.%s.%s",
    _context.getClusterName(), _context.getResourceName(), _context.getTransition());

// after
return String.format("StateTransitionStat.%s.%s",
    _context.getClusterName(), _context.getTransition());
```

**Why not change `StateTransitionContext` to be truly per-resource?** Making `equals`/`hashCode` include the resource (and creating one MBean per `(cluster, resource, transition)`) would match the misleading sensor name's claim, but explodes cardinality. A storage host with ~200 databases and ~7 transitions would emit ~29k JMX attributes per host for this metric alone, which is impractical for RRD-style backends. Per-resource granularity is a real need but belongs in OTel with `resource` as a dimensional attribute, not in MBean cardinality.

### Tests

- [x] The following tests are written for this issue:

- `TestParticipantMonitor.testStateTransitionStatMonitorSensorNameOmitsResource` (new) - asserts the sensor name has the new 3-part format, that two contexts differing only by resource produce identical sensor names, and that resource names do not appear in the sensor name string.
- Existing `TestParticipantMonitor.testReportStateTransitionData` continues to pass.

- The following is the result of the "mvn test" command on the appropriate module:

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.45 s - in org.apache.helix.monitoring.TestParticipantMonitor
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

### Changes that Break Backward Compatibility (Optional)

- [x] My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

The JMX `SensorName` attribute value, and anything derived from it (RRD paths, InGraphs paths, OTel `Sensor.Name` dimensions, custom JMX scrapers), changes:

```
old: StateTransitionStat.<cluster>.<resource>.<transition>
new: StateTransitionStat.<cluster>.<transition>
```

What is **not** affected:

- The JMX MBean `ObjectName` (`CLMParticipantReport:Cluster=X,Transition=Y`) - unchanged.
- Counter/gauge values, attribute names, MBean cardinality - unchanged.
- JMX consumers querying by `ObjectName` - unaffected.

Operators with dashboards, alerts, or scrapers that hardcode the old 4-part format will need to update their queries. Recommend calling this out in release notes for the next Helix release.

### Documentation (Optional)

No documentation changes required.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines.

### Code Quality

- [x] My diff has been formatted using helix-style.xml
