### PR TITLE
Add logout functionality to helix-front

### DIFF
--- a/helix-front/server/controllers/d.ts
+++ b/helix-front/server/controllers/d.ts
@@ -12,6 +12,7 @@ interface HelixSession {
   identityToken: any;
   username: string;
   isAdmin: boolean;
+  destroy(callback: (err?: any) => void): void;
 }
 
 type AgentOptions = {

--- a/helix-front/server/controllers/user.ts
+++ b/helix-front/server/controllers/user.ts
@@ -17,6 +17,7 @@ export class UserCtrl {
     // uncomment the following line to use customized login
     // router.route('/user/authorize').get(this.authorize);
     router.route('/user/login').post(this.login.bind(this));
+    router.route('/user/logout').post(this.logout.bind(this));
     router.route('/user/current').get(this.current);
     router.route('/user/can').get(this.can);
   }
@@ -54,6 +55,17 @@ export class UserCtrl {
       );
       return false;
     }
+  }
+
+  protected logout(req: HelixRequest, res: Response) {
+    req.session.destroy((err) => {
+      if (err) {
+        res.status(500).json({ error: 'Logout failed' });
+        return;
+      }
+      res.clearCookie('connect.sid');
+      res.json(true);
+    });
   }
 
   protected login(req: HelixRequest, res: Response) {

--- a/helix-front/server/controllers/user.ts
+++ b/helix-front/server/controllers/user.ts
@@ -63,7 +63,8 @@ export class UserCtrl {
         res.status(500).json({ error: 'Logout failed' });
         return;
       }
-      res.clearCookie('connect.sid');
+      res.clearCookie('connect.sid', { path: '/' });
+      res.clearCookie('helixui_identity.token');
       res.json(true);
     });
   }

--- a/helix-front/src/app/app.component.html
+++ b/helix-front/src/app/app.component.html
@@ -28,10 +28,20 @@
       <span class="helix-title">Helix</span>
     </a>
     <span fxFlex="1 1 auto"></span>
-    <a mat-button (click)="login()">
+    <button mat-button [matMenuTriggerFor]="userMenu">
       <mat-icon>person</mat-icon>
       {{ currentUser | async }}
-    </a>
+    </button>
+    <mat-menu #userMenu="matMenu">
+      <button mat-menu-item (click)="login()">
+        <mat-icon>login</mat-icon>
+        <span>Sign In</span>
+      </button>
+      <button mat-menu-item (click)="logout()">
+        <mat-icon>logout</mat-icon>
+        <span>Sign Out</span>
+      </button>
+    </mat-menu>
   </mat-toolbar>
   <mat-progress-bar
     *ngIf="isLoading"

--- a/helix-front/src/app/app.component.html
+++ b/helix-front/src/app/app.component.html
@@ -28,16 +28,16 @@
       <span class="helix-title">Helix</span>
     </a>
     <span fxFlex="1 1 auto"></span>
-    <button mat-button [matMenuTriggerFor]="userMenu">
+    <a mat-button (click)="login()" *ngIf="(currentUser | async) === 'Sign In'">
+      <mat-icon>person</mat-icon>
+      {{ currentUser | async }}
+    </a>
+    <button mat-button [matMenuTriggerFor]="userMenu" *ngIf="(currentUser | async) !== 'Sign In'">
       <mat-icon>person</mat-icon>
       {{ currentUser | async }}
     </button>
     <mat-menu #userMenu="matMenu">
-      <button mat-menu-item (click)="login()" *ngIf="(currentUser | async) === 'Sign In'">
-        <mat-icon>login</mat-icon>
-        <span>Sign In</span>
-      </button>
-      <button mat-menu-item (click)="logout()" *ngIf="(currentUser | async) !== 'Sign In'">
+      <button mat-menu-item (click)="logout()">
         <mat-icon>logout</mat-icon>
         <span>Sign Out</span>
       </button>

--- a/helix-front/src/app/app.component.html
+++ b/helix-front/src/app/app.component.html
@@ -32,7 +32,11 @@
       <mat-icon>person</mat-icon>
       {{ currentUser | async }}
     </a>
-    <button mat-button [matMenuTriggerFor]="userMenu" *ngIf="(currentUser | async) !== 'Sign In'">
+    <button
+      mat-button
+      [matMenuTriggerFor]="userMenu"
+      *ngIf="(currentUser | async) !== 'Sign In'"
+    >
       <mat-icon>person</mat-icon>
       {{ currentUser | async }}
     </button>

--- a/helix-front/src/app/app.component.html
+++ b/helix-front/src/app/app.component.html
@@ -33,11 +33,11 @@
       {{ currentUser | async }}
     </button>
     <mat-menu #userMenu="matMenu">
-      <button mat-menu-item (click)="login()">
+      <button mat-menu-item (click)="login()" *ngIf="(currentUser | async) === 'Sign In'">
         <mat-icon>login</mat-icon>
         <span>Sign In</span>
       </button>
-      <button mat-menu-item (click)="logout()">
+      <button mat-menu-item (click)="logout()" *ngIf="(currentUser | async) !== 'Sign In'">
         <mat-icon>logout</mat-icon>
         <span>Sign Out</span>
       </button>

--- a/helix-front/src/app/app.component.ts
+++ b/helix-front/src/app/app.component.ts
@@ -116,4 +116,16 @@ export class AppComponent implements OnInit {
         }
       );
   }
+
+  logout() {
+    this.service.logout().subscribe(
+      () => {
+        this.currentUser = this.service.getCurrentUser();
+        this.helper.showSnackBar('Signed out successfully.');
+      },
+      (error) => {
+        this.helper.showError(error);
+      }
+    );
+  }
 }

--- a/helix-front/src/app/core/user.service.ts
+++ b/helix-front/src/app/core/user.service.ts
@@ -17,8 +17,11 @@ export class UserService {
   }
 
   public logout(): Observable<any> {
-    return this.http
-      .post(`${Settings.userAPI}/logout`, {}, { headers: this.getHeaders() });
+    return this.http.post(
+      `${Settings.userAPI}/logout`,
+      {},
+      { headers: this.getHeaders() }
+    );
   }
 
   public login(username: string, password: string): Observable<any> {

--- a/helix-front/src/app/core/user.service.ts
+++ b/helix-front/src/app/core/user.service.ts
@@ -16,6 +16,12 @@ export class UserService {
       .pipe(catchError((_) => _));
   }
 
+  public logout(): Observable<any> {
+    return this.http
+      .post(`${Settings.userAPI}/logout`, {}, { headers: this.getHeaders() })
+      .pipe(catchError((_) => _));
+  }
+
   public login(username: string, password: string): Observable<any> {
     const url = `${Settings.userAPI}/login`;
     const body = { username, password };

--- a/helix-front/src/app/core/user.service.ts
+++ b/helix-front/src/app/core/user.service.ts
@@ -18,8 +18,7 @@ export class UserService {
 
   public logout(): Observable<any> {
     return this.http
-      .post(`${Settings.userAPI}/logout`, {}, { headers: this.getHeaders() })
-      .pipe(catchError((_) => _));
+      .post(`${Settings.userAPI}/logout`, {}, { headers: this.getHeaders() });
   }
 
   public login(username: string, password: string): Observable<any> {


### PR DESCRIPTION
## Summary
- Adds `POST /user/logout` server route that destroys the Express session and clears the `connect.sid` cookie
- Adds `destroy()` to the `HelixSession` TypeScript interface
- Adds `logout()` method to Angular `UserService`
- Replaces the user chip with a `mat-menu` dropdown offering Sign In and Sign Out
- Adds `logout()` method to `AppComponent` with snackbar confirmation

## Testing Done
- Manually verified in browser on `localhost:4200`:
  - Click username chip → dropdown menu shows Sign In and Sign Out with distinct icons
  - Sign In opens LDAP dialog, authenticates as before
  - Sign Out clears session, chip reverts to "Sign In", snackbar confirms
  - After sign out, write operations correctly require re-authentication


https://github.com/user-attachments/assets/6287f6e1-f21a-4704-ba70-1f1d248a0750

## Context
Users had no way to log out or re-authenticate after their identity token expired (~24h), causing 401 errors on write operations while the UI still showed them as logged in. The only workaround was manually clearing cookies in DevTools.

This repo holds the source code — Angular components (.ts, .html), services, and the open-source server controllers . PR deals with Client-side changes (mat-menu, UserService.logout, AppComponent) + server-side (user.ts, d.ts)