### PR TITLE
Fix MaintenanceRebalancer over-cap dispatch by clearing stale listFields

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -21,11 +21,9 @@ package org.apache.helix.controller.rebalancer;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.stages.CurrentStateOutput;
@@ -38,89 +36,94 @@ import org.slf4j.LoggerFactory;
 public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceControllerDataProvider> {
   private static final Logger LOG = LoggerFactory.getLogger(MaintenanceRebalancer.class);
 
+  /**
+   * Under maintenance mode, the cluster is meant to be frozen: no new replicas should be
+   * bootstrapped. For every partition of the resource, the rebalancer sets the
+   * preferenceList to the participant-reported CurrentState hosts (or empty if no
+   * participant reports state for that partition).
+   *
+   * <p>For partitions with CurrentState reports, the preferenceList is rebuilt from the
+   * reported hosts, ordered to keep top-state hosts first (so role assignments are
+   * preserved). For partitions without CurrentState, the preferenceList is set to empty,
+   * which causes the inherited mapping calculator to produce no BestPossibleState and
+   * therefore no OFFLINE -> ASSIGNED message dispatch.
+   *
+   * <p>This is the single-rule version of what was previously a two-branch implementation
+   * (Branch A: clear all when the entire resource has no CurrentState; Branch B: rebuild
+   * preferenceLists only for partitions with CurrentState). The previous Branch B silently
+   * preserved listFields entries for partitions whose participants had not reported yet,
+   * which let WAGED-written speculative placements (target hosts for in-flight swaps that
+   * had not converged) be dispatched without the per-pipeline capacity check that lives
+   * in DelayedAutoRebalancer. The unified rule eliminates that asymmetry.
+   */
   @Override
   public IdealState computeNewIdealState(String resourceName, IdealState currentIdealState,
       CurrentStateOutput currentStateOutput, ResourceControllerDataProvider clusterData) {
-    LOG.info(String
-        .format("Start computing ideal state for resource %s in maintenance mode.", resourceName));
-    Map<Partition, Map<String, String>> currentStateMap =
-        currentStateOutput.getCurrentStateMap(resourceName);
-    if (currentStateMap == null || currentStateMap.size() == 0) {
-      LOG.warn(String
-          .format("No new partition will be assigned for %s in maintenance mode", resourceName));
+    LOG.info("Start computing ideal state for resource {} in maintenance mode.", resourceName);
 
-      // Clear all preference lists, if the resource has not yet been rebalanced,
-      // leave it as is
-      for (List<String> pList : currentIdealState.getPreferenceLists().values()) {
-        pList.clear();
-      }
+    // Defensive NPE guard: a null CurrentStateOutput leaves the IS unchanged.
+    if (currentStateOutput == null) {
+      LOG.warn("CurrentStateOutput is null for resource {} in maintenance mode; "
+          + "leaving IdealState unchanged.", resourceName);
       return currentIdealState;
     }
 
-    // One principal is to prohibit DROP -> OFFLINE and OFFLINE -> DROP state transitions.
-    // Derived preference list from current state with state priority
-    StateModelDefinition stateModelDef = clusterData.getStateModelDef(currentIdealState.getStateModelDefRef());
-
-    for (Partition partition : currentStateMap.keySet()) {
-      Map<String, String> stateMap = currentStateMap.get(partition);
-      List<String> preferenceList = new ArrayList<>(stateMap.keySet());
-
-      /**
-       * This sorting preserves the ordering of current state hosts in the order of current IS pref list
-       * Example:
-       * ideal state pref-list: [A, B, C]
-       * current-state: {
-       *     A: FOLLOWER,
-       *     B: LEADER,
-       *     C: FOLLOWER
-       * }
-       * Lets say newPrefList = new ArrayList<>(current-state.keySet()) => [C, B, A]
-       *
-       * Sort 1: Sort based on preference-list order:
-       * --------------------------------------------------------
-       * newPrefList = [C, B, A] => [A, B, C]
-       */
-      Collections.sort(preferenceList, new PreferenceListNodeComparator(stateMap, stateModelDef,
-          currentIdealState.getPreferenceList(partition.getPartitionName()), clusterData));
-
-      /**
-       * Sort 2: Sort based on state-priority order:
-       * --------------------------------------------------------
-       * newPrefList = [A, B, C] => [B, A, C]
-       * Here, A will be 2nd and C will be third always as both have same priority so original (pref-list) order will be maintained.
-       */
-      preferenceList.sort(new StatePriorityComparator(stateMap, stateModelDef));
-
-      currentIdealState.setPreferenceList(partition.getPartitionName(), preferenceList);
-    }
-
-    // Clear preferenceList for partitions that have no participant CurrentState.
-    // Under maintenance mode the cluster is meant to be frozen: new replicas should
-    // not be bootstrapped. A listFields entry without any CurrentState represents a
-    // planned-but-not-executed placement (e.g., WAGED wrote a target for a partition
-    // whose in-flight swap had not converged before MM activated). Preserving such an
-    // entry causes the inherited mapping calculator to dispatch a bootstrap that
-    // bypasses the per-pipeline capacity check in DelayedAutoRebalancer, which can
-    // push hosts over their configured cap. Generalize Branch A's
-    // "clear-all-when-no-CS" behavior to a per-partition rule.
-    Set<String> partitionNamesWithCurrentState = currentStateMap.keySet().stream()
-        .map(Partition::getPartitionName)
-        .collect(Collectors.toCollection(HashSet::new));
-    for (Map.Entry<String, List<String>> entry :
-        currentIdealState.getPreferenceLists().entrySet()) {
-      if (!partitionNamesWithCurrentState.contains(entry.getKey())) {
-        if (!entry.getValue().isEmpty()) {
-          LOG.info(
-              "Clearing preferenceList for partition {} in resource {} under maintenance mode "
-                  + "(no participant CurrentState).",
-              entry.getKey(), resourceName);
-          entry.getValue().clear();
-        }
+    // Index CurrentState by partition name for O(1) lookup in the unified loop below.
+    Map<Partition, Map<String, String>> currentStateMap =
+        currentStateOutput.getCurrentStateMap(resourceName);
+    Map<String, Map<String, String>> currentStateByPartitionName = new HashMap<>();
+    if (currentStateMap != null) {
+      for (Map.Entry<Partition, Map<String, String>> entry : currentStateMap.entrySet()) {
+        currentStateByPartitionName.put(entry.getKey().getPartitionName(), entry.getValue());
       }
     }
 
-    LOG.info(String
-        .format("End computing ideal state for resource %s in maintenance mode.", resourceName));
+    if (currentStateByPartitionName.isEmpty()) {
+      LOG.warn("No partition will be assigned for {} in maintenance mode "
+          + "(no participant CurrentState reports for this resource).", resourceName);
+    }
+
+    StateModelDefinition stateModelDef =
+        clusterData.getStateModelDef(currentIdealState.getStateModelDefRef());
+
+    // Single per-partition rule for every partition the IdealState knows about:
+    //   preferenceList = sorted(CurrentState hosts)   if CurrentState is non-empty
+    //   preferenceList = []                            otherwise
+    for (String partitionName : currentIdealState.getPartitionSet()) {
+      Map<String, String> stateMap = currentStateByPartitionName.get(partitionName);
+
+      if (stateMap == null || stateMap.isEmpty()) {
+        // No participant reports state for this partition. Under MM we do not
+        // bootstrap new replicas, so clear any planned-but-not-executed
+        // listFields entry. The inherited mapping calculator will then produce
+        // an empty BestPossibleStateMap for this partition.
+        currentIdealState.setPreferenceList(partitionName, new ArrayList<>());
+        continue;
+      }
+
+      List<String> preferenceList = new ArrayList<>(stateMap.keySet());
+
+      /*
+       * Sort 1: preserve the ordering of CurrentState hosts in the order of the
+       * existing IS preferenceList. Example:
+       *   IS preferenceList: [A, B, C]
+       *   CurrentState:      { A:FOLLOWER, B:LEADER, C:FOLLOWER }
+       *   newPrefList = new ArrayList<>(CS.keySet())  =>  arbitrary, e.g. [C, B, A]
+       *   after Sort 1                               =>  [A, B, C]
+       */
+      Collections.sort(preferenceList, new PreferenceListNodeComparator(stateMap, stateModelDef,
+          currentIdealState.getPreferenceList(partitionName), clusterData));
+
+      /*
+       * Sort 2: state priority. Top-state hosts (e.g., MASTER/LEADER) come first.
+       *   [A, B, C]  =>  [B, A, C]   (B is MASTER per stateMap)
+       */
+      preferenceList.sort(new StatePriorityComparator(stateMap, stateModelDef));
+
+      currentIdealState.setPreferenceList(partitionName, preferenceList);
+    }
+
+    LOG.info("End computing ideal state for resource {} in maintenance mode.", resourceName);
     return currentIdealState;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -61,14 +61,29 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
       CurrentStateOutput currentStateOutput, ResourceControllerDataProvider clusterData) {
     LOG.info("Start computing ideal state for resource {} in maintenance mode.", resourceName);
 
-    // Defensive NPE guard: a null CurrentStateOutput leaves the IS unchanged.
+    // Without a CurrentStateOutput we have no information about which partitions
+    // are still live on participants and which are not, so we cannot decide which
+    // preferenceLists to rebuild and which to clear. Returning the IdealState
+    // unchanged is the safe no-op: the next pipeline run will provide a non-null
+    // CurrentStateOutput, and DelayedAutoRebalancer's per-pipeline cap-check
+    // continues to enforce safety on placements in the meantime.
     if (currentStateOutput == null) {
       LOG.warn("CurrentStateOutput is null for resource {} in maintenance mode; "
           + "leaving IdealState unchanged.", resourceName);
       return currentIdealState;
     }
 
-    // Index CurrentState by partition name for O(1) lookup in the unified loop below.
+    // CurrentStateOutput returns Map<Partition, Map<host, state>> keyed by Partition
+    // objects, but the unified loop below iterates partition names from
+    // currentIdealState.getPartitionSet() (Set<String>). Build a name-indexed view
+    // of CurrentState up front so the per-partition lookup inside the loop is a
+    // constant-time HashMap.get() rather than a linear scan over Partition keys.
+    //
+    // A null currentStateMap (the resource has no CurrentState entries at all,
+    // e.g., the resource has never been touched by any participant) leaves
+    // currentStateByPartitionName empty. The loop below then treats every
+    // partition as a "no CS" case and clears each preferenceList, which is
+    // identical to the pre-refactor Branch A behavior.
     Map<Partition, Map<String, String>> currentStateMap =
         currentStateOutput.getCurrentStateMap(resourceName);
     Map<String, Map<String, String>> currentStateByPartitionName = new HashMap<>();
@@ -86,17 +101,38 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
     StateModelDefinition stateModelDef =
         clusterData.getStateModelDef(currentIdealState.getStateModelDefRef());
 
-    // Single per-partition rule for every partition the IdealState knows about:
-    //   preferenceList = sorted(CurrentState hosts)   if CurrentState is non-empty
-    //   preferenceList = []                            otherwise
+    // Invariant for every partition in the resource under maintenance mode:
+    //
+    //   preferenceList = sorted(participant CurrentState hosts for this partition)
+    //
+    // Two consequences fall out of this single rule:
+    //
+    // 1. Partitions with at least one participant CurrentState report keep their
+    //    placement: the preferenceList is rebuilt from the CS hosts and sorted so
+    //    top-state replicas come first. No host that has the partition in CS will
+    //    be evicted by MaintenanceRebalancer.
+    //
+    // 2. Partitions without any participant CurrentState report get an empty
+    //    preferenceList. The inherited mapping calculator
+    //    (AbstractRebalancer.computeBestPossibleStateForPartition) then returns an
+    //    empty BestPossibleStateMap, MessageGenerationPhase emits no transition,
+    //    and no OFFLINE -> ASSIGNED bootstrap is dispatched. This prevents
+    //    MaintenanceRebalancer from acting on speculative listFields entries that
+    //    WAGED may have written for in-flight swaps that had not yet converged
+    //    when maintenance mode activated -- the original bypass that allowed
+    //    over-cap dispatches.
+    //
+    // Iteration uses currentIdealState.getPartitionSet() so partitions that
+    // exist only as listFields entries (the dangerous case) are also visited.
     for (String partitionName : currentIdealState.getPartitionSet()) {
       Map<String, String> stateMap = currentStateByPartitionName.get(partitionName);
 
       if (stateMap == null || stateMap.isEmpty()) {
-        // No participant reports state for this partition. Under MM we do not
-        // bootstrap new replicas, so clear any planned-but-not-executed
-        // listFields entry. The inherited mapping calculator will then produce
-        // an empty BestPossibleStateMap for this partition.
+        // No participant CurrentState for this partition -> clear the
+        // preferenceList. setPreferenceList(name, new ArrayList<>()) replaces the
+        // list rather than mutating it in place, which avoids
+        // UnsupportedOperationException if the stored list happens to be
+        // immutable (e.g., set via Arrays.asList or Collections.emptyList).
         currentIdealState.setPreferenceList(partitionName, new ArrayList<>());
         continue;
       }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -88,12 +88,25 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
     //
     //   preferenceList = sorted(participant CurrentState hosts for this partition)
     //
+    // Example resource with two partitions, P0 and P1:
+    //   IS.listFields before: P0 -> [hostA, hostB]
+    //                         P1 -> [hostC, hostD]
+    //   CurrentState:         P0 -> { hostA:LEADER, hostB:FOLLOWER }
+    //                         P1 -> (no participant reports any state)
+    //   IS.listFields after:  P0 -> [hostA, hostB]   (rebuilt from CS, LEADER first)
+    //                         P1 -> []                (cleared because no CS report)
+    //
     // Two consequences fall out of this single rule:
     //
     // 1. Partitions with at least one participant CurrentState report keep their
     //    placement: the preferenceList is rebuilt from the CS hosts and sorted so
     //    any top-state host (per the resource's state model) appears first. No host
     //    that has the partition in CurrentState is evicted by this rebalancer.
+    //
+    //    Example:
+    //      IS preferenceList: [hostA, hostB]
+    //      CurrentState:      { hostA:FOLLOWER, hostB:LEADER }
+    //      -->  preferenceList after = [hostB, hostA]   (LEADER promoted to head)
     //
     // 2. Partitions without any participant CurrentState report get an empty
     //    preferenceList. With an empty preferenceList the inherited mapping
@@ -103,6 +116,11 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
     //    new bootstrap" for partitions whose listFields may have been written
     //    speculatively (e.g., a planned target for an in-flight move that had not
     //    yet been realized when MM activated).
+    //
+    //    Example:
+    //      IS preferenceList: [hostX, hostY]
+    //      CurrentState:      (no entries for this partition)
+    //      -->  preferenceList after = []
     //
     // Iteration uses currentIdealState.getPartitionSet() so partitions that exist
     // only as listFields entries -- the dangerous case under MM -- are also visited.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -21,8 +21,11 @@ package org.apache.helix.controller.rebalancer;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.stages.CurrentStateOutput;
@@ -90,6 +93,32 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
 
       currentIdealState.setPreferenceList(partition.getPartitionName(), preferenceList);
     }
+
+    // Clear preferenceList for partitions that have no participant CurrentState.
+    // Under maintenance mode the cluster is meant to be frozen: new replicas should
+    // not be bootstrapped. A listFields entry without any CurrentState represents a
+    // planned-but-not-executed placement (e.g., WAGED wrote a target for a partition
+    // whose in-flight swap had not converged before MM activated). Preserving such an
+    // entry causes the inherited mapping calculator to dispatch a bootstrap that
+    // bypasses the per-pipeline capacity check in DelayedAutoRebalancer, which can
+    // push hosts over their configured cap. Generalize Branch A's
+    // "clear-all-when-no-CS" behavior to a per-partition rule.
+    Set<String> partitionNamesWithCurrentState = currentStateMap.keySet().stream()
+        .map(Partition::getPartitionName)
+        .collect(Collectors.toCollection(HashSet::new));
+    for (Map.Entry<String, List<String>> entry :
+        currentIdealState.getPreferenceLists().entrySet()) {
+      if (!partitionNamesWithCurrentState.contains(entry.getKey())) {
+        if (!entry.getValue().isEmpty()) {
+          LOG.info(
+              "Clearing preferenceList for partition {} in resource {} under maintenance mode "
+                  + "(no participant CurrentState).",
+              entry.getKey(), resourceName);
+          entry.getValue().clear();
+        }
+      }
+    }
+
     LOG.info(String
         .format("End computing ideal state for resource %s in maintenance mode.", resourceName));
     return currentIdealState;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -61,18 +61,6 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
       CurrentStateOutput currentStateOutput, ResourceControllerDataProvider clusterData) {
     LOG.info("Start computing ideal state for resource {} in maintenance mode.", resourceName);
 
-    // Without a CurrentStateOutput we have no information about which partitions
-    // are still live on participants and which are not, so we cannot decide which
-    // preferenceLists to rebuild and which to clear. Returning the IdealState
-    // unchanged is the safe no-op: the next pipeline run will provide a non-null
-    // CurrentStateOutput, and DelayedAutoRebalancer's per-pipeline cap-check
-    // continues to enforce safety on placements in the meantime.
-    if (currentStateOutput == null) {
-      LOG.warn("CurrentStateOutput is null for resource {} in maintenance mode; "
-          + "leaving IdealState unchanged.", resourceName);
-      return currentIdealState;
-    }
-
     // CurrentStateOutput returns Map<Partition, Map<host, state>> keyed by Partition
     // objects, but the unified loop below iterates partition names from
     // currentIdealState.getPartitionSet() (Set<String>). Build a name-indexed view

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -51,14 +51,6 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
    * messages for it; this is what enforces "no new bootstrap under MM" regardless of
    * which upstream rebalancer wrote the original listFields entry or what state model
    * the resource uses.
-   *
-   * <p>This unifies what was previously a two-branch implementation: Branch A cleared
-   * every preferenceList when the entire resource had no CurrentState, and Branch B
-   * rebuilt preferenceLists only for partitions that did have CurrentState. The
-   * previous Branch B silently preserved listFields entries for partitions with no
-   * CurrentState yet, which could let a planned-but-not-executed placement get
-   * dispatched under MM and bypass safety checks that other rebalancers normally
-   * apply on placement. The unified rule eliminates that asymmetry.
    */
   @Override
   public IdealState computeNewIdealState(String resourceName, IdealState currentIdealState,
@@ -66,7 +58,7 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
     LOG.info("Start computing ideal state for resource {} in maintenance mode.", resourceName);
 
     // CurrentStateOutput returns Map<Partition, Map<host, state>> keyed by Partition
-    // objects, but the unified loop below iterates partition names from
+    // objects, but the loop below iterates partition names from
     // currentIdealState.getPartitionSet() (Set<String>). Build a name-indexed view
     // of CurrentState up front so the per-partition lookup inside the loop is a
     // constant-time HashMap.get() rather than a linear scan over Partition keys.
@@ -74,8 +66,7 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
     // A null currentStateMap (the resource has no CurrentState entries at all,
     // e.g., the resource has never been touched by any participant) leaves
     // currentStateByPartitionName empty. The loop below then treats every
-    // partition as a "no CS" case and clears each preferenceList, which is
-    // identical to the pre-refactor Branch A behavior.
+    // partition as a "no CS" case and clears each preferenceList.
     Map<Partition, Map<String, String>> currentStateMap =
         currentStateOutput.getCurrentStateMap(resourceName);
     Map<String, Map<String, String>> currentStateByPartitionName = new HashMap<>();

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/MaintenanceRebalancer.java
@@ -37,24 +37,28 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
   private static final Logger LOG = LoggerFactory.getLogger(MaintenanceRebalancer.class);
 
   /**
-   * Under maintenance mode, the cluster is meant to be frozen: no new replicas should be
+   * Under maintenance mode the cluster is meant to be frozen: no new replicas should be
    * bootstrapped. For every partition of the resource, the rebalancer sets the
    * preferenceList to the participant-reported CurrentState hosts (or empty if no
    * participant reports state for that partition).
    *
    * <p>For partitions with CurrentState reports, the preferenceList is rebuilt from the
-   * reported hosts, ordered to keep top-state hosts first (so role assignments are
-   * preserved). For partitions without CurrentState, the preferenceList is set to empty,
-   * which causes the inherited mapping calculator to produce no BestPossibleState and
-   * therefore no OFFLINE -> ASSIGNED message dispatch.
+   * reported hosts, ordered so that any top-state host (as defined by the resource's
+   * state model) is listed first. No host that has the partition in CurrentState is
+   * dropped from the preferenceList. For partitions without any CurrentState report,
+   * the preferenceList is set to empty so the inherited mapping calculator produces
+   * no BestPossibleState for the partition and the pipeline emits no state-transition
+   * messages for it; this is what enforces "no new bootstrap under MM" regardless of
+   * which upstream rebalancer wrote the original listFields entry or what state model
+   * the resource uses.
    *
-   * <p>This is the single-rule version of what was previously a two-branch implementation
-   * (Branch A: clear all when the entire resource has no CurrentState; Branch B: rebuild
-   * preferenceLists only for partitions with CurrentState). The previous Branch B silently
-   * preserved listFields entries for partitions whose participants had not reported yet,
-   * which let WAGED-written speculative placements (target hosts for in-flight swaps that
-   * had not converged) be dispatched without the per-pipeline capacity check that lives
-   * in DelayedAutoRebalancer. The unified rule eliminates that asymmetry.
+   * <p>This unifies what was previously a two-branch implementation: Branch A cleared
+   * every preferenceList when the entire resource had no CurrentState, and Branch B
+   * rebuilt preferenceLists only for partitions that did have CurrentState. The
+   * previous Branch B silently preserved listFields entries for partitions with no
+   * CurrentState yet, which could let a planned-but-not-executed placement get
+   * dispatched under MM and bypass safety checks that other rebalancers normally
+   * apply on placement. The unified rule eliminates that asymmetry.
    */
   @Override
   public IdealState computeNewIdealState(String resourceName, IdealState currentIdealState,
@@ -97,21 +101,20 @@ public class MaintenanceRebalancer extends SemiAutoRebalancer<ResourceController
     //
     // 1. Partitions with at least one participant CurrentState report keep their
     //    placement: the preferenceList is rebuilt from the CS hosts and sorted so
-    //    top-state replicas come first. No host that has the partition in CS will
-    //    be evicted by MaintenanceRebalancer.
+    //    any top-state host (per the resource's state model) appears first. No host
+    //    that has the partition in CurrentState is evicted by this rebalancer.
     //
     // 2. Partitions without any participant CurrentState report get an empty
-    //    preferenceList. The inherited mapping calculator
-    //    (AbstractRebalancer.computeBestPossibleStateForPartition) then returns an
-    //    empty BestPossibleStateMap, MessageGenerationPhase emits no transition,
-    //    and no OFFLINE -> ASSIGNED bootstrap is dispatched. This prevents
-    //    MaintenanceRebalancer from acting on speculative listFields entries that
-    //    WAGED may have written for in-flight swaps that had not yet converged
-    //    when maintenance mode activated -- the original bypass that allowed
-    //    over-cap dispatches.
+    //    preferenceList. With an empty preferenceList the inherited mapping
+    //    calculator produces no BestPossibleState entry for the partition, so the
+    //    downstream pipeline emits no state-transition messages and no replica is
+    //    bootstrapped. This is what enforces the maintenance-mode contract of "no
+    //    new bootstrap" for partitions whose listFields may have been written
+    //    speculatively (e.g., a planned target for an in-flight move that had not
+    //    yet been realized when MM activated).
     //
-    // Iteration uses currentIdealState.getPartitionSet() so partitions that
-    // exist only as listFields entries (the dangerous case) are also visited.
+    // Iteration uses currentIdealState.getPartitionSet() so partitions that exist
+    // only as listFields entries -- the dangerous case under MM -- are also visited.
     for (String partitionName : currentIdealState.getPartitionSet()) {
       Map<String, String> stateMap = currentStateByPartitionName.get(partitionName);
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestMaintenanceRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/TestMaintenanceRebalancer.java
@@ -1,5 +1,8 @@
 package org.apache.helix.controller.rebalancer;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -55,6 +58,121 @@ public class TestMaintenanceRebalancer {
         "comment", "stateModel", "liveInstances", "preferenceList", "currentStateMap", "expectedPreferenceList"
     };
     return TestInputLoader.loadTestInputs("MaintenanceRebalancer.ComputeNewIdealState.json", params);
+  }
+
+  /**
+   * Verifies that under maintenance mode, a partition with a non-empty preferenceList but
+   * NO participant CurrentState gets its preferenceList cleared rather than preserved.
+   * Preserving such an entry would cause the inherited mapping calculator to dispatch a
+   * bootstrap that bypasses the per-pipeline capacity check in DelayedAutoRebalancer.
+   * Regression test for the "MM bypass" issue where a WAGED-planned listFields entry for a
+   * partition with no CurrentState survived MaintenanceRebalancer and got dispatched.
+   */
+  @Test
+  public void testClearsListFieldsForPartitionWithoutCurrentState() {
+    final String partWithCs = "p0_withCs";
+    final String partWithoutCs = "p1_withoutCs";
+    final String hostA = "hostA";
+    final String hostB = "hostB";
+    final String hostC = "hostC";
+    final String hostD = "hostD";
+
+    // Resource has two partitions:
+    //   p0_withCs:    preferenceList=[hostA, hostB], currentState={hostA:MASTER, hostB:SLAVE}
+    //   p1_withoutCs: preferenceList=[hostC, hostD], currentState={} (none reported)
+    IdealState currentIdealState = new IdealState(RESOURCE_NAME);
+    currentIdealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+    currentIdealState.setRebalancerClassName(
+        "org.apache.helix.controller.rebalancer.waged.WagedRebalancer");
+    currentIdealState.setStateModelDefRef("MasterSlave");
+    currentIdealState.setPreferenceList(partWithCs, new ArrayList<>(Arrays.asList(hostA, hostB)));
+    currentIdealState.setPreferenceList(partWithoutCs, new ArrayList<>(Arrays.asList(hostC, hostD)));
+
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    Partition p0 = new Partition(partWithCs);
+    currentStateOutput.setCurrentState(RESOURCE_NAME, p0, hostA, "MASTER");
+    currentStateOutput.setCurrentState(RESOURCE_NAME, p0, hostB, "SLAVE");
+    // p1_withoutCs: deliberately no setCurrentState calls
+
+    ResourceControllerDataProvider dataCache = mock(ResourceControllerDataProvider.class);
+    when(dataCache.getStateModelDef("MasterSlave")).thenReturn(MasterSlaveSMD.build());
+
+    IdealState updated = new MaintenanceRebalancer()
+        .computeNewIdealState(RESOURCE_NAME, currentIdealState, currentStateOutput, dataCache);
+
+    // p0 retains its preferenceList (rebuilt from CS).
+    List<String> p0List = updated.getPreferenceList(partWithCs);
+    Assert.assertNotNull(p0List, "preferenceList for partition with CS should not be null");
+    Assert.assertEquals(p0List.size(), 2,
+        "preferenceList for partition with CS should have both hosts");
+    Assert.assertTrue(p0List.contains(hostA) && p0List.contains(hostB),
+        "preferenceList for partition with CS should contain both CS hosts");
+
+    // p1 gets its preferenceList cleared because no participant reports CurrentState for it.
+    List<String> p1List = updated.getPreferenceList(partWithoutCs);
+    Assert.assertNotNull(p1List, "preferenceList for partition without CS should not be null");
+    Assert.assertTrue(p1List.isEmpty(),
+        "preferenceList for partition with no CurrentState should be empty under MM, "
+            + "but was: " + p1List);
+  }
+
+  /**
+   * Verifies that the existing Branch A behavior is preserved: if the entire resource has no
+   * participant CurrentState reports, every partition's preferenceList is cleared.
+   */
+  @Test
+  public void testClearsAllListFieldsWhenResourceHasNoCurrentState() {
+    IdealState currentIdealState = new IdealState(RESOURCE_NAME);
+    currentIdealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+    currentIdealState.setRebalancerClassName(
+        "org.apache.helix.controller.rebalancer.waged.WagedRebalancer");
+    currentIdealState.setStateModelDefRef("MasterSlave");
+    currentIdealState.setPreferenceList("p0", new ArrayList<>(Arrays.asList("hostA", "hostB")));
+    currentIdealState.setPreferenceList("p1", new ArrayList<>(Arrays.asList("hostC", "hostD")));
+
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    ResourceControllerDataProvider dataCache = mock(ResourceControllerDataProvider.class);
+    when(dataCache.getStateModelDef("MasterSlave")).thenReturn(MasterSlaveSMD.build());
+
+    IdealState updated = new MaintenanceRebalancer()
+        .computeNewIdealState(RESOURCE_NAME, currentIdealState, currentStateOutput, dataCache);
+
+    Assert.assertEquals(updated.getPreferenceList("p0"), Collections.emptyList(),
+        "p0 preferenceList should be cleared (Branch A: no CS for any partition)");
+    Assert.assertEquals(updated.getPreferenceList("p1"), Collections.emptyList(),
+        "p1 preferenceList should be cleared (Branch A: no CS for any partition)");
+  }
+
+  /**
+   * Verifies that a partition whose preferenceList is already empty stays empty (no spurious
+   * "Clearing preferenceList" log line, no NPE).
+   */
+  @Test
+  public void testEmptyPreferenceListStaysEmpty() {
+    final String partWithCs = "p0_withCs";
+    final String partWithoutCs = "p1_withoutCs";
+
+    IdealState currentIdealState = new IdealState(RESOURCE_NAME);
+    currentIdealState.setRebalanceMode(IdealState.RebalanceMode.FULL_AUTO);
+    currentIdealState.setRebalancerClassName(
+        "org.apache.helix.controller.rebalancer.waged.WagedRebalancer");
+    currentIdealState.setStateModelDefRef("MasterSlave");
+    currentIdealState.setPreferenceList(partWithCs, new ArrayList<>(Arrays.asList("hostA", "hostB")));
+    currentIdealState.setPreferenceList(partWithoutCs, new ArrayList<String>());
+
+    CurrentStateOutput currentStateOutput = new CurrentStateOutput();
+    Partition p0 = new Partition(partWithCs);
+    currentStateOutput.setCurrentState(RESOURCE_NAME, p0, "hostA", "MASTER");
+    currentStateOutput.setCurrentState(RESOURCE_NAME, p0, "hostB", "SLAVE");
+
+    ResourceControllerDataProvider dataCache = mock(ResourceControllerDataProvider.class);
+    when(dataCache.getStateModelDef("MasterSlave")).thenReturn(MasterSlaveSMD.build());
+
+    IdealState updated = new MaintenanceRebalancer()
+        .computeNewIdealState(RESOURCE_NAME, currentIdealState, currentStateOutput, dataCache);
+
+    Assert.assertEquals(updated.getPreferenceList(partWithCs).size(), 2);
+    Assert.assertTrue(updated.getPreferenceList(partWithoutCs).isEmpty());
   }
 
 }


### PR DESCRIPTION
## Summary

Under maintenance mode (MM), `MaintenanceRebalancer` could dispatch an `OFFLINE -> ASSIGNED` bootstrap that bypassed the per-pipeline capacity check in `DelayedAutoRebalancer`, pushing target hosts over their configured `INSTANCE_CAPACITY_MAP` cap. This PR closes that bypass.

## Background

In `MaintenanceRebalancer.computeNewIdealState`, two branches handle the IS update:

- **Branch A** (`currentStateMap.size() == 0`): clears every partition's `preferenceList`,  nothing to dispatch.
- **Branch B** (some partition has CurrentState): rebuilds `preferenceList` from CS keys only for partitions present in `currentStateMap.keySet()`. Partitions absent from that set keep their existing `listFields` verbatim.

Branch B's "leave the rest alone" behavior was safe in the world before WAGED, when `listFields` was operator-set. After WAGED, `listFields` is the controller's own *planned* placement, which can differ from reality during any in-flight swap:

1. WAGED writes `listFields[p] = [hostA, hostB]` based on its forward-looking plan.
2. The participant has not yet reported CS for partition `p` (e.g., the bootstrap dispatch is being held by `DelayedAutoRebalancer`'s cap-check because the destination hosts still have stuck incumbents from a prior in-flight swap).
3. A maintenance-mode event fires. The controller switches to `MaintenanceRebalancer`.
4. `currentStateMap` for the resource has some partitions (those with CS) but not `p`. Branch B runs.
5. `listFields[p]` is preserved as `[hostA, hostB]`.
6. The inherited mapping calculator (`AbstractRebalancer.computeBestPossibleStateForPartition`) consumes `preferenceList = [hostA, hostB]` verbatim,  it has no capacity check.
7. `MessageGenerationPhase` emits `OFFLINE -> ASSIGNED` to both hosts. Hosts go over-cap, participants ERROR.

The cap-check that prevents this in normal pipelines lives only in `DelayedAutoRebalancer.computeBestPossibleStateForPartition`'s override (lines 373-389). `MaintenanceRebalancer extends SemiAutoRebalancer extends AbstractRebalancer`, none of which override that method, so the check is structurally absent under MM.

## Fix

Generalize Branch A's "clear-all-when-no-CS" to a per-partition rule: after rebuilding `preferenceList`s for partitions with CurrentState, clear the `preferenceList` for any partition that has no CurrentState report. This means MM cannot bootstrap a brand-new replica regardless of cap state, semantically aligned with the intent of maintenance mode ("freeze the cluster"), and structurally aligned with Branch A's existing behavior.

Code-anchored summary:

- `MaintenanceRebalancer.java`: 29 lines added after the existing Branch B loop. Iterates `currentIdealState.getPreferenceLists().entrySet()`; for any partition name not present in `currentStateMap.keySet()` and whose `preferenceList` is non-empty, logs an INFO line and calls `clear()`.

## Why not just add the cap-check?

An alternative would be to override `computeBestPossibleStateForPartition` in `MaintenanceRebalancer` with a copy of `DelayedAutoRebalancer`'s cap-check. That works for this specific bug but:

- It duplicates the cap-check logic in two subclasses (drift risk).
- It validates capacity rather than respecting MM's stated semantics (don't bootstrap).
- It leaves the class hierarchy open to the same bug class if another `Rebalancer` subclass is added.

The chosen fix is smaller (29 lines vs. ~25 + a new override), purely additive, and aligned with the existing Branch A pattern.

## Test Coverage

Added three regression tests in `TestMaintenanceRebalancer.java`:

| Test | Coverage |
|---|---|
| `testClearsListFieldsForPartitionWithoutCurrentState` | The actual bug. Multi-partition resource: one with CS keeps a rebuilt `preferenceList`, one without CS gets `preferenceList` cleared. |
| `testClearsAllListFieldsWhenResourceHasNoCurrentState` | Branch A regression,  confirms the existing "no CS for any partition → clear everything" behavior is unchanged. |
| `testEmptyPreferenceListStaysEmpty` | Defensive: partition with an already-empty `preferenceList` stays empty, no NPE, no spurious log line. |

### `mvn test` results

`TestMaintenanceRebalancer` (this PR's test class):

```
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
  (6 existing data-driven cases + 3 new)
```

Broader smoke test of the relevant surfaces (rebalancers + WAGED capacity model):

```
TestMaintenanceRebalancer
TestAbstractRebalancer
TestNodeCapacityConstraint
TestWagedInstanceCapacity
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0
```

## Backward Compatibility

None. The change tightens behavior under MM only, partitions that previously had a `preferenceList` *without* a corresponding CurrentState would have been candidates for bootstrap-under-MM (the bug). After this PR they stay un-bootstrapped until MM clears, at which point normal rebalancing resumes via `DelayedAutoRebalancer` (with the cap-check). No public API surface changes. No state-machine or message-format changes.

## Related Code Paths

- Mechanism: `BestPossibleStateCalcStage.java#L693-L726` selects `MaintenanceRebalancer` for FULL_AUTO+MM resources.
- Cap-check that's bypassed: `DelayedAutoRebalancer.java#L373-L389`.
- Capacity model populated from real CurrentState: `WagedInstanceCapacity.processCurrentState` at `WagedInstanceCapacity.java#L134-L160`.

### Code Quality

- [x] Diff has been formatted using `helix-style.xml`.
