### PR TITLE
Make auto-MM entry and exit measure the same offline budget

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/BestPossibleStateCalcStage.java
@@ -33,7 +33,6 @@ import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixRebalanceException;
-import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.pipeline.AbstractBaseStage;
@@ -373,28 +372,12 @@ public class BestPossibleStateCalcStage extends AbstractBaseStage {
     int maxInstancesUnableToAcceptOnlineReplicas =
         cache.getClusterConfig().getMaxOfflineInstancesAllowed();
     if (maxInstancesUnableToAcceptOnlineReplicas >= 0) {
-      // Build the set of instances that currently count toward the offline budget:
-      //   routable InstanceConfig minus the enabled-live set. We exclude UNROUTABLE
-      //   operations (e.g. SWAP_IN, UNKNOWN) up front because those should not consume
-      //   cluster capacity. Then we drop instances carrying a valid instance-operation
-      //   maintenance marker, since they're inside an operator-approved window.
-      //
-      // The same marker-based subtraction is applied at MM exit in MaintenanceRecoveryStage
-      // so a marker that lets an instance escape MM entry also lets the cluster recover
-      // when the marker expires.
-      Set<String> offlineBudgetInstances = cache.getInstanceConfigMap().entrySet().stream()
-          .filter(instanceEntry -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
-              instanceEntry.getValue().getInstanceOperation().getOperation()))
-          .map(Map.Entry::getKey)
-          .collect(Collectors.toCollection(HashSet::new));
-      offlineBudgetInstances.removeAll(cache.getEnabledLiveInstances());
-
-      long nowMs = System.currentTimeMillis();
-      offlineBudgetInstances.removeIf(instanceName -> {
-        InstanceConfig cfg = cache.getInstanceConfigMap().get(instanceName);
-        return cfg != null && cfg.isUnderInstanceOperationMaintenance(nowMs);
-      });
-      int instancesUnableToAcceptOnlineReplicas = offlineBudgetInstances.size();
+      // Delegate to the shared offline-budget accessor so MM entry and MM exit
+      // (MaintenanceRecoveryStage) observe the exact same population. See
+      // BaseControllerDataProvider#getInstancesUnableToAcceptOnlineReplicas for the
+      // membership rules (routable, not enabled-live, no valid maintenance marker).
+      int instancesUnableToAcceptOnlineReplicas = cache
+          .getInstancesUnableToAcceptOnlineReplicas(System.currentTimeMillis()).size();
       if (instancesUnableToAcceptOnlineReplicas > maxInstancesUnableToAcceptOnlineReplicas) {
         String errMsg = String.format(
             "Instances unable to take ONLINE replicas count %d greater than allowed count %d. Put cluster %s into "

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/MaintenanceRecoveryStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/MaintenanceRecoveryStage.java
@@ -21,7 +21,6 @@ package org.apache.helix.controller.stages;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixManager;
@@ -32,7 +31,6 @@ import org.apache.helix.controller.pipeline.AbstractAsyncBaseStage;
 import org.apache.helix.controller.pipeline.AsyncWorkerType;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MaintenanceSignal;
 import org.apache.helix.model.Partition;
 import org.slf4j.Logger;
@@ -83,37 +81,30 @@ public class MaintenanceRecoveryStage extends AbstractAsyncBaseStage {
     boolean shouldExitMaintenance;
     String reason;
     switch (internalReason) {
+    // MAX_OFFLINE_INSTANCES_EXCEEDED is the deprecated alias for
+    // MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS; no current code path writes it, but
+    // long-lived MM signals persisted before the rename can still carry it on disk. The
+    // two arms must stay collapsed for backward compatibility.
     case MAX_OFFLINE_INSTANCES_EXCEEDED:
     case MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS:
-      // Check on the number of offline/disabled instances
       int numOfflineInstancesForAutoExit =
           cache.getClusterConfig().getNumOfflineInstancesForAutoExit();
       if (numOfflineInstancesForAutoExit < 0) {
         return; // Config is not set, no auto-exit
       }
-      // Count offline-or-disabled assignable instances, then subtract those carrying a
-      // valid instance-operation maintenance marker so a deploy window can't trap the
-      // cluster in MM. The same marker-based subtraction runs at MM entry in
-      // BestPossibleStateCalcStage.
-      Set<String> assignable = cache.getAssignableInstances();
-      Set<String> enabledLive = cache.getEnabledLiveInstances();
-      long nowMs = System.currentTimeMillis();
-      int markedAndOfflineCount = 0;
-      for (String instanceName : assignable) {
-        if (enabledLive.contains(instanceName)) {
-          continue;
-        }
-        InstanceConfig cfg = cache.getInstanceConfigMap().get(instanceName);
-        if (cfg != null && cfg.isUnderInstanceOperationMaintenance(nowMs)) {
-          markedAndOfflineCount++;
-        }
-      }
-      int offlineDisabledCount =
-          assignable.size() - enabledLive.size() - markedAndOfflineCount;
-      shouldExitMaintenance = offlineDisabledCount <= numOfflineInstancesForAutoExit;
+      // Use the shared offline-budget accessor so MM exit measures against the same
+      // population MM entry uses in BestPossibleStateCalcStage. See
+      // BaseControllerDataProvider#getInstancesUnableToAcceptOnlineReplicas for the
+      // membership rules (routable, not enabled-live, no valid maintenance marker).
+      int instancesUnableToAcceptOnlineReplicas =
+          cache.getInstancesUnableToAcceptOnlineReplicas(System.currentTimeMillis()).size();
+      shouldExitMaintenance =
+          instancesUnableToAcceptOnlineReplicas <= numOfflineInstancesForAutoExit;
       reason = String.format(
-          "Auto-exiting maintenance mode for cluster %s; Num. of offline/disabled instances is %d, less than or equal to the exit threshold %d",
-          event.getClusterName(), offlineDisabledCount, numOfflineInstancesForAutoExit);
+          "Auto-exiting maintenance mode for cluster %s; instances unable to take ONLINE "
+              + "replicas count %d is less than or equal to the exit threshold %d",
+          event.getClusterName(), instancesUnableToAcceptOnlineReplicas,
+          numOfflineInstancesForAutoExit);
       break;
     case MAX_PARTITION_PER_INSTANCE_EXCEEDED:
       IntermediateStateOutput intermediateStateOutput =

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationMaintenanceBudget.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperationMaintenanceBudget.java
@@ -44,8 +44,10 @@ import org.testng.annotations.Test;
 
 /**
  * End-to-end check that INSTANCE_OPERATION_MAINTENANCE_UNTIL_MS markers exempt instances
- * from the cluster-wide offline budget that drives auto Maintenance Mode entry, while
- * preserving the trigger for unplanned losses.
+ * from the cluster-wide offline budget that drives auto Maintenance Mode -- at both entry
+ * (MAX_OFFLINE_INSTANCES_ALLOWED) and exit (NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT) -- while
+ * preserving the trigger for unplanned losses. Also covers the EVACUATE auto-exit path,
+ * which previously diverged from entry and could oscillate the cluster in and out of MM.
  */
 public class TestInstanceOperationMaintenanceBudget extends ZkTestBase {
   private static final int NUM_NODE = 6;
@@ -193,8 +195,8 @@ public class TestInstanceOperationMaintenanceBudget extends ZkTestBase {
   /**
    * Covers the EVACUATE operation: an instance with operation = EVACUATE is in the MM-entry
    * baseline and not in enabledLive, so it counts toward the budget without a marker. The
-   * marker should exempt it. (Exit treats EVACUATE separately via getAssignableInstances;
-   * that's pre-existing controller behavior and is not what this test exercises.)
+   * marker should exempt it from both MM entry and MM exit thresholds, which both now
+   * delegate to the shared offline-budget accessor.
    */
   @Test(dependsOnMethods = "testMarkedDisabledInstanceDoesNotTripMM")
   public void testMarkedEvacuatingInstanceDoesNotTripMM() throws Exception {
@@ -216,6 +218,77 @@ public class TestInstanceOperationMaintenanceBudget extends ZkTestBase {
     // Restore: return to ENABLE and clear the marker.
     _gSetupTool.getClusterManagementTool().setInstanceOperation(_clusterName, h0,
         InstanceConstants.InstanceOperation.ENABLE);
+    restoreClusterState();
+  }
+
+  /**
+   * Locks in the auto-exit half of the entry/exit consistency fix. An unmarked EVACUATE
+   * instance counts toward the offline budget at MM entry (it always did) and now also
+   * counts at MM exit (this PR's behavior change). So while the EVACUATE instance is
+   * present, the cluster must stay in MM even after the original triggering condition
+   * clears -- previously the exit-side baseline excluded EVACUATE and the cluster would
+   * oscillate in and out of MM on every pipeline tick.
+   *
+   * <p>Sequence:
+   * <ol>
+   *   <li>Put h0 into EVACUATE (no marker). Entry count = 1, which equals
+   *       MAX_OFFLINE_INSTANCES_ALLOWED, so MM does not enter yet.</li>
+   *   <li>Stop h1 (no EVACUATE, no marker). Entry count = 2 &gt; 1 -- MM enters.</li>
+   *   <li>Restart h1. Entry count drops to 1, but MaintenanceRecoveryStage is the only
+   *       path that can auto-exit. With the shared accessor, exit sees the EVACUATE
+   *       instance and reports count = 1 &gt; NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT (0),
+   *       so it must hold MM.</li>
+   *   <li>Flip h0 back to ENABLE. Exit count drops to 0 and the cluster auto-exits.</li>
+   * </ol>
+   */
+  @Test(dependsOnMethods = "testMarkedEvacuatingInstanceDoesNotTripMM")
+  public void testUnmarkedEvacuatingInstanceHoldsMMUntilCleared() throws Exception {
+    Assert.assertNull(_dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance()));
+
+    String h0 = _participants.get(0).getInstanceName();
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(_clusterName, h0,
+        InstanceConstants.InstanceOperation.EVACUATE);
+
+    // h0 alone is at the boundary; MM does not enter yet.
+    Assert.assertNull(_dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance()));
+
+    // Stop h1 -- now offline budget is 2 (EVACUATE h0 + offline h1), which exceeds
+    // MAX_OFFLINE_INSTANCES_ALLOWED = 1, so MM fires.
+    _participants.get(1).syncStop();
+    boolean enteredMM = TestHelper.verify(() -> {
+      MaintenanceSignal ms = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+      return ms != null && ms.getReason() != null;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(enteredMM,
+        "MM must enter once EVACUATE + an unplanned offline exceed the budget");
+
+    // Bring h1 back. With pre-fix behavior MM would auto-exit immediately because the
+    // exit path ignored EVACUATE; with the shared accessor, exit still sees one
+    // (EVACUATE) instance > the exit threshold of 0, so MM must stay on.
+    MockParticipantManager h1Replacement = new MockParticipantManager(ZK_ADDR, _clusterName,
+        _participants.get(1).getInstanceName());
+    h1Replacement.syncStart();
+    _participants.set(1, h1Replacement);
+    boolean stayedInMM = TestHelper.verify(() -> {
+      MaintenanceSignal ms = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+      return ms != null;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(stayedInMM,
+        "MM must hold while an unmarked EVACUATE instance is still in the offline budget; "
+            + "without the shared accessor the exit path would have ignored it and "
+            + "auto-exited prematurely");
+
+    // Flip h0 back to ENABLE. Exit count drops to 0 (h0 is live again and routable)
+    // and MM auto-exits.
+    _gSetupTool.getClusterManagementTool().setInstanceOperation(_clusterName, h0,
+        InstanceConstants.InstanceOperation.ENABLE);
+    boolean exitedMM = TestHelper.verify(() -> {
+      MaintenanceSignal ms = _dataAccessor.getProperty(_dataAccessor.keyBuilder().maintenance());
+      return ms == null;
+    }, TestHelper.WAIT_DURATION);
+    Assert.assertTrue(exitedMM,
+        "MM must auto-exit once the EVACUATE op clears and the offline budget drops to 0");
+
     restoreClusterState();
   }
 


### PR DESCRIPTION
### Issues

Follow-up to #175. Fixes the entry/exit offline-budget asymmetry called out as
deferred work in that PR. Depends on #181 (shared accessor) — please merge that
first; until it lands, the diff view here will include #181's commit.

### Description

Switches `BestPossibleStateCalcStage` (MM entry) and `MaintenanceRecoveryStage`
(MM exit) to call `BaseControllerDataProvider#getInstancesUnableToAcceptOnlineReplicas`,
the shared accessor introduced in #181.

**Problem.** The two stages computed their offline counts independently and
disagreed on `EVACUATE` instances:
- Entry filtered by `!UNROUTABLE_INSTANCE_OPERATIONS` (= everything except `SWAP_IN`/`UNKNOWN`),
  so `EVACUATE+offline` instances counted toward `MAX_OFFLINE_INSTANCES_ALLOWED`.
- Exit filtered by `getAssignableInstances()` (= `{ENABLE, DISABLE}`),
  so `EVACUATE+offline` instances did **not** count toward `NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT`.

This could oscillate a cluster in and out of MM on every pipeline tick:
entry enters MM because of an `EVACUATE+offline` instance, exit immediately
auto-exits because the same instance doesn't show up in its base set.

**Fix.** Both stages now delegate to the shared accessor, which measures the
same population: routable, not enabled-live, no valid maintenance marker.

### Behavior change

One-directional and safer: auto-exit holds longer when `EVACUATE` instances
are present.

- Clusters that never carry `EVACUATE` in steady state see no change.
- Auto-MM is opt-in (`MAX_OFFLINE_INSTANCES_ALLOWED` defaults to `-1`), so
  clusters that don't use auto-MM are unaffected.
- Clusters that do run with `EVACUATE` instances will see auto-MM hold until
  the `EVACUATE` clears (or the instance gets a maintenance marker). Set
  `NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT` higher if you want to retain the
  previous behavior under specific scenarios.

### Other changes in this PR

- `MaintenanceRecoveryStage`'s exit log message now reads "instances unable to
  take ONLINE replicas count %d..." to match the entry stage and the
  `MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS` trigger reason.
- Added a comment on the `MAX_OFFLINE_INSTANCES_EXCEEDED` switch case
  explaining the fall-through is intentional backward-compat for long-lived MM
  signals persisted before the reason was renamed. No code path writes this
  value today, but the fall-through must stay.

### Tests

`TestInstanceOperationMaintenanceBudget.testUnmarkedEvacuatingInstanceHoldsMMUntilCleared`
(new) exercises the full lifecycle:
1. Put h0 into `EVACUATE` (no marker). Entry count = 1, equal to the budget; MM does not enter.
2. Stop h1 (no `EVACUATE`, no marker). Entry count = 2 > 1; MM enters.
3. Restart h1. Entry count drops to 1, but `MaintenanceRecoveryStage` now sees
   the `EVACUATE` instance and reports 1 > `NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT (0)`,
   so it must hold MM. Pre-fix this is where the cluster would have oscillated.
4. Flip h0 back to `ENABLE`. Exit count drops to 0 and MM auto-exits.

Other tests in the same class had their docstrings updated to reflect that
both entry and exit now apply the marker subtraction.

Targeted run (helix-core only):

​```
mvn -pl helix-core test \
  -Dtest='TestInstancesUnableToAcceptOnlineReplicas,TestInstanceOperationMaintenanceBudget,TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit,TestClusterMaintenanceMode'

TestInstancesUnableToAcceptOnlineReplicas:                          18/18 pass
TestInstanceOperationMaintenanceBudget:                              5/5 pass
TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit:       2/2 pass
TestClusterMaintenanceMode:                                          12/12 pass
Total:                                                              37/37 pass
​```

### Changes that Break Backward Compatibility (Optional)

Auto-exit semantics tighten as described above. No public API changes; no wire
format changes. Recommend a brief mention in release notes calling out the
`EVACUATE` counting change for operators tuning `NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT`.

### Documentation (Optional)

N/A — internal controller logic, documented in code comments and the shared
accessor's Javadoc.

### Commits

- [x] Subject in imperative mood, body explains what + why, wraps at 72.

### Code Quality

- [x] Diff formatted to match surrounding style. No new lint warnings.