### PR TITLE
Batch ZKHelixAdmin.dropInstance to avoid jute.maxbuffer violations

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -36,6 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -128,6 +129,10 @@ public class ZKHelixAdmin implements HelixAdmin {
   public static final String CONNECTION_TIMEOUT = "helixAdmin.timeOutInSec";
   private static final String MAINTENANCE_ZNODE_ID = "maintenance";
   private static final int DEFAULT_SUPERCLUSTER_REPLICA = 3;
+  // Batch size for dropInstance subtree deletion. Sized so each multi() packet
+  // stays well under jute.maxbuffer (4 MB default): ~240 bytes/op * 1000 ops
+  // ~= 240 KB. See dropInstancePathsRecursively for context.
+  private static final int DROP_INSTANCE_DELETE_BATCH_SIZE = 1000;
   private static final ImmutableSet<InstanceConstants.InstanceOperation>
       INSTANCE_OPERATION_TO_EXCLUDE_FROM_ASSIGNMENT =
       ImmutableSet.of(InstanceConstants.InstanceOperation.EVACUATE,
@@ -266,15 +271,15 @@ public class ZKHelixAdmin implements HelixAdmin {
     String instanceName = instanceConfig.getInstanceName();
 
     String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
-    if (!_zkClient.exists(instanceConfigPath)) {
+    String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
+    boolean hasConfig = _zkClient.exists(instanceConfigPath);
+    boolean hasInstance = _zkClient.exists(instancePath);
+    // dropInstancePathsRecursively is no longer atomic (config is deleted before
+    // the subtree). A retry after a partial drop may find the config already
+    // gone but the subtree still present; treat that as a resume case.
+    if (!hasConfig && !hasInstance) {
       throw new HelixException(
           "Node " + instanceName + " does not exist in config for cluster " + clusterName);
-    }
-
-    String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
-    if (!_zkClient.exists(instancePath)) {
-      throw new HelixException(
-          "Node " + instanceName + " does not exist in instances for cluster " + clusterName);
     }
 
     String liveInstancePath = PropertyPathBuilder.liveInstance(clusterName, instanceName);
@@ -286,13 +291,37 @@ public class ZKHelixAdmin implements HelixAdmin {
     dropInstancePathsRecursively(clusterName, instanceName);
   }
 
+  // Two-phase drop to avoid jute.maxbuffer violations on instances that have
+  // accumulated large subtrees (e.g. tens of thousands of MESSAGES, CURRENTSTATES,
+  // TASKCURRENTSTATES). The previous single deleteRecursivelyAtomic([instance, config])
+  // built one multi() packet whose size grew O(#znodes); on instances with ~13K
+  // messages it crossed the 4 MB jute.maxbuffer limit, which ZK surfaces as
+  // CONNECTIONLOSS. The default 24h ZK retry timeout then pinned Jetty threads
+  // until the REST pool was exhausted.
+  //
+  // Phase 1: delete InstanceConfig first. This makes the instance non-Assignable,
+  //   so the controller stops generating new state-transition messages while the
+  //   subtree delete is in flight.
+  // Phase 2: delete the /INSTANCES/{instance} subtree in batched multi() calls
+  //   sized below jute.maxbuffer.
+  //
+  // Trade-off: this is no longer atomic. If the JVM dies between Phase 1 and
+  // the end of Phase 2, a stale /INSTANCES/{instance} subtree remains. The next
+  // dropInstance call (or a follow-up retry) is idempotent and finishes the
+  // cleanup. dropInstance's own existence check is relaxed below to allow the
+  // resume case where InstanceConfig is already gone.
   private void dropInstancePathsRecursively(String clusterName, String instanceName) {
     String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
     String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
     int retryCnt = 0;
     while (true) {
       try {
-        _zkClient.deleteRecursivelyAtomic(Arrays.asList(instancePath, instanceConfigPath));
+        // Phase 1
+        if (_zkClient.exists(instanceConfigPath)) {
+          _zkClient.delete(instanceConfigPath);
+        }
+        // Phase 2
+        deleteInstanceSubtreeBatched(instancePath);
         return;
       } catch (ZkClientException e) {
         if (retryCnt < 3 && e.getCause() instanceof ZkException && e.getCause()
@@ -311,6 +340,97 @@ public class ZKHelixAdmin implements HelixAdmin {
         }
       }
     }
+  }
+
+  // Delete the given path and all descendants using batched multi() calls. Each
+  // batch is sized so the on-wire packet stays comfortably below jute.maxbuffer.
+  // NoNode errors inside a batch are tolerated to keep retries idempotent.
+  private void deleteInstanceSubtreeBatched(String rootPath) {
+    if (!_zkClient.exists(rootPath)) {
+      return;
+    }
+    List<String> orderedPaths = collectSubtreeChildrenFirst(rootPath);
+    if (orderedPaths.isEmpty()) {
+      return;
+    }
+    for (int i = 0; i < orderedPaths.size(); i += DROP_INSTANCE_DELETE_BATCH_SIZE) {
+      int end = Math.min(i + DROP_INSTANCE_DELETE_BATCH_SIZE, orderedPaths.size());
+      List<Op> ops = new ArrayList<>(end - i);
+      for (int j = i; j < end; j++) {
+        ops.add(Op.delete(orderedPaths.get(j), -1));
+      }
+      List<OpResult> opResults;
+      try {
+        opResults = _zkClient.multi(ops);
+      } catch (Exception e) {
+        throw new ZkClientException(
+            "Failed batched delete for subtree " + rootPath + " (batch starting at index " + i
+                + ", size " + ops.size() + ")", e);
+      }
+      Map<String, KeeperException.Code> failedPathsMap = new HashMap<>();
+      Map<String, KeeperException.Code> notEmptyPathsMap = new HashMap<>();
+      for (int k = 0; k < opResults.size(); k++) {
+        if (opResults.get(k) instanceof OpResult.ErrorResult) {
+          KeeperException.Code code = KeeperException.Code
+              .get(((OpResult.ErrorResult) opResults.get(k)).getErr());
+          if (code == KeeperException.Code.OK || code == KeeperException.Code.NONODE) {
+            // NoNode is tolerated: a previous partial delete or concurrent
+            // delete may have already removed this znode.
+            continue;
+          }
+          if (code == KeeperException.Code.NOTEMPTY) {
+            // NotEmpty surfaces when a child znode (typically ParticipantHistory
+            // written by the controller) appears under a parent we are deleting.
+            // Bubble this up in the same exception shape the legacy
+            // deleteRecursivelyAtomic produced so the existing retry loop in
+            // dropInstancePathsRecursively re-walks and retries.
+            notEmptyPathsMap.put(ops.get(k).getPath(), code);
+          } else {
+            failedPathsMap.put(ops.get(k).getPath(), code);
+          }
+        }
+      }
+      if (!notEmptyPathsMap.isEmpty()) {
+        String firstNotEmptyPath = notEmptyPathsMap.keySet().iterator().next();
+        throw new ZkClientException(
+            "Batched delete for subtree " + rootPath + " hit NotEmpty on " + notEmptyPathsMap
+                .keySet(),
+            new ZkException(
+                "Batched delete for subtree " + rootPath + " hit NotEmpty on " + notEmptyPathsMap
+                    .keySet(),
+                new KeeperException.NotEmptyException(firstNotEmptyPath)));
+      }
+      if (!failedPathsMap.isEmpty()) {
+        throw new ZkClientException(
+            "Batched delete for subtree " + rootPath + " failed with errors: " + failedPathsMap);
+      }
+    }
+  }
+
+  // BFS-walk the subtree rooted at path and return all znode paths ordered so
+  // children come before their parents (safe for sequential delete). NoNode
+  // during traversal is tolerated; the missing branch is skipped.
+  private List<String> collectSubtreeChildrenFirst(String path) {
+    List<String> orderedPaths = new ArrayList<>();
+    Queue<String> queue = new LinkedList<>();
+    queue.offer(path);
+    while (!queue.isEmpty()) {
+      String node = queue.poll();
+      List<String> children;
+      try {
+        children = _zkClient.getChildren(node);
+      } catch (ZkNoNodeException e) {
+        continue;
+      }
+      if (children != null) {
+        for (String child : children) {
+          queue.offer(node + "/" + child);
+        }
+      }
+      orderedPaths.add(node);
+    }
+    Collections.reverse(orderedPaths);
+    return orderedPaths;
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -224,20 +224,21 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     }
 
     // Tests that ZkClientException thrown from ZkClient should be caught
-    // and it should be converted HelixException to be rethrown
+    // and it should be converted HelixException to be rethrown.
+    // dropInstance now does a two-phase batched delete (config first, then
+    // subtree via multi() batches). Simulate the racy NotEmpty case by having
+    // multi() return an OpResult.ErrorResult with NOTEMPTY for the parent znode.
     String instancePath = PropertyPathBuilder.instance(clusterName, config.getInstanceName());
     String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
     String liveInstancePath = PropertyPathBuilder.liveInstance(clusterName, instanceName);
     RealmAwareZkClient mockZkClient = Mockito.mock(RealmAwareZkClient.class);
-    // Mock the exists() method to let dropInstance() reach deleteRecursively().
     Mockito.when(mockZkClient.exists(instanceConfigPath)).thenReturn(true);
     Mockito.when(mockZkClient.exists(instancePath)).thenReturn(true);
     Mockito.when(mockZkClient.exists(liveInstancePath)).thenReturn(false);
-    Mockito.doThrow(new ZkClientException("ZkClientException: failed to delete " + instancePath,
-        new ZkException("ZkException: failed to delete " + instancePath,
-            new KeeperException.NotEmptyException(
-                "NotEmptyException: directory" + instancePath + " is not empty"))))
-        .when(mockZkClient).deleteRecursivelyAtomic(Arrays.asList(instancePath, instanceConfigPath));
+    Mockito.when(mockZkClient.getChildren(instancePath)).thenReturn(Collections.emptyList());
+    Mockito.when(mockZkClient.multi(Mockito.anyIterable())).thenReturn(Collections.singletonList(
+        (org.apache.zookeeper.OpResult) new org.apache.zookeeper.OpResult.ErrorResult(
+            KeeperException.Code.NOTEMPTY.intValue())));
 
     HelixAdmin helixAdminMock = new ZKHelixAdmin(mockZkClient);
     try {
@@ -1365,6 +1366,210 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     }
     Assert.assertTrue(admin.getInstancesInCluster(clusterName).isEmpty(), "Instances should be removed");
 
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  // Verifies dropInstance handles a subtree larger than DROP_INSTANCE_DELETE_BATCH_SIZE
+  // (1000 ops) by using batched multi() calls. Reproduces the production scenario
+  // where an instance accumulates large numbers of MESSAGES; the legacy single
+  // deleteRecursivelyAtomic() built one multi() packet that crossed jute.maxbuffer.
+  @Test
+  public void testDropInstanceWithLargeMessageSubtree() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    final String clusterName = "TestDropInstanceLargeSubtree";
+    final String instanceName = "host_with_many_messages";
+    final int numMessages = 2500; // > 2 batches of 1000
+
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+    admin.addCluster(clusterName, true);
+    admin.addInstance(clusterName, new InstanceConfig(instanceName));
+
+    // Pre-populate /INSTANCES/{instance}/MESSAGES with many znodes
+    String messagesPath = PropertyPathBuilder.instanceMessage(clusterName, instanceName);
+    for (int i = 0; i < numMessages; i++) {
+      _gZkClient.createPersistent(messagesPath + "/msg-" + i);
+    }
+    AssertJUnit.assertEquals(numMessages, _gZkClient.getChildren(messagesPath).size());
+
+    admin.dropInstance(clusterName, new InstanceConfig(instanceName));
+
+    String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
+    String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
+    AssertJUnit.assertFalse("instance subtree should be gone", _gZkClient.exists(instancePath));
+    AssertJUnit.assertFalse("instance config should be gone", _gZkClient.exists(instanceConfigPath));
+    AssertJUnit
+        .assertTrue("cluster instance list should be empty", admin.getInstancesInCluster(clusterName).isEmpty());
+
+    _gSetupTool.deleteCluster(clusterName);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  // Resume case: if a previous dropInstance partially completed (config deleted
+  // but subtree delete failed), a follow-up dropInstance should clean up the
+  // remaining subtree instead of erroring on "config does not exist".
+  @Test
+  public void testDropInstanceResumesAfterPartialDelete() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    final String clusterName = "TestDropInstanceResume";
+    final String instanceName = "host_partial";
+
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+    admin.addCluster(clusterName, true);
+    admin.addInstance(clusterName, new InstanceConfig(instanceName));
+    String messagesPath = PropertyPathBuilder.instanceMessage(clusterName, instanceName);
+    _gZkClient.createPersistent(messagesPath + "/leftover-msg");
+
+    // Simulate a prior partial drop: InstanceConfig already deleted, subtree remains.
+    String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
+    _gZkClient.delete(instanceConfigPath);
+    AssertJUnit.assertFalse(_gZkClient.exists(instanceConfigPath));
+    AssertJUnit.assertTrue(_gZkClient.exists(PropertyPathBuilder.instance(clusterName, instanceName)));
+
+    // Resume should succeed and clean up the leftover subtree.
+    admin.dropInstance(clusterName, new InstanceConfig(instanceName));
+
+    AssertJUnit.assertFalse(_gZkClient.exists(PropertyPathBuilder.instance(clusterName, instanceName)));
+    _gSetupTool.deleteCluster(clusterName);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  // Realistic instance shape: addInstance creates 7 standard subdirs (MESSAGES,
+  // CURRENTSTATES, TASKCURRENTSTATES, CUSTOMIZEDSTATES, ERRORS, STATUSUPDATES,
+  // HISTORY) plus ParticipantHistory. Populate nested children at depth>=2 under
+  // CURRENTSTATES (sessionId/resource) to verify children-first BFS ordering
+  // works for non-trivial trees.
+  @Test
+  public void testDropInstanceWithDeepSubtreeShape() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    final String clusterName = "TestDropInstanceDeepShape";
+    final String instanceName = "host_deep";
+
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+    admin.addCluster(clusterName, true);
+    admin.addInstance(clusterName, new InstanceConfig(instanceName));
+
+    // depth>=2 znodes under CURRENTSTATES: /CURRENTSTATES/{sessionId}/{resource}
+    String csPath = PropertyPathBuilder.instanceCurrentState(clusterName, instanceName);
+    String session = "session-1";
+    _gZkClient.createPersistent(csPath + "/" + session);
+    for (int i = 0; i < 50; i++) {
+      _gZkClient.createPersistent(csPath + "/" + session + "/resource-" + i);
+    }
+    // Mixed leaf znodes under MESSAGES and ERRORS
+    String msgPath = PropertyPathBuilder.instanceMessage(clusterName, instanceName);
+    for (int i = 0; i < 100; i++) {
+      _gZkClient.createPersistent(msgPath + "/msg-" + i);
+    }
+    String errPath = PropertyPathBuilder.instanceError(clusterName, instanceName);
+    _gZkClient.createPersistent(errPath + "/" + session);
+    _gZkClient.createPersistent(errPath + "/" + session + "/res-1");
+
+    admin.dropInstance(clusterName, new InstanceConfig(instanceName));
+
+    AssertJUnit.assertFalse(_gZkClient.exists(PropertyPathBuilder.instance(clusterName, instanceName)));
+    AssertJUnit.assertFalse(_gZkClient.exists(PropertyPathBuilder.instanceConfig(clusterName, instanceName)));
+    _gSetupTool.deleteCluster(clusterName);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  // Boundary: small subtree fits in a single multi() batch. Verifies the
+  // single-batch path (loop runs once) is exercised end-to-end.
+  @Test
+  public void testDropInstanceFitsInSingleBatch() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    final String clusterName = "TestDropInstanceSingleBatch";
+    final String instanceName = "host_small";
+
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+    admin.addCluster(clusterName, true);
+    admin.addInstance(clusterName, new InstanceConfig(instanceName));
+    String msgPath = PropertyPathBuilder.instanceMessage(clusterName, instanceName);
+    for (int i = 0; i < 10; i++) {
+      _gZkClient.createPersistent(msgPath + "/msg-" + i);
+    }
+
+    admin.dropInstance(clusterName, new InstanceConfig(instanceName));
+
+    AssertJUnit.assertFalse(_gZkClient.exists(PropertyPathBuilder.instance(clusterName, instanceName)));
+    _gSetupTool.deleteCluster(clusterName);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  // Non-NotEmpty errors from multi() must NOT trigger the 3-retry loop. The
+  // production incident was 1880 threads stuck retrying CONNECTIONLOSS for 24h;
+  // we want fail-fast for anything that isn't the racy NotEmpty case.
+  @Test
+  public void testDropInstanceFailsFastOnNonRetryableMultiError() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    final String clusterName = "TestDropInstanceFailFast";
+    final String instanceName = "host_failfast";
+    InstanceConfig config = new InstanceConfig(instanceName);
+
+    String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
+    String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
+    String liveInstancePath = PropertyPathBuilder.liveInstance(clusterName, instanceName);
+
+    RealmAwareZkClient mockZkClient = Mockito.mock(RealmAwareZkClient.class);
+    Mockito.when(mockZkClient.exists(instanceConfigPath)).thenReturn(true);
+    Mockito.when(mockZkClient.exists(instancePath)).thenReturn(true);
+    Mockito.when(mockZkClient.exists(liveInstancePath)).thenReturn(false);
+    Mockito.when(mockZkClient.getChildren(instancePath)).thenReturn(Collections.emptyList());
+    Mockito.when(mockZkClient.multi(Mockito.anyIterable())).thenReturn(Collections.singletonList(
+        (org.apache.zookeeper.OpResult) new org.apache.zookeeper.OpResult.ErrorResult(
+            KeeperException.Code.SYSTEMERROR.intValue())));
+
+    HelixAdmin helixAdminMock = new ZKHelixAdmin(mockZkClient);
+    long start = System.currentTimeMillis();
+    try {
+      helixAdminMock.dropInstance(clusterName, config);
+      Assert.fail("Should throw HelixException");
+    } catch (HelixException expected) {
+      // Should fail on the FIRST attempt - retryCnt=0
+      Assert.assertEquals(expected.getMessage(),
+          "Failed to drop instance: " + instanceName + ". Retry times: 0",
+          "Non-NotEmpty errors must not trigger the 3-retry loop");
+    }
+    long elapsed = System.currentTimeMillis() - start;
+    AssertJUnit.assertTrue("dropInstance should fail fast (took " + elapsed + " ms)", elapsed < 2000);
+
+    // multi() should have been invoked exactly once (no retries)
+    Mockito.verify(mockZkClient, Mockito.times(1)).multi(Mockito.anyIterable());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  // multi() throwing (e.g. unrecoverable connection loss after lower-level
+  // ZkClient retries are exhausted) is wrapped as ZkClientException. The wrapped
+  // exception's cause is NOT the NotEmpty-shaped chain, so the outer retry loop
+  // must NOT retry - it must fail fast as HelixException("Retry times: 0").
+  @Test
+  public void testDropInstanceFailsFastWhenMultiThrows() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    final String clusterName = "TestDropInstanceMultiThrows";
+    final String instanceName = "host_multithrow";
+    InstanceConfig config = new InstanceConfig(instanceName);
+
+    String instancePath = PropertyPathBuilder.instance(clusterName, instanceName);
+    String instanceConfigPath = PropertyPathBuilder.instanceConfig(clusterName, instanceName);
+    String liveInstancePath = PropertyPathBuilder.liveInstance(clusterName, instanceName);
+
+    RealmAwareZkClient mockZkClient = Mockito.mock(RealmAwareZkClient.class);
+    Mockito.when(mockZkClient.exists(instanceConfigPath)).thenReturn(true);
+    Mockito.when(mockZkClient.exists(instancePath)).thenReturn(true);
+    Mockito.when(mockZkClient.exists(liveInstancePath)).thenReturn(false);
+    Mockito.when(mockZkClient.getChildren(instancePath)).thenReturn(Collections.emptyList());
+    Mockito.when(mockZkClient.multi(Mockito.anyIterable()))
+        .thenThrow(new RuntimeException("simulated unrecoverable ZK error"));
+
+    HelixAdmin helixAdminMock = new ZKHelixAdmin(mockZkClient);
+    try {
+      helixAdminMock.dropInstance(clusterName, config);
+      Assert.fail("Should throw HelixException");
+    } catch (HelixException expected) {
+      Assert.assertEquals(expected.getMessage(),
+          "Failed to drop instance: " + instanceName + ". Retry times: 0",
+          "multi() throws should not be retried by the outer NotEmpty loop");
+    }
+    Mockito.verify(mockZkClient, Mockito.times(1)).multi(Mockito.anyIterable());
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 }


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Internal LinkedIn ticket: [CICP-2994](https://linkedin.atlassian.net/browse/CICP-2994) (HelixACM pipeline crashes from helix-rest call timeouts).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Replace the single atomic `deleteRecursivelyAtomic([instance, config])` call in `ZKHelixAdmin.dropInstance` with a two-phase batched approach.

**Why:** Instances that accumulated large MESSAGES queues (~13K) caused `deleteRecursivelyAtomic` to bundle every descendant znode into one ZooKeeper `multi()` packet ~3.75 MB in size. Crossing the 4 MB `jute.maxbuffer` limit, ZK rejected the packet as `CONNECTIONLOSS`. The default 24-hour `ZkClient` retry timeout pinned the Helix REST Jetty thread pool, taking down the embedded REST endpoint until the service was restarted (1,880 threads observed stuck across thread dumps from `lor1-0006434`).

**How:**
- **Phase 1**: delete `/CONFIGS/PARTICIPANT/{instance}` first (single op). Once gone the instance is non-Assignable, so the controller stops generating new state-transition messages while the subtree delete is in flight.
- **Phase 2**: BFS-walk the `/INSTANCES/{instance}` subtree children-first, then delete in `multi()` batches of `DROP_INSTANCE_DELETE_BATCH_SIZE = 1000` ops. Each on-wire packet is ~240 KB, well under `jute.maxbuffer`.
- `NoNode` results inside a batch are tolerated, keeping retries idempotent.
- `NotEmpty` results bubble up wrapped as `ZkClientException -> ZkException -> KeeperException.NotEmptyException`, the same shape the legacy code threw, so the existing 3-retry loop in `dropInstancePathsRecursively` continues to handle the racy `ParticipantHistory` write case.
- `dropInstance`'s pre-condition is relaxed: it now succeeds when *either* InstanceConfig or the subtree exists, so a retry after a partial drop can complete cleanup instead of erroring on \"does not exist in config\".

### Tests

- [x] The following tests are written for this issue:

In `helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java`:
- `testZkHelixAdmin` (existing, updated): mock-based 3-retry path migrated to `OpResult.ErrorResult` NOTEMPTY shape.
- `testDropInstance` (existing): regression baseline.
- `testDropInstanceWithLargeMessageSubtree`: 2,500 messages spanning multiple batches.
- `testDropInstanceResumesAfterPartialDelete`: config gone, subtree remains -> resume succeeds.
- `testDropInstanceWithDeepSubtreeShape`: depth>=2 paths under CURRENTSTATES + ERRORS, verifies BFS children-first ordering.
- `testDropInstanceFitsInSingleBatch`: small subtree, single-batch loop iteration.
- `testDropInstanceFailsFastOnNonRetryableMultiError`: non-NotEmpty OpResult error fails fast (multi() invoked exactly once, elapsed < 2s) - directly guards against re-creating the 1,880-stuck-thread incident.
- `testDropInstanceFailsFastWhenMultiThrows`: thrown exception fails fast (no spurious retries).

- The following is the result of the \"mvn test\" command on the appropriate module:

\`\`\`
mvn -pl helix-core test -Dtest=TestZkHelixAdmin
...
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
\`\`\`

### Changes that Break Backward Compatibility (Optional)

- `ZKHelixAdmin.dropInstance` is no longer atomic across `(InstanceConfig, /INSTANCES/{instance})`. A crash between Phase 1 and Phase 2 leaves a stale `/INSTANCES/{instance}` subtree; the next `dropInstance` call resumes cleanup. Callers that depended on \"either everything is deleted or nothing is\" will see partial state during the (typically sub-second) window of Phase 2.
- `dropInstance` no longer throws `\"... does not exist in instances for cluster ...\"` as a distinct error. The unified pre-condition error message is `\"... does not exist in config for cluster ...\"` whenever neither InstanceConfig nor the subtree is present.

### Documentation (Optional)

- N/A

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from \"[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)\".

### Code Quality

- [x] My diff has been formatted using helix-style.xml

### Local Review

- [x] Local code review completed