### PR TITLE
Fix task framework excluding EVACUATE-flagged live instances (CICP-34004)

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -715,6 +715,20 @@ public class BaseControllerDataProvider implements ControlContextProvider {
   }
 
   /**
+   * Return a set of all instances that have the EVACUATE InstanceOperation.
+   * Per InstanceOperation.EVACUATE semantics, replicas are moved off the node only after
+   * the (N+1) replacement replica has been bootstrapped, so existing replica states
+   * (e.g., MASTER) may still be hosted on these instances during the swap-out window.
+   *
+   * @return An unmodifiable set of instance names with EVACUATE operation
+   */
+  public Set<String> getEvacuatingInstances() {
+    return Collections.unmodifiableSet(
+        _derivedInstanceCache.getInstanceConfigMapByInstanceOperation(
+            InstanceConstants.InstanceOperation.EVACUATE).keySet());
+  }
+
+  /**
    * Return all the live nodes that are enabled. If a node is enabled, it is assignable.
    * @return An unmodifiable set contains live instance name and that are marked enabled
    */

--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/WorkflowControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/WorkflowControllerDataProvider.java
@@ -19,7 +19,9 @@ package org.apache.helix.controller.dataproviders;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,6 +29,7 @@ import java.util.Set;
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.common.caches.AbstractDataCache;
 import org.apache.helix.common.caches.TaskDataCache;
@@ -263,6 +266,49 @@ public class WorkflowControllerDataProvider extends BaseControllerDataProvider {
   public Map<String, CurrentState> getTaskCurrentState(String instanceName,
       String clientSessionId) {
     return _taskCurrentStateCache.getParticipantState(instanceName, clientSessionId);
+  }
+
+  /**
+   * Override to include EVACUATE-flagged live instances. The task framework co-locates tasks
+   * with existing replica states (e.g., MASTER) of the target resource. EVACUATE instances may
+   * still host such replicas until the (N+1) replacement replica completes bootstrap; excluding
+   * them here causes FixedTargetTaskAssignmentCalculator to leave those task partitions
+   * unassigned, which manifests as stuck/timed-out workflow jobs (e.g., backup, bulk operations)
+   * during long swap-out windows. See CICP-34004.
+   *
+   * Note: this override is intentionally scoped to the task pipeline. Replica-placement
+   * pipelines (WAGED, DelayedAuto) continue to use the base class behavior which excludes
+   * EVACUATE - correct for NEW replica assignment per InstanceOperation.EVACUATE semantics.
+   */
+  @Override
+  public Set<String> getEnabledLiveInstances() {
+    Set<String> result = new HashSet<>(super.getEnabledLiveInstances());
+    Set<String> liveInstances = getLiveInstances().keySet();
+    for (String instance : getEvacuatingInstances()) {
+      if (liveInstances.contains(instance)) {
+        result.add(instance);
+      }
+    }
+    return Collections.unmodifiableSet(result);
+  }
+
+  /**
+   * Override applies the same EVACUATE-inclusive policy as {@link #getEnabledLiveInstances()},
+   * then filters by instance tag. The base class implementation routes through
+   * getAssignableInstancesWithTag, which excludes EVACUATE instances (since isAssignable() is
+   * false for them); this override sources tags directly from InstanceConfig instead.
+   */
+  @Override
+  public Set<String> getEnabledLiveInstancesWithTag(String instanceTag) {
+    Set<String> result = new HashSet<>();
+    Map<String, InstanceConfig> configMap = getInstanceConfigMap();
+    for (String instance : getEnabledLiveInstances()) {
+      InstanceConfig config = configMap.get(instance);
+      if (config != null && config.containsTag(instanceTag)) {
+        result.add(instance);
+      }
+    }
+    return Collections.unmodifiableSet(result);
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java
+++ b/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java
@@ -647,8 +647,15 @@ public abstract class AbstractTaskDispatcher {
       int jobCfgLimitation =
           jobCfg.getNumConcurrentTasksPerInstance() - assignedPartitions.get(instance).size();
       // 2. throttled by participant capacity
-      int participantCapacity =
-          cache.getAssignableInstanceConfigMap().get(instance).getMaxConcurrentTask();
+      // Use the full instance config map rather than getAssignableInstanceConfigMap(): the latter
+      // is filtered by InstanceConfig.isAssignable() (only ENABLE/DISABLE) and would return null
+      // for EVACUATE-flagged instances that the task pipeline now schedules tasks onto, causing
+      // an NPE on the chained getMaxConcurrentTask() below. The configured task capacity of an
+      // instance is independent of its rebalancer-eligibility operation. See CICP-34004.
+      InstanceConfig instanceConfig = cache.getInstanceConfigMap().get(instance);
+      int participantCapacity = instanceConfig == null
+          ? InstanceConfig.MAX_CONCURRENT_TASK_NOT_SET
+          : instanceConfig.getMaxConcurrentTask();
       if (participantCapacity == InstanceConfig.MAX_CONCURRENT_TASK_NOT_SET) {
         participantCapacity = cache.getClusterConfig().getMaxConcurrentTaskPerInstance();
       }

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProviderEvacuate.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProviderEvacuate.java
@@ -88,6 +88,42 @@ public class TestWorkflowControllerDataProviderEvacuate {
     Assert.assertFalse(placementEligible.contains(disableLive));
   }
 
+  /**
+   * Regression guard for the throttle-path NPE fix at AbstractTaskDispatcher.java:651.
+   * The pre-fix code did `cache.getAssignableInstanceConfigMap().get(instance).getMaxConcurrentTask()`
+   * which NPE'd for EVACUATE-flagged live instances because they are filtered out of
+   * `_assignableInstanceConfigMap` by `InstanceConfig.isAssignable()`. The fix uses
+   * `cache.getInstanceConfigMap()` instead, which returns the full config including EVACUATE.
+   * This test asserts both maps' contents to lock in the contract relied upon by the fix.
+   */
+  @Test
+  public void testInstanceConfigMapIncludesEvacuateForThrottlePath() {
+    String enabledLive = "host_enabled_live";
+    String evacuateLive = "host_evacuate_live";
+
+    Map<String, InstanceConfig> configMap = new HashMap<>();
+    configMap.put(enabledLive,
+        instanceWithOperation(enabledLive, InstanceConstants.InstanceOperation.ENABLE));
+    configMap.put(evacuateLive,
+        instanceWithOperation(evacuateLive, InstanceConstants.InstanceOperation.EVACUATE));
+
+    List<LiveInstance> liveInstances =
+        Arrays.asList(new LiveInstance(enabledLive), new LiveInstance(evacuateLive));
+
+    WorkflowControllerDataProvider provider = newProvider(configMap, liveInstances);
+
+    // Full instance config map (used by the fixed throttle path) must include EVACUATE
+    Assert.assertNotNull(provider.getInstanceConfigMap().get(evacuateLive),
+        "InstanceConfigMap must include EVACUATE instance - throttle path depends on this");
+    Assert.assertNotNull(provider.getInstanceConfigMap().get(enabledLive));
+
+    // Assignable instance config map (used by the BUGGY pre-fix throttle path) does NOT include
+    // EVACUATE. Locking this in to document the contract that necessitated the fix.
+    Assert.assertNull(provider.getAssignableInstanceConfigMap().get(evacuateLive),
+        "AssignableInstanceConfigMap must NOT include EVACUATE - this is why the original throttle code path NPE'd");
+    Assert.assertNotNull(provider.getAssignableInstanceConfigMap().get(enabledLive));
+  }
+
   @Test
   public void testEnabledLiveInstancesWithTagIncludesEvacuate() {
     String tag = "BACKUP_TAG";

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProviderEvacuate.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProviderEvacuate.java
@@ -156,6 +156,44 @@ public class TestWorkflowControllerDataProviderEvacuate {
         "Tagged task assignment must include EVACUATE+live+tagged instances and exclude untagged");
   }
 
+  /**
+   * Coverage for EVACUATE -&gt; ENABLE transition during a live cache (CICP-34004 review nit).
+   * Phase 1: instance is EVACUATE, must be eligible via the override.
+   * Phase 2: same instance flipped to ENABLE on the same provider instance, must remain
+   * eligible - but now through the base-class path (super.getEnabledLiveInstances()),
+   * not the override's EVACUATE-additive branch. This guards against future changes that
+   * might inadvertently couple the override's behavior to the initial state.
+   */
+  @Test
+  public void testEvacuateFlipsBackToEnableExposesInstance() {
+    String host = "host_flipping";
+
+    Map<String, InstanceConfig> configMap = new HashMap<>();
+    configMap.put(host, instanceWithOperation(host, InstanceConstants.InstanceOperation.EVACUATE));
+    List<LiveInstance> liveInstances = Arrays.asList(new LiveInstance(host));
+
+    WorkflowControllerDataProvider provider = newProvider(configMap, liveInstances);
+
+    // Phase 1: EVACUATE+live - eligible via override (additive branch).
+    Assert.assertTrue(provider.getEnabledLiveInstances().contains(host),
+        "EVACUATE+live must be task-eligible (override path)");
+    Assert.assertFalse(provider.getEvacuatingInstances().isEmpty(),
+        "Sanity: instance must be in evacuating set before flip");
+
+    // Mutate in place: flip the same instance to ENABLE. setInstanceConfigMap rebuilds
+    // _derivedInstanceCache (BaseControllerDataProvider#updateInstanceSets), so the
+    // override's super.getEnabledLiveInstances() now returns the host directly.
+    Map<String, InstanceConfig> flippedMap = new HashMap<>();
+    flippedMap.put(host, instanceWithOperation(host, InstanceConstants.InstanceOperation.ENABLE));
+    provider.setInstanceConfigMap(flippedMap);
+
+    // Phase 2: ENABLE+live - eligible via super (not via the EVACUATE-additive branch).
+    Assert.assertTrue(provider.getEnabledLiveInstances().contains(host),
+        "ENABLE+live must remain task-eligible after EVACUATE->ENABLE flip (base path)");
+    Assert.assertTrue(provider.getEvacuatingInstances().isEmpty(),
+        "After flip, evacuating set must be empty - confirms eligibility is via super, not override");
+  }
+
   private static WorkflowControllerDataProvider newProvider(Map<String, InstanceConfig> configMap,
       List<LiveInstance> liveInstances) {
     WorkflowControllerDataProvider provider = new WorkflowControllerDataProvider(CLUSTER);

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProviderEvacuate.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProviderEvacuate.java
@@ -1,0 +1,138 @@
+package org.apache.helix.controller.dataproviders;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Regression coverage for CICP-34004. Verifies that the task pipeline data provider
+ * (WorkflowControllerDataProvider) treats EVACUATE-flagged live instances as eligible for
+ * task assignment, while the replica-placement pipeline data provider
+ * (ResourceControllerDataProvider) continues to exclude them.
+ */
+public class TestWorkflowControllerDataProviderEvacuate {
+
+  private static final String CLUSTER = "TestEvacuateCluster";
+
+  @Test
+  public void testEnabledLiveInstancesIncludesEvacuate() {
+    String enabledLive = "host_enabled_live";
+    String evacuateLive = "host_evacuate_live";
+    String evacuateOffline = "host_evacuate_offline";
+    String disableLive = "host_disable_live";
+
+    Map<String, InstanceConfig> configMap = new HashMap<>();
+    configMap.put(enabledLive,
+        instanceWithOperation(enabledLive, InstanceConstants.InstanceOperation.ENABLE));
+    configMap.put(evacuateLive,
+        instanceWithOperation(evacuateLive, InstanceConstants.InstanceOperation.EVACUATE));
+    configMap.put(evacuateOffline,
+        instanceWithOperation(evacuateOffline, InstanceConstants.InstanceOperation.EVACUATE));
+    configMap.put(disableLive,
+        instanceWithOperation(disableLive, InstanceConstants.InstanceOperation.DISABLE));
+
+    List<LiveInstance> liveInstances = Arrays.asList(new LiveInstance(enabledLive),
+        new LiveInstance(evacuateLive), new LiveInstance(disableLive));
+
+    WorkflowControllerDataProvider workflowProvider = newProvider(configMap, liveInstances);
+
+    Set<String> taskEligible = workflowProvider.getEnabledLiveInstances();
+    Assert.assertTrue(taskEligible.contains(enabledLive),
+        "ENABLE+live instance must be eligible for task assignment");
+    Assert.assertTrue(taskEligible.contains(evacuateLive),
+        "EVACUATE+live instance must be eligible for task assignment (CICP-34004 fix)");
+    Assert.assertFalse(taskEligible.contains(evacuateOffline),
+        "EVACUATE+offline instance must not be eligible (not live)");
+    Assert.assertFalse(taskEligible.contains(disableLive),
+        "DISABLE+live instance must not be eligible (replicas are OFFLINE)");
+
+    // Regression guard for the placement pipeline.
+    ResourceControllerDataProvider resourceProvider = new ResourceControllerDataProvider(CLUSTER);
+    resourceProvider.setClusterConfig(new ClusterConfig(CLUSTER));
+    resourceProvider.setInstanceConfigMap(configMap);
+    resourceProvider.setLiveInstances(liveInstances);
+
+    Set<String> placementEligible = resourceProvider.getEnabledLiveInstances();
+    Assert.assertTrue(placementEligible.contains(enabledLive));
+    Assert.assertFalse(placementEligible.contains(evacuateLive),
+        "ResourceControllerDataProvider must continue to exclude EVACUATE for replica placement");
+    Assert.assertFalse(placementEligible.contains(disableLive));
+  }
+
+  @Test
+  public void testEnabledLiveInstancesWithTagIncludesEvacuate() {
+    String tag = "BACKUP_TAG";
+    String enabledLiveTagged = "host_enabled_tagged";
+    String evacuateLiveTagged = "host_evacuate_tagged";
+    String evacuateLiveUntagged = "host_evacuate_untagged";
+
+    Map<String, InstanceConfig> configMap = new HashMap<>();
+    InstanceConfig enabledCfg =
+        instanceWithOperation(enabledLiveTagged, InstanceConstants.InstanceOperation.ENABLE);
+    enabledCfg.addTag(tag);
+    configMap.put(enabledLiveTagged, enabledCfg);
+
+    InstanceConfig evacuateTaggedCfg =
+        instanceWithOperation(evacuateLiveTagged, InstanceConstants.InstanceOperation.EVACUATE);
+    evacuateTaggedCfg.addTag(tag);
+    configMap.put(evacuateLiveTagged, evacuateTaggedCfg);
+
+    configMap.put(evacuateLiveUntagged,
+        instanceWithOperation(evacuateLiveUntagged, InstanceConstants.InstanceOperation.EVACUATE));
+
+    List<LiveInstance> liveInstances =
+        Arrays.asList(new LiveInstance(enabledLiveTagged), new LiveInstance(evacuateLiveTagged),
+            new LiveInstance(evacuateLiveUntagged));
+
+    WorkflowControllerDataProvider workflowProvider = newProvider(configMap, liveInstances);
+
+    Set<String> taggedEligible = workflowProvider.getEnabledLiveInstancesWithTag(tag);
+    Assert.assertEquals(taggedEligible, ImmutableSet.of(enabledLiveTagged, evacuateLiveTagged),
+        "Tagged task assignment must include EVACUATE+live+tagged instances and exclude untagged");
+  }
+
+  private static WorkflowControllerDataProvider newProvider(Map<String, InstanceConfig> configMap,
+      List<LiveInstance> liveInstances) {
+    WorkflowControllerDataProvider provider = new WorkflowControllerDataProvider(CLUSTER);
+    provider.setClusterConfig(new ClusterConfig(CLUSTER));
+    provider.setInstanceConfigMap(configMap);
+    provider.setLiveInstances(liveInstances);
+    return provider;
+  }
+
+  private static InstanceConfig instanceWithOperation(String instanceName,
+      InstanceConstants.InstanceOperation operation) {
+    InstanceConfig config = new InstanceConfig(instanceName);
+    config.setInstanceOperation(operation);
+    return config;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProviderEvacuate.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestWorkflowControllerDataProviderEvacuate.java
@@ -157,7 +157,6 @@ public class TestWorkflowControllerDataProviderEvacuate {
   }
 
   /**
-   * Coverage for EVACUATE -&gt; ENABLE transition during a live cache (CICP-34004 review nit).
    * Phase 1: instance is EVACUATE, must be eligible via the override.
    * Phase 2: same instance flipped to ENABLE on the same provider instance, must remain
    * eligible - but now through the base-class path (super.getEnabledLiveInstances()),

--- a/helix-core/src/test/java/org/apache/helix/task/TestEvacuateInstanceTaskAssignment.java
+++ b/helix-core/src/test/java/org/apache/helix/task/TestEvacuateInstanceTaskAssignment.java
@@ -1,0 +1,296 @@
+package org.apache.helix.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.common.caches.TaskDataCache;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
+import org.apache.helix.controller.stages.BestPossibleStateOutput;
+import org.apache.helix.controller.stages.CurrentStateOutput;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.Partition;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end mocked test for CICP-34004. Reproduces the production scenario where the MASTER
+ * replica of a target resource still resides on an EVACUATE-flagged live instance during a
+ * swap-out window, and verifies that:
+ *
+ * 1. The task framework assigns the task to that EVACUATE+MASTER instance (the data-provider
+ *    fix in WorkflowControllerDataProvider exposes EVACUATE+live to the assignment calculator).
+ * 2. The throttle path in AbstractTaskDispatcher does NOT throw NPE when the candidate instance
+ *    is EVACUATE-flagged (the fix at AbstractTaskDispatcher.java:651 sources the per-instance
+ *    capacity from the full instance config map rather than the assignable-only map).
+ *
+ * The test mocks WorkflowControllerDataProvider exactly as the production controller flow uses
+ * it. It deliberately mocks `getAssignableInstanceConfigMap()` to EXCLUDE the EVACUATE instance
+ * (matching production behavior - that map is filtered by InstanceConfig.isAssignable()) and
+ * mocks `getInstanceConfigMap()` to include all instances. If the fix at line 651 regresses,
+ * `getAssignableInstanceConfigMap().get(evacuateInstance)` would return null and NPE.
+ */
+public class TestEvacuateInstanceTaskAssignment {
+  private static final String CLUSTER_NAME = "TestEvacuateCluster";
+  private static final String INSTANCE_PREFIX = "Instance_";
+  private static final int NUM_PARTICIPANTS = 3;
+  private static final String WORKFLOW_NAME = "TestEvacuateWorkflow";
+  private static final String JOB_NAME = "TestEvacuateJob";
+  private static final String PARTITION_NAME = "0";
+  private static final String TARGET_RESOURCES = "TestDB";
+
+  private static final String SLAVE_INSTANCE = INSTANCE_PREFIX + "0";
+  /** This instance hosts the MASTER replica AND is flagged InstanceOperation.EVACUATE. */
+  private static final String MASTER_EVACUATE_INSTANCE = INSTANCE_PREFIX + "1";
+  private static final String SLAVE_INSTANCE_2 = INSTANCE_PREFIX + "2";
+
+  private Map<String, LiveInstance> _liveInstances;
+  private Map<String, InstanceConfig> _allInstanceConfigs;
+  private Map<String, InstanceConfig> _assignableInstanceConfigs;
+  private ClusterConfig _clusterConfig;
+  private AssignableInstanceManager _assignableInstanceManager;
+
+  @BeforeClass
+  public void beforeClass() {
+    _liveInstances = new HashMap<>();
+    _allInstanceConfigs = new HashMap<>();
+    _assignableInstanceConfigs = new HashMap<>();
+    _clusterConfig = new ClusterConfig(CLUSTER_NAME);
+
+    for (int i = 0; i < NUM_PARTICIPANTS; i++) {
+      String instanceName = INSTANCE_PREFIX + i;
+      _liveInstances.put(instanceName, new LiveInstance(instanceName));
+
+      InstanceConfig config = new InstanceConfig(instanceName);
+      if (instanceName.equals(MASTER_EVACUATE_INSTANCE)) {
+        // Mark MASTER instance as EVACUATE - the production scenario from CICP-34004.
+        config.setInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE);
+      } else {
+        config.setInstanceOperation(InstanceConstants.InstanceOperation.ENABLE);
+      }
+      _allInstanceConfigs.put(instanceName, config);
+
+      // Match production semantics of getAssignableInstanceConfigMap(): only ENABLE/DISABLE
+      // (per InstanceConstants.ASSIGNABLE_INSTANCE_OPERATIONS) make it into this map.
+      if (config.isAssignable()) {
+        _assignableInstanceConfigs.put(instanceName, config);
+      }
+    }
+
+    // Sanity: EVACUATE instance is in the full map but NOT in the assignable map - this is the
+    // discrepancy that caused the NPE before the fix at AbstractTaskDispatcher.java:651.
+    Assert.assertTrue(_allInstanceConfigs.containsKey(MASTER_EVACUATE_INSTANCE));
+    Assert.assertFalse(_assignableInstanceConfigs.containsKey(MASTER_EVACUATE_INSTANCE));
+
+    _assignableInstanceManager = new AssignableInstanceManager();
+  }
+
+  @Test
+  public void testTaskAssignedToEvacuatingInstanceHostingMaster() {
+    MockTestInformation mock = new MockTestInformation();
+    when(mock._cache.getWorkflowConfig(WORKFLOW_NAME)).thenReturn(mock._workflowConfig);
+    when(mock._cache.getJobConfig(JOB_NAME)).thenReturn(mock._jobConfig);
+    when(mock._cache.getTaskDataCache()).thenReturn(mock._taskDataCache);
+    when(mock._cache.getJobContext(JOB_NAME)).thenReturn(mock._jobContext);
+    when(mock._cache.getIdealStates()).thenReturn(mock._idealStates);
+    // Reflects the fixed WorkflowControllerDataProvider.getEnabledLiveInstances() behavior:
+    // the EVACUATE+live instance IS included in the eligible set for task assignment.
+    when(mock._cache.getEnabledLiveInstances()).thenReturn(_liveInstances.keySet());
+    // Full instance config map - what the FIXED throttle path at AbstractTaskDispatcher.java:651
+    // queries. Includes EVACUATE.
+    when(mock._cache.getInstanceConfigMap()).thenReturn(_allInstanceConfigs);
+    // Assignable-only instance config map - what the BUGGY pre-fix throttle path queried. Does
+    // NOT include EVACUATE. Mocking this to match production semantics so that any future
+    // regression that reintroduces a call to this map for an EVACUATE instance will NPE here.
+    when(mock._cache.getAssignableInstanceConfigMap()).thenReturn(_assignableInstanceConfigs);
+    when(mock._cache.getClusterConfig()).thenReturn(_clusterConfig);
+    when(mock._taskDataCache.getRuntimeJobDag(WORKFLOW_NAME)).thenReturn(mock._runtimeJobDag);
+    _assignableInstanceManager.buildAssignableInstances(_clusterConfig, mock._taskDataCache,
+        _liveInstances, _allInstanceConfigs);
+    when(mock._cache.getAssignableInstanceManager()).thenReturn(_assignableInstanceManager);
+    when(mock._cache.getExistsLiveInstanceOrCurrentStateOrMessageChange()).thenReturn(false);
+    Set<String> inflightJobDag = new HashSet<>();
+    inflightJobDag.add(JOB_NAME);
+    when(mock._taskDataCache.getRuntimeJobDag(WORKFLOW_NAME).getInflightJobList())
+        .thenReturn(inflightJobDag);
+
+    // Sanity: AssignableInstanceManager built from raw liveInstances must include the EVACUATE
+    // instance (no operation filter at this layer).
+    Assert.assertTrue(_assignableInstanceManager.getAssignableInstanceNames()
+            .contains(MASTER_EVACUATE_INSTANCE),
+        "AssignableInstanceManager must include EVACUATE+live instance");
+
+    BestPossibleStateOutput bestPossibleStateOutput = new BestPossibleStateOutput();
+    WorkflowDispatcher workflowDispatcher = new WorkflowDispatcher();
+    workflowDispatcher.updateCache(mock._cache);
+
+    // The actual call under test. If line 651 still used getAssignableInstanceConfigMap, this
+    // would NPE before producing any output.
+    workflowDispatcher.updateWorkflowStatus(WORKFLOW_NAME, mock._workflowConfig,
+        mock._workflowContext, mock._currentStateOutput, bestPossibleStateOutput);
+
+    Partition taskPartition = new Partition(JOB_NAME + "_" + PARTITION_NAME);
+    Map<String, String> partitionMap =
+        bestPossibleStateOutput.getPartitionStateMap(JOB_NAME).getPartitionMap(taskPartition);
+    Assert.assertNotNull(partitionMap, "Task partition must have an assignment in BestPossibleStateOutput");
+    String stateOnMaster = partitionMap.get(MASTER_EVACUATE_INSTANCE);
+    Assert.assertEquals(stateOnMaster, TaskPartitionState.RUNNING.name(),
+        "Task must be assigned to the EVACUATE+MASTER instance, since that's where the target "
+            + "MASTER replica resides. Pre-fix this would have been left unassigned (CICP-34004).");
+  }
+
+  private WorkflowConfig prepareWorkflowConfig() {
+    WorkflowConfig.Builder workflowConfigBuilder = new WorkflowConfig.Builder();
+    workflowConfigBuilder.setWorkflowId(WORKFLOW_NAME);
+    workflowConfigBuilder.setTerminable(false);
+    workflowConfigBuilder.setTargetState(TargetState.START);
+    workflowConfigBuilder.setJobQueue(true);
+    JobDag jobDag = new JobDag();
+    jobDag.addNode(JOB_NAME);
+    workflowConfigBuilder.setJobDag(jobDag);
+    return workflowConfigBuilder.build();
+  }
+
+  private JobConfig prepareJobConfig() {
+    JobConfig.Builder jobConfigBuilder = new JobConfig.Builder();
+    jobConfigBuilder.setWorkflow(WORKFLOW_NAME);
+    jobConfigBuilder.setCommand("TestCommand");
+    jobConfigBuilder.setTargetResource(TARGET_RESOURCES);
+    jobConfigBuilder.setJobId(JOB_NAME);
+    List<String> targetPartition = new ArrayList<>();
+    targetPartition.add(TARGET_RESOURCES + "_0");
+    jobConfigBuilder.setTargetPartitions(targetPartition);
+    Set<String> targetPartitionStates = new HashSet<>();
+    targetPartitionStates.add("MASTER");
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    TaskConfig.Builder taskConfigBuilder = new TaskConfig.Builder();
+    taskConfigBuilder.setTaskId("0");
+    taskConfigs.add(taskConfigBuilder.build());
+    jobConfigBuilder.setTargetPartitionStates(targetPartitionStates);
+    jobConfigBuilder.addTaskConfigs(taskConfigs);
+    return jobConfigBuilder.build();
+  }
+
+  private WorkflowContext prepareWorkflowContext() {
+    ZNRecord record = new ZNRecord(WORKFLOW_NAME);
+    record.setSimpleField(WorkflowContext.WorkflowContextProperties.StartTime.name(), "0");
+    record.setSimpleField(WorkflowContext.WorkflowContextProperties.NAME.name(), WORKFLOW_NAME);
+    record.setSimpleField(WorkflowContext.WorkflowContextProperties.STATE.name(),
+        TaskState.IN_PROGRESS.name());
+    Map<String, String> jobState = new HashMap<>();
+    jobState.put(JOB_NAME, TaskState.IN_PROGRESS.name());
+    record.setMapField(WorkflowContext.WorkflowContextProperties.JOB_STATES.name(), jobState);
+    return new WorkflowContext(record);
+  }
+
+  /**
+   * Job context: target partition is mapped to TARGET_RESOURCES_0 (which has MASTER on
+   * MASTER_EVACUATE_INSTANCE per IdealState below). No assignment yet.
+   */
+  private JobContext prepareJobContext() {
+    ZNRecord record = new ZNRecord(JOB_NAME);
+    JobContext jobContext = new JobContext(record);
+    jobContext.setStartTime(0L);
+    jobContext.setName(JOB_NAME);
+    jobContext.setPartitionTarget(0, TARGET_RESOURCES + "_0");
+    return jobContext;
+  }
+
+  private Map<String, IdealState> prepareIdealStates() {
+    ZNRecord record = new ZNRecord(JOB_NAME);
+    record.setSimpleField(IdealState.IdealStateProperty.NUM_PARTITIONS.name(), "1");
+    record.setSimpleField(IdealState.IdealStateProperty.EXTERNAL_VIEW_DISABLED.name(), "true");
+    record.setSimpleField(IdealState.IdealStateProperty.IDEAL_STATE_MODE.name(), "AUTO");
+    record.setSimpleField(IdealState.IdealStateProperty.REBALANCE_MODE.name(), "TASK");
+    record.setSimpleField(IdealState.IdealStateProperty.REPLICAS.name(), "1");
+    record.setSimpleField(IdealState.IdealStateProperty.STATE_MODEL_DEF_REF.name(), "Task");
+    record.setSimpleField(IdealState.IdealStateProperty.STATE_MODEL_FACTORY_NAME.name(), "DEFAULT");
+    record.setSimpleField(IdealState.IdealStateProperty.REBALANCER_CLASS_NAME.name(),
+        "org.apache.helix.task.JobRebalancer");
+    record.setMapField(JOB_NAME + "_" + PARTITION_NAME, new HashMap<>());
+    record.setListField(JOB_NAME + "_" + PARTITION_NAME, new ArrayList<>());
+    Map<String, IdealState> idealStates = new HashMap<>();
+    idealStates.put(JOB_NAME, new IdealState(record));
+
+    ZNRecord recordDB = new ZNRecord(TARGET_RESOURCES);
+    recordDB.setSimpleField(IdealState.IdealStateProperty.REPLICAS.name(), "3");
+    recordDB.setSimpleField(IdealState.IdealStateProperty.REBALANCE_MODE.name(), "FULL_AUTO");
+    recordDB.setSimpleField(IdealState.IdealStateProperty.STATE_MODEL_DEF_REF.name(), "MasterSlave");
+    Map<String, String> mapping = new HashMap<>();
+    mapping.put(MASTER_EVACUATE_INSTANCE, "MASTER");
+    mapping.put(SLAVE_INSTANCE, "SLAVE");
+    mapping.put(SLAVE_INSTANCE_2, "SLAVE");
+    recordDB.setMapField(TARGET_RESOURCES + "_0", mapping);
+    List<String> listField = new ArrayList<>();
+    listField.add(MASTER_EVACUATE_INSTANCE);
+    listField.add(SLAVE_INSTANCE);
+    listField.add(SLAVE_INSTANCE_2);
+    recordDB.setListField(TARGET_RESOURCES + "_0", listField);
+    idealStates.put(TARGET_RESOURCES, new IdealState(recordDB));
+
+    return idealStates;
+  }
+
+  private CurrentStateOutput prepareCurrentState() {
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    currentStateOutput.setResourceStateModelDef(JOB_NAME, "TASK");
+    currentStateOutput.setBucketSize(JOB_NAME, 0);
+    currentStateOutput.setResourceStateModelDef(TARGET_RESOURCES, "MasterSlave");
+    currentStateOutput.setBucketSize(TARGET_RESOURCES, 0);
+    Partition dbPartition = new Partition(TARGET_RESOURCES + "_0");
+    // MASTER replica still resides on the EVACUATE-flagged instance. This is the precise
+    // production state described in CICP-34004.
+    currentStateOutput.setEndTime(TARGET_RESOURCES, dbPartition, MASTER_EVACUATE_INSTANCE, 0L);
+    currentStateOutput.setCurrentState(TARGET_RESOURCES, dbPartition, MASTER_EVACUATE_INSTANCE,
+        "MASTER");
+    currentStateOutput.setInfo(TARGET_RESOURCES, dbPartition, MASTER_EVACUATE_INSTANCE, "");
+    currentStateOutput.setEndTime(TARGET_RESOURCES, dbPartition, SLAVE_INSTANCE, 0L);
+    currentStateOutput.setCurrentState(TARGET_RESOURCES, dbPartition, SLAVE_INSTANCE, "SLAVE");
+    currentStateOutput.setInfo(TARGET_RESOURCES, dbPartition, SLAVE_INSTANCE, "");
+    currentStateOutput.setEndTime(TARGET_RESOURCES, dbPartition, SLAVE_INSTANCE_2, 0L);
+    currentStateOutput.setCurrentState(TARGET_RESOURCES, dbPartition, SLAVE_INSTANCE_2, "SLAVE");
+    currentStateOutput.setInfo(TARGET_RESOURCES, dbPartition, SLAVE_INSTANCE_2, "");
+    return currentStateOutput;
+  }
+
+  private class MockTestInformation {
+    private WorkflowControllerDataProvider _cache = mock(WorkflowControllerDataProvider.class);
+    private TaskDataCache _taskDataCache = mock(TaskDataCache.class);
+    private RuntimeJobDag _runtimeJobDag = mock(RuntimeJobDag.class);
+    private WorkflowConfig _workflowConfig = prepareWorkflowConfig();
+    private WorkflowContext _workflowContext = prepareWorkflowContext();
+    private Map<String, IdealState> _idealStates = prepareIdealStates();
+    private JobConfig _jobConfig = prepareJobConfig();
+    private JobContext _jobContext = prepareJobContext();
+    private CurrentStateOutput _currentStateOutput = prepareCurrentState();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes [CICP-34004](https://linkedin.atlassian.net/browse/CICP-34004). The Helix task framework was excluding `EVACUATE`-flagged live instances from task assignment, even when those instances still legitimately host the target replica (`MASTER`). This caused Espresso `BackupQueue` and `BulkOperationsQueue` workflow jobs on `prod-lva1 ESPRESSO_MT-LD-7 / MT-LD-9` to leave partitions unassigned during long swap-out windows, producing job timeouts and ~4-day stale backups.

The fix has **two parts**:

1. **Data-provider override (primary fix).** `WorkflowControllerDataProvider.getEnabledLiveInstances()` and `getEnabledLiveInstancesWithTag()` now additively include EVACUATE+live instances. `ResourceControllerDataProvider` (replica placement) is unchanged.
2. **Throttle-path NPE fix (latent bug uncovered by the primary fix).** `AbstractTaskDispatcher.java:651` previously did `cache.getAssignableInstanceConfigMap().get(instance).getMaxConcurrentTask()`. `getAssignableInstanceConfigMap()` is filtered by `InstanceConfig.isAssignable()` (only ENABLE/DISABLE per `ASSIGNABLE_INSTANCE_OPERATIONS`), so `.get(EVACUATE_instance)` returned null → NPE on chained call. Switched to `cache.getInstanceConfigMap()` (full map) with a null-guard fallback. The per-instance task capacity is independent of rebalancer-eligibility, so this is semantically correct for ENABLE instances and works for EVACUATE.

Root cause of part 1: regression from apache/helix#2772 (Apr 2024) which silently changed `BaseControllerDataProvider.getEnabledInstances()` from `(All − HELIX_DISABLED)` to `(only InstanceOperation.ENABLE)`. `EVACUATE` has been in active production use for ~1+ year (Espresso ACM operations since NSS migration), so the bug has been latent for that entire time. It only surfaced now because mass-swap campaigns on high-partition multi-tenant Espresso clusters recently produced `EVACUATE` windows long enough to exceed the 18h job timeout.

## Testing Done

**Unit tests** (`TestWorkflowControllerDataProviderEvacuate`, 3 cases):
- `testEnabledLiveInstancesIncludesEvacuate` - verifies task pipeline includes EVACUATE+live and excludes EVACUATE+offline / DISABLE+live; regression-guards that `ResourceControllerDataProvider` continues to exclude EVACUATE.
- `testEnabledLiveInstancesWithTagIncludesEvacuate` - tag-filtered variant honors the same policy.
- `testInstanceConfigMapIncludesEvacuateForThrottlePath` - locks in the data-provider contract that the throttle-path fix relies on (full map includes EVACUATE; assignable-only map does not).

**Integration test** (`TestEvacuateInstanceTaskAssignment`, 1 case):
- Reproduces CICP-34004 end-to-end via mocked `WorkflowControllerDataProvider`. MASTER replica on EVACUATE+live host. Drives `WorkflowDispatcher.updateWorkflowStatus`. Asserts: task is assigned to the EVACUATE+MASTER instance with state `RUNNING`. Without either part of the fix, this test would either leave the task unassigned (data-provider bug) or NPE (throttle-path bug).

**Regression suites:**
```
mvn -pl helix-core test -Dtest=TestEvacuateWithExclusions,TestInstanceOperationEvacuation
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

```
mvn -pl helix-core test -Dtest=TestWorkflowControllerDataProviderEvacuate,TestEvacuateInstanceTaskAssignment,TestResourceControllerDataProvider
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

**Code-path audit (every consumer of "live instances" in the task path):**

| Consumer | File:Line | Verdict |
|---|---|---|
| Primary entry | `JobDispatcher.java:144-145, 243` (`cache.getEnabledLiveInstances()`) | Fixed via override |
| Build assignable instances | `TaskSchedulingStage.java:74-76`, `AssignableInstanceManager.java:80-99,196-216,365-394` | Pass raw `cache.getLiveInstances()`, no operation filter |
| Current state output | `CurrentStateComputationStage.java:93` | Iterates ALL liveInstances; only UNKNOWN goes to filtered secondary output |
| Excluded set | `AbstractTaskDispatcher.java:1055-1087` (`getExcludedInstances`) | Only excludes overlap-job participants. No InstanceOperation filter |
| FixedTarget calc | `FixedTargetTaskAssignmentCalculator.java:202-333` | Iterates passed liveInstances. Inner `getAssignableInstanceNames()` check uses unfiltered `_assignableInstanceMap` |
| Throttle (jobCfg limit) | `AbstractTaskDispatcher.java:647-648` | No InstanceOperation filter |
| **Throttle (capacity)** | `AbstractTaskDispatcher.java:651` | **Fixed in this PR** — was NPE for EVACUATE |
| Quota release | `AbstractTaskDispatcher.java:631-633, 701-704` | Guarded by `getAssignableInstanceMap()` (broader, includes EVACUATE) |
| Generic-task path | `ThreadCountBasedTaskAssignmentCalculator.java:101` | Same flow, also fixed |
| Message generation | `MessageGenerationPhase`, `TaskMessageDispatchStage` | No InstanceOperation references |
| Participant-side | `HelixTaskExecutor`, `TaskStateModel`, `TaskRunner` | No InstanceOperation references; participant accepts based on state-model semantics only |

---

### Issues

- [x] Internal: [CICP-34004](https://linkedin.atlassian.net/browse/CICP-34004) - *Helix task framework not assigning job partitions to instances with EVACUATE operation*
- [x] Regression source: apache/helix#2772 (merged Apr 2024)

### Description

**Why this is a bug, not the documented `EVACUATE` semantic.** `InstanceOperation.EVACUATE` Javadoc states *will not be considered for NEW assignment*, where "new" refers to **new replica placement**. Tasks are not new replicas - they co-locate with **existing** replica states. The `MASTER` legitimately remains on an `EVACUATE` instance until the (N+1) replica is fully bootstrapped, so tasks targeting `MASTER` must be schedulable to that instance.

**Files changed:**
1. `helix-core/.../BaseControllerDataProvider.java` (+14): public `getEvacuatingInstances()` accessor.
2. `helix-core/.../WorkflowControllerDataProvider.java` (+46): override two `getEnabledLiveInstances*` methods to include EVACUATE+live.
3. `helix-core/.../AbstractTaskDispatcher.java` (+11/-2): throttle-path NPE fix.
4. `helix-core/.../TestWorkflowControllerDataProviderEvacuate.java` (new, 3 cases).
5. `helix-core/.../TestEvacuateInstanceTaskAssignment.java` (new, 1 end-to-end mocked case).

### Changes that Break Backward Compatibility

None. Behavior change is scoped to `WorkflowControllerDataProvider` (task pipeline) and a defensive null-guard at one throttle line. No public API removed; one new public method added (`getEvacuatingInstances()` on `BaseControllerDataProvider`).

### Documentation

N/A - bug fix; no new functionality.

### Code Quality

- [x] Diff follows existing style of touched files.