### PR TITLE
Add per-event-type topology change metrics for controller

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -970,10 +970,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
         _clusterStatusMonitor
             .updateClusterEventDuration(ClusterEventMonitor.PhaseName.TotalProcessed.name(),
                 _lastPipelineEndTimestamp - startTime);
-        // Count topology-change events that completed the resource pipeline successfully.
-        // Paired with the received counter incremented in pushToEventQueues; the gap
-        // between the two reflects coalescing in the cluster event queue under load.
-        if (!rebalanceFail) {
+        if (shouldCountTopologyEventAsProcessed(rebalanceFail, dataProvider)) {
           _clusterStatusMonitor.incrementTopologyChangeEventProcessed(event.getEventType());
         }
       }
@@ -989,6 +986,19 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     // So reset ClusterStatusMonitor according to it's status after all event handling.
     // TODO remove this once clusterStatusMonitor blocks any MBean register on isMonitoring = false.
     resetClusterStatusMonitor();
+  }
+
+  /**
+   * Gate for the topology-change "processed" counter increment in {@link #handleEvent}. Counts
+   * only resource-pipeline runs that completed without failure -- the management-mode and
+   * task-framework pipelines run their own logic (the management registry only handles
+   * {@code LiveInstanceChange} and short-circuits the other four topology types as empty
+   * pipeline lists, which would otherwise leave {@code rebalanceFail=false} and falsely credit
+   * those events as processed). Package-private for direct unit testing.
+   */
+  static boolean shouldCountTopologyEventAsProcessed(boolean rebalanceFail,
+      BaseControllerDataProvider dataProvider) {
+    return !rebalanceFail && dataProvider instanceof ResourceControllerDataProvider;
   }
 
   private void updateContinuousRebalancedFailureCount(boolean isTaskFrameworkPipeline,
@@ -1295,7 +1305,7 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
     // Count topology-change events received from ZK before they get coalesced in the
     // cluster event queue. Counted once per logical event (not per pipeline fan-out into
     // DEFAULT/TASK queues) so the metric reflects ZK-driven churn, not internal queueing.
-    if (_isMonitoring && _clusterStatusMonitor != null) {
+    if (_isMonitoring) {
       _clusterStatusMonitor.incrementTopologyChangeEventReceived(eventType);
     }
     // No need for completed UUID, prefixed should be fine

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -970,6 +970,12 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
         _clusterStatusMonitor
             .updateClusterEventDuration(ClusterEventMonitor.PhaseName.TotalProcessed.name(),
                 _lastPipelineEndTimestamp - startTime);
+        // Count topology-change events that completed the resource pipeline successfully.
+        // Paired with the received counter incremented in pushToEventQueues; the gap
+        // between the two reflects coalescing in the cluster event queue under load.
+        if (!rebalanceFail) {
+          _clusterStatusMonitor.incrementTopologyChangeEventProcessed(event.getEventType());
+        }
       }
       sb.append(String.format("InQueue time for event: %s took: %s ms\n", event.getEventType(),
           startTime - enqueueTime));
@@ -1286,6 +1292,12 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
 
   private void pushToEventQueues(ClusterEventType eventType, NotificationContext changeContext,
       Map<String, Object> eventAttributes) {
+    // Count topology-change events received from ZK before they get coalesced in the
+    // cluster event queue. Counted once per logical event (not per pipeline fan-out into
+    // DEFAULT/TASK queues) so the metric reflects ZK-driven churn, not internal queueing.
+    if (_isMonitoring && _clusterStatusMonitor != null) {
+      _clusterStatusMonitor.incrementTopologyChangeEventReceived(eventType);
+    }
     // No need for completed UUID, prefixed should be fine
     String uid = UUID.randomUUID().toString().substring(0, 8);
     ClusterEvent event = new ClusterEvent(_clusterName, eventType,

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEventType.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ClusterEventType.java
@@ -19,6 +19,10 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
 public enum ClusterEventType {
   IdealStateChange,
   CurrentStateChange,
@@ -40,5 +44,32 @@ public enum ClusterEventType {
   ControllerChange,
   RetryRebalance,
   StateVerifier,
-  Unknown
+  Unknown;
+
+  // Subset of event types that change the cluster's logical topology -- the inputs
+  // that the rebalancer's placement decisions actually depend on. Kept in lockstep
+  // with the HelixConstants.ChangeType values recognized by
+  // ResourceChangeDetector.determinePropertyMapByType, so the metric counts the same
+  // events the rebalancer treats as topology-affecting.
+  private static final Set<ClusterEventType> TOPOLOGY_CHANGE_EVENT_TYPES =
+      Collections.unmodifiableSet(EnumSet.of(
+          IdealStateChange,
+          InstanceConfigChange,
+          ResourceConfigChange,
+          LiveInstanceChange,
+          ClusterConfigChange));
+
+  /**
+   * @return true iff this event type represents a topology change (config / instance / resource).
+   */
+  public boolean isTopologyChange() {
+    return TOPOLOGY_CHANGE_EVENT_TYPES.contains(this);
+  }
+
+  /**
+   * @return the set of event types classified as topology changes.
+   */
+  public static Set<ClusterEventType> topologyChangeEventTypes() {
+    return TOPOLOGY_CHANGE_EVENT_TYPES;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Sets;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
 import org.apache.helix.controller.stages.BestPossibleStateOutput;
+import org.apache.helix.controller.stages.ClusterEventType;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
@@ -104,6 +105,10 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   // phaseName -> eventMonitor
   protected final ConcurrentHashMap<String, ClusterEventMonitor> _clusterEventMonitorMap =
       new ConcurrentHashMap<>();
+
+  // ClusterEventType -> topologyChangeEventMonitor (one entry per topology event type)
+  protected final ConcurrentHashMap<ClusterEventType, TopologyChangeEventMonitor>
+      _topologyChangeEventMonitorMap = new ConcurrentHashMap<>();
 
   private CustomizedViewMonitor _customizedViewMonitor;
 
@@ -798,6 +803,10 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     LOG.info("Active ClusterStatusMonitor");
     try {
       register(this, getObjectName(clusterBeanName()));
+      // Register one MBean per topology-change event type up-front so dashboards see a
+      // stable schema (and OTel exporters discover all dimensions) before the first event
+      // of that type arrives. Each MBean starts at zero.
+      registerAllTopologyChangeEventMonitors();
     } catch (Exception e) {
       LOG.error("Fail to register ClusterStatusMonitor", e);
     }
@@ -811,6 +820,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       unregisterAllPerInstanceResources();
       unregister(getObjectName(clusterBeanName()));
       unregisterAllEventMonitors();
+      unregisterAllTopologyChangeEventMonitors();
       unregisterAllWorkflowsMonitor();
       unregisterAllJobs();
 
@@ -1052,6 +1062,61 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
         monitor.unregister();
       }
       _clusterEventMonitorMap.clear();
+    }
+  }
+
+  /**
+   * Increment the per-{@link ClusterEventType} received counter for topology-change events.
+   * No-op for non-topology event types so callers don't need to filter.
+   */
+  public void incrementTopologyChangeEventReceived(ClusterEventType eventType) {
+    if (eventType == null || !eventType.isTopologyChange()) {
+      return;
+    }
+    TopologyChangeEventMonitor monitor = _topologyChangeEventMonitorMap.get(eventType);
+    if (monitor != null) {
+      monitor.incrementReceived();
+    }
+  }
+
+  /**
+   * Increment the per-{@link ClusterEventType} processed counter for topology-change events.
+   * No-op for non-topology event types so callers don't need to filter.
+   */
+  public void incrementTopologyChangeEventProcessed(ClusterEventType eventType) {
+    if (eventType == null || !eventType.isTopologyChange()) {
+      return;
+    }
+    TopologyChangeEventMonitor monitor = _topologyChangeEventMonitorMap.get(eventType);
+    if (monitor != null) {
+      monitor.incrementProcessed();
+    }
+  }
+
+  private void registerAllTopologyChangeEventMonitors() {
+    synchronized (_topologyChangeEventMonitorMap) {
+      for (ClusterEventType eventType : ClusterEventType.topologyChangeEventTypes()) {
+        if (_topologyChangeEventMonitorMap.containsKey(eventType)) {
+          continue;
+        }
+        try {
+          TopologyChangeEventMonitor monitor = new TopologyChangeEventMonitor(this, eventType);
+          monitor.register();
+          _topologyChangeEventMonitorMap.put(eventType, monitor);
+        } catch (JMException e) {
+          LOG.error("Failed to register TopologyChangeEventMonitor for cluster {} eventType {}",
+              _clusterName, eventType, e);
+        }
+      }
+    }
+  }
+
+  private void unregisterAllTopologyChangeEventMonitors() {
+    synchronized (_topologyChangeEventMonitorMap) {
+      for (TopologyChangeEventMonitor monitor : _topologyChangeEventMonitorMap.values()) {
+        monitor.unregister();
+      }
+      _topologyChangeEventMonitorMap.clear();
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/TopologyChangeEventMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/TopologyChangeEventMonitor.java
@@ -21,6 +21,7 @@ package org.apache.helix.monitoring.mbeans;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.management.JMException;
 
 import org.apache.helix.controller.stages.ClusterEventType;
@@ -34,15 +35,19 @@ import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
  * <p>One instance is registered for each event type returned by
  * {@link ClusterEventType#topologyChangeEventTypes()}. Each instance exposes:
  * <ul>
- *   <li>{@code ReceivedCounter} — incremented when the controller enqueues an event of this
+ *   <li>{@code ReceivedCounter} -- incremented when the controller enqueues an event of this
  *       type onto the cluster event queue (post ZK-callback, pre coalescing).</li>
- *   <li>{@code ProcessedCounter} — incremented when the controller's resource pipeline
+ *   <li>{@code ProcessedCounter} -- incremented when the controller's resource pipeline
  *       finishes processing an event of this type without failure.</li>
  * </ul>
  *
  * <p>Received and processed counts diverge under load because the controller's event queue
  * coalesces events of the same {@link ClusterEventType}; that gap is the intended signal --
  * it reflects controller load and rebalance throughput against topology churn.
+ *
+ * <p>{@code pushToEventQueues} runs on independent ZK callback threads (one per
+ * controller listener), so increments must be safe under concurrent calls. Both
+ * counters are backed by {@link AtomicLong} for that reason.
  */
 public class TopologyChangeEventMonitor extends DynamicMBeanProvider {
 
@@ -50,13 +55,11 @@ public class TopologyChangeEventMonitor extends DynamicMBeanProvider {
   public static final String EVENT_NAME_KEY = "eventName";
   public static final String EVENT_TYPE_KEY = "eventType";
 
-  private static final String SENSOR_DN_KEY = "TopologyChangeEvent";
-
   private final ClusterStatusMonitor _clusterStatusMonitor;
   private final ClusterEventType _eventType;
 
-  private final SimpleDynamicMetric<Long> _receivedCounter;
-  private final SimpleDynamicMetric<Long> _processedCounter;
+  private final AtomicLongMetric _receivedCounter;
+  private final AtomicLongMetric _processedCounter;
 
   public TopologyChangeEventMonitor(ClusterStatusMonitor clusterStatusMonitor,
       ClusterEventType eventType) {
@@ -67,33 +70,25 @@ public class TopologyChangeEventMonitor extends DynamicMBeanProvider {
     }
     _clusterStatusMonitor = clusterStatusMonitor;
     _eventType = eventType;
-    _receivedCounter = new SimpleDynamicMetric<>("ReceivedCounter", 0L);
-    _processedCounter = new SimpleDynamicMetric<>("ProcessedCounter", 0L);
+    _receivedCounter = new AtomicLongMetric("ReceivedCounter");
+    _processedCounter = new AtomicLongMetric("ProcessedCounter");
   }
 
   public void incrementReceived() {
-    _receivedCounter.updateValue(_receivedCounter.getValue() + 1);
+    _receivedCounter.increment();
   }
 
   public void incrementProcessed() {
-    _processedCounter.updateValue(_processedCounter.getValue() + 1);
+    _processedCounter.increment();
   }
 
   public ClusterEventType getEventType() {
     return _eventType;
   }
 
-  long getReceivedCounter() {
-    return _receivedCounter.getValue();
-  }
-
-  long getProcessedCounter() {
-    return _processedCounter.getValue();
-  }
-
   @Override
   public String getSensorName() {
-    return String.format("%s.%s.%s", SENSOR_DN_KEY, _clusterStatusMonitor.getClusterName(),
+    return String.format("%s.%s.%s", EVENT_NAME, _clusterStatusMonitor.getClusterName(),
         _eventType.name());
   }
 
@@ -109,5 +104,41 @@ public class TopologyChangeEventMonitor extends DynamicMBeanProvider {
     attributeList.add(_processedCounter);
     doRegister(attributeList, _clusterStatusMonitor.getObjectName(getBeanName()));
     return this;
+  }
+
+  /**
+   * {@link SimpleDynamicMetric} variant whose value is backed by an {@link AtomicLong},
+   * making concurrent increments safe. The MBean attribute remains a {@code Long} so
+   * downstream JMX scrapers (and the LinkedIn OTel adaptor) consume it identically to
+   * the existing simple-Long counters in {@link ClusterEventMonitor}.
+   */
+  static final class AtomicLongMetric extends SimpleDynamicMetric<Long> {
+    private final AtomicLong _value = new AtomicLong(0L);
+
+    AtomicLongMetric(String metricName) {
+      super(metricName, 0L);
+    }
+
+    void increment() {
+      _value.incrementAndGet();
+    }
+
+    @Override
+    public Long getValue() {
+      return _value.get();
+    }
+
+    @Override
+    public Long getAttributeValue(String attributeName) {
+      if (!_metricName.equals(attributeName)) {
+        return null;
+      }
+      return _value.get();
+    }
+
+    @Override
+    public void updateValue(Long newValue) {
+      _value.set(newValue == null ? 0L : newValue);
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/TopologyChangeEventMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/TopologyChangeEventMonitor.java
@@ -1,0 +1,113 @@
+package org.apache.helix.monitoring.mbeans;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.management.JMException;
+
+import org.apache.helix.controller.stages.ClusterEventType;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMBeanProvider;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.DynamicMetric;
+import org.apache.helix.monitoring.mbeans.dynamicMBeans.SimpleDynamicMetric;
+
+/**
+ * Per-{@link ClusterEventType} counter MBean for topology-change events.
+ *
+ * <p>One instance is registered for each event type returned by
+ * {@link ClusterEventType#topologyChangeEventTypes()}. Each instance exposes:
+ * <ul>
+ *   <li>{@code ReceivedCounter} — incremented when the controller enqueues an event of this
+ *       type onto the cluster event queue (post ZK-callback, pre coalescing).</li>
+ *   <li>{@code ProcessedCounter} — incremented when the controller's resource pipeline
+ *       finishes processing an event of this type without failure.</li>
+ * </ul>
+ *
+ * <p>Received and processed counts diverge under load because the controller's event queue
+ * coalesces events of the same {@link ClusterEventType}; that gap is the intended signal --
+ * it reflects controller load and rebalance throughput against topology churn.
+ */
+public class TopologyChangeEventMonitor extends DynamicMBeanProvider {
+
+  public static final String EVENT_NAME = "TopologyChangeEvent";
+  public static final String EVENT_NAME_KEY = "eventName";
+  public static final String EVENT_TYPE_KEY = "eventType";
+
+  private static final String SENSOR_DN_KEY = "TopologyChangeEvent";
+
+  private final ClusterStatusMonitor _clusterStatusMonitor;
+  private final ClusterEventType _eventType;
+
+  private final SimpleDynamicMetric<Long> _receivedCounter;
+  private final SimpleDynamicMetric<Long> _processedCounter;
+
+  public TopologyChangeEventMonitor(ClusterStatusMonitor clusterStatusMonitor,
+      ClusterEventType eventType) {
+    if (!eventType.isTopologyChange()) {
+      throw new IllegalArgumentException(
+          "TopologyChangeEventMonitor only supports topology-change event types, got: "
+              + eventType);
+    }
+    _clusterStatusMonitor = clusterStatusMonitor;
+    _eventType = eventType;
+    _receivedCounter = new SimpleDynamicMetric<>("ReceivedCounter", 0L);
+    _processedCounter = new SimpleDynamicMetric<>("ProcessedCounter", 0L);
+  }
+
+  public void incrementReceived() {
+    _receivedCounter.updateValue(_receivedCounter.getValue() + 1);
+  }
+
+  public void incrementProcessed() {
+    _processedCounter.updateValue(_processedCounter.getValue() + 1);
+  }
+
+  public ClusterEventType getEventType() {
+    return _eventType;
+  }
+
+  long getReceivedCounter() {
+    return _receivedCounter.getValue();
+  }
+
+  long getProcessedCounter() {
+    return _processedCounter.getValue();
+  }
+
+  @Override
+  public String getSensorName() {
+    return String.format("%s.%s.%s", SENSOR_DN_KEY, _clusterStatusMonitor.getClusterName(),
+        _eventType.name());
+  }
+
+  private String getBeanName() {
+    return String.format("%s,%s=%s,%s=%s", _clusterStatusMonitor.clusterBeanName(),
+        EVENT_NAME_KEY, EVENT_NAME, EVENT_TYPE_KEY, _eventType.name());
+  }
+
+  @Override
+  public TopologyChangeEventMonitor register() throws JMException {
+    List<DynamicMetric<?, ?>> attributeList = new ArrayList<>();
+    attributeList.add(_receivedCounter);
+    attributeList.add(_processedCounter);
+    doRegister(attributeList, _clusterStatusMonitor.getObjectName(getBeanName()));
+    return this;
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/TestGenericHelixControllerTopologyMetricGate.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/TestGenericHelixControllerTopologyMetricGate.java
@@ -1,0 +1,74 @@
+package org.apache.helix.controller;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
+import org.apache.helix.controller.dataproviders.ManagementControllerDataProvider;
+import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
+import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link GenericHelixController#shouldCountTopologyEventAsProcessed}.
+ *
+ * <p>The processed counter on {@link org.apache.helix.monitoring.mbeans.TopologyChangeEventMonitor}
+ * must only advance for resource-pipeline runs that actually completed work. The management-mode
+ * pipeline only handles {@code LiveInstanceChange} -- for the other four topology event types its
+ * pipeline list is empty, the for-loop in {@code handleEvent} runs zero times, and
+ * {@code rebalanceFail} stays false. Without an explicit data-provider gate, those events would
+ * be falsely credited as "processed" while the controller is stuck in management mode -- the
+ * exact false-healthy signal PRR-30 was set up to detect. This test pins the gate to fail closed.
+ */
+public class TestGenericHelixControllerTopologyMetricGate {
+
+  @Test
+  public void resourceControllerSuccessIsCounted() {
+    BaseControllerDataProvider dp = Mockito.mock(ResourceControllerDataProvider.class);
+    Assert.assertTrue(GenericHelixController.shouldCountTopologyEventAsProcessed(false, dp));
+  }
+
+  @Test
+  public void resourceControllerFailureIsNotCounted() {
+    BaseControllerDataProvider dp = Mockito.mock(ResourceControllerDataProvider.class);
+    Assert.assertFalse(GenericHelixController.shouldCountTopologyEventAsProcessed(true, dp));
+  }
+
+  @Test
+  public void managementPipelineIsNotCounted() {
+    BaseControllerDataProvider dp = Mockito.mock(ManagementControllerDataProvider.class);
+    Assert.assertFalse(GenericHelixController.shouldCountTopologyEventAsProcessed(false, dp),
+        "Management-mode runs must not bump the processed counter -- otherwise dashboards "
+            + "would show received==processed while topology events sit unhandled.");
+  }
+
+  @Test
+  public void taskPipelineIsNotCounted() {
+    BaseControllerDataProvider dp = Mockito.mock(WorkflowControllerDataProvider.class);
+    Assert.assertFalse(GenericHelixController.shouldCountTopologyEventAsProcessed(false, dp));
+  }
+
+  @Test
+  public void unknownDataProviderIsNotCounted() {
+    BaseControllerDataProvider dp = Mockito.mock(BaseControllerDataProvider.class);
+    Assert.assertFalse(GenericHelixController.shouldCountTopologyEventAsProcessed(false, dp));
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestTopologyChangeEventMetric.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestTopologyChangeEventMetric.java
@@ -1,0 +1,187 @@
+package org.apache.helix.integration;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.management.ManagementFactory;
+import java.util.Date;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.TestHelper;
+import org.apache.helix.common.ZkTestBase;
+import org.apache.helix.controller.stages.ClusterEventType;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Drives a real controller through topology-change events and asserts the per-event-type
+ * counters on {@link org.apache.helix.monitoring.mbeans.TopologyChangeEventMonitor}
+ * actually advance via the JMX surface. Complements the pure-unit test
+ * {@code TestTopologyChangeEventMonitor} which exercises only the MBean wiring.
+ */
+public class TestTopologyChangeEventMetric extends ZkTestBase {
+
+  private static final int N_PARTICIPANTS = 2;
+  private static final int N_PARTITIONS = 4;
+  private static final int N_REPLICAS = 2;
+  private static final String RESOURCE = "TestDB";
+  private static final String NEW_RESOURCE = "TestDB2";
+  private static final int START_PORT = 12918;
+
+  @Test
+  public void testCountersAdvanceOnRealTopologyChanges() throws Exception {
+    String clusterName = TestHelper.getTestMethodName();
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+
+    TestHelper.setupCluster(clusterName, ZK_ADDR, START_PORT,
+        "localhost", RESOURCE,
+        1,                  // # resources
+        N_PARTITIONS,
+        N_PARTICIPANTS,
+        N_REPLICAS,
+        "MasterSlave",
+        true);              // do rebalance
+
+    MockParticipantManager[] participants = new MockParticipantManager[N_PARTICIPANTS];
+    for (int i = 0; i < N_PARTICIPANTS; i++) {
+      String instanceName = "localhost_" + (START_PORT + i);
+      participants[i] = new MockParticipantManager(ZK_ADDR, clusterName, instanceName);
+      participants[i].syncStart();
+    }
+
+    ClusterControllerManager controller =
+        new ClusterControllerManager(ZK_ADDR, clusterName, "controller_0");
+    controller.syncStart();
+
+    BestPossibleExternalViewVerifier verifier =
+        new BestPossibleExternalViewVerifier.Builder(clusterName).setZkClient(_gZkClient)
+            .setWaitTillVerify(TestHelper.DEFAULT_REBALANCE_PROCESSING_WAIT_TIME)
+            .build();
+    Assert.assertTrue(verifier.verifyByPolling(), "cluster did not converge after startup");
+
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+
+    // 1) Eager registration: all 5 topology-event MBeans should exist as soon as the
+    //    controller acquired leadership and called ClusterStatusMonitor.active().
+    for (ClusterEventType type : ClusterEventType.topologyChangeEventTypes()) {
+      ObjectName name = topologyBean(clusterName, type);
+      Assert.assertTrue(server.isRegistered(name),
+          "Expected MBean to be registered: " + name);
+    }
+
+    // 2) Cluster startup itself drives LiveInstanceChange and IdealStateChange events
+    //    through the controller pipeline. Both Received and Processed must move.
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.LiveInstanceChange,
+        "ReceivedCounter", 1);
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.LiveInstanceChange,
+        "ProcessedCounter", 1);
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.IdealStateChange,
+        "ReceivedCounter", 1);
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.IdealStateChange,
+        "ProcessedCounter", 1);
+
+    // 3) Trigger a fresh IdealStateChange by adding a second resource and verify the
+    //    IdealStateChange counter advances past the post-startup baseline.
+    long isReceivedBefore = getCounter(server, clusterName,
+        ClusterEventType.IdealStateChange, "ReceivedCounter");
+    long isProcessedBefore = getCounter(server, clusterName,
+        ClusterEventType.IdealStateChange, "ProcessedCounter");
+
+    HelixAdmin admin = new ZKHelixAdmin(_gZkClient);
+    _gSetupTool.addResourceToCluster(clusterName, NEW_RESOURCE, N_PARTITIONS, "MasterSlave");
+    _gSetupTool.rebalanceStorageCluster(clusterName, NEW_RESOURCE, N_REPLICAS);
+
+    Assert.assertTrue(verifier.verifyByPolling(), "cluster did not converge after add resource");
+
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.IdealStateChange,
+        "ReceivedCounter", isReceivedBefore + 1);
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.IdealStateChange,
+        "ProcessedCounter", isProcessedBefore + 1);
+
+    // 4) Trigger an InstanceConfigChange by disabling one participant and verify that
+    //    counter advances. Use a fresh JMX read because earlier checks may have raced
+    //    with other topology events that bumped this counter incidentally.
+    long icReceivedBefore = getCounter(server, clusterName,
+        ClusterEventType.InstanceConfigChange, "ReceivedCounter");
+    long icProcessedBefore = getCounter(server, clusterName,
+        ClusterEventType.InstanceConfigChange, "ProcessedCounter");
+
+    admin.enableInstance(clusterName, participants[0].getInstanceName(), false);
+    Assert.assertTrue(verifier.verifyByPolling(), "cluster did not converge after disable");
+
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.InstanceConfigChange,
+        "ReceivedCounter", icReceivedBefore + 1);
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.InstanceConfigChange,
+        "ProcessedCounter", icProcessedBefore + 1);
+
+    // Re-enable so cleanup proceeds cleanly.
+    admin.enableInstance(clusterName, participants[0].getInstanceName(), true);
+    Assert.assertTrue(verifier.verifyByPolling(), "cluster did not converge after re-enable");
+
+    // 5) Sanity: non-topology event types never get an MBean registered for them.
+    Assert.assertFalse(server.isRegistered(new ObjectName(
+            "ClusterStatus:cluster=" + clusterName
+                + ",eventName=TopologyChangeEvent,eventType=MessageChange")),
+        "MessageChange should not have a TopologyChangeEvent MBean");
+
+    // Cleanup
+    controller.syncStop();
+    for (MockParticipantManager p : participants) {
+      p.syncStop();
+    }
+    deleteCluster(clusterName);
+
+    System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
+  }
+
+  private static ObjectName topologyBean(String clusterName, ClusterEventType eventType)
+      throws Exception {
+    return new ObjectName("ClusterStatus:cluster=" + clusterName
+        + ",eventName=TopologyChangeEvent,eventType=" + eventType.name());
+  }
+
+  private static long getCounter(MBeanServer server, String clusterName,
+      ClusterEventType eventType, String attr) throws Exception {
+    Object value = server.getAttribute(topologyBean(clusterName, eventType), attr);
+    Assert.assertTrue(value instanceof Long,
+        "Expected Long for " + attr + ", got " + (value == null ? "null" : value.getClass()));
+    return (Long) value;
+  }
+
+  private static void awaitCounterAtLeast(MBeanServer server, String clusterName,
+      ClusterEventType eventType, String attr, long minValue) throws Exception {
+    boolean ok = TestHelper.verify(() -> {
+      try {
+        return getCounter(server, clusterName, eventType, attr) >= minValue;
+      } catch (Exception e) {
+        return false;
+      }
+    }, TestHelper.WAIT_DURATION);
+    long observed = getCounter(server, clusterName, eventType, attr);
+    Assert.assertTrue(ok,
+        String.format("Counter %s for %s did not reach >= %d (observed=%d)",
+            attr, eventType, minValue, observed));
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/integration/TestTopologyChangeEventMetric.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/TestTopologyChangeEventMetric.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
@@ -31,6 +32,8 @@ import org.apache.helix.controller.stages.ClusterEventType;
 import org.apache.helix.integration.manager.ClusterControllerManager;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.tools.ClusterVerifiers.BestPossibleExternalViewVerifier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -140,7 +143,43 @@ public class TestTopologyChangeEventMetric extends ZkTestBase {
     admin.enableInstance(clusterName, participants[0].getInstanceName(), true);
     Assert.assertTrue(verifier.verifyByPolling(), "cluster did not converge after re-enable");
 
-    // 5) Sanity: non-topology event types never get an MBean registered for them.
+    // 5) ResourceConfigChange -- write a ResourceConfig and verify the counter advances.
+    long rcReceivedBefore = getCounter(server, clusterName,
+        ClusterEventType.ResourceConfigChange, "ReceivedCounter");
+    long rcProcessedBefore = getCounter(server, clusterName,
+        ClusterEventType.ResourceConfigChange, "ProcessedCounter");
+
+    ConfigAccessor configAccessor = new ConfigAccessor(_gZkClient);
+    ResourceConfig resourceConfig = new ResourceConfig.Builder(RESOURCE + "0")
+        .setMonitorDisabled(false)
+        .build();
+    configAccessor.setResourceConfig(clusterName, RESOURCE + "0", resourceConfig);
+    Assert.assertTrue(verifier.verifyByPolling(),
+        "cluster did not converge after ResourceConfig write");
+
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.ResourceConfigChange,
+        "ReceivedCounter", rcReceivedBefore + 1);
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.ResourceConfigChange,
+        "ProcessedCounter", rcProcessedBefore + 1);
+
+    // 6) ClusterConfigChange -- toggle a cluster config and verify the counter advances.
+    long ccReceivedBefore = getCounter(server, clusterName,
+        ClusterEventType.ClusterConfigChange, "ReceivedCounter");
+    long ccProcessedBefore = getCounter(server, clusterName,
+        ClusterEventType.ClusterConfigChange, "ProcessedCounter");
+
+    ClusterConfig clusterConfig = configAccessor.getClusterConfig(clusterName);
+    clusterConfig.setRebalanceTimePeriod(60_000L);
+    configAccessor.setClusterConfig(clusterName, clusterConfig);
+    Assert.assertTrue(verifier.verifyByPolling(),
+        "cluster did not converge after ClusterConfig write");
+
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.ClusterConfigChange,
+        "ReceivedCounter", ccReceivedBefore + 1);
+    awaitCounterAtLeast(server, clusterName, ClusterEventType.ClusterConfigChange,
+        "ProcessedCounter", ccProcessedBefore + 1);
+
+    // 7) Sanity: non-topology event types never get an MBean registered for them.
     Assert.assertFalse(server.isRegistered(new ObjectName(
             "ClusterStatus:cluster=" + clusterName
                 + ",eventName=TopologyChangeEvent,eventType=MessageChange")),

--- a/helix-core/src/test/java/org/apache/helix/monitoring/TestTopologyChangeEventMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/TestTopologyChangeEventMonitor.java
@@ -1,0 +1,147 @@
+package org.apache.helix.monitoring;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+
+import org.apache.helix.controller.stages.ClusterEventType;
+import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
+import org.apache.helix.monitoring.mbeans.TopologyChangeEventMonitor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestTopologyChangeEventMonitor {
+
+  private static final String CLUSTER = "TopoMetricTestCluster";
+
+  @Test
+  public void testEagerRegistrationAndCounters() throws Exception {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(CLUSTER);
+    monitor.active();
+    try {
+      MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+
+      // 5 topology event types -> 5 MBeans registered eagerly at active().
+      Set<ObjectInstance> mbeans = server.queryMBeans(
+          new ObjectName(
+              "ClusterStatus:cluster=" + CLUSTER + ",eventName=TopologyChangeEvent,*"),
+          null);
+      Assert.assertEquals(mbeans.size(),
+          ClusterEventType.topologyChangeEventTypes().size(),
+          "Expected one MBean per topology-change event type");
+
+      // Every MBean has the expected attributes, all starting at zero.
+      for (ObjectInstance mbean : mbeans) {
+        ObjectName name = mbean.getObjectName();
+        Long received = (Long) server.getAttribute(name, "ReceivedCounter");
+        Long processed = (Long) server.getAttribute(name, "ProcessedCounter");
+        Assert.assertEquals(received, Long.valueOf(0L),
+            "ReceivedCounter should start at 0 for " + name);
+        Assert.assertEquals(processed, Long.valueOf(0L),
+            "ProcessedCounter should start at 0 for " + name);
+      }
+
+      // Increments only flow to the matching event type.
+      monitor.incrementTopologyChangeEventReceived(ClusterEventType.IdealStateChange);
+      monitor.incrementTopologyChangeEventReceived(ClusterEventType.IdealStateChange);
+      monitor.incrementTopologyChangeEventProcessed(ClusterEventType.IdealStateChange);
+
+      monitor.incrementTopologyChangeEventReceived(ClusterEventType.LiveInstanceChange);
+
+      ObjectName idealStateBean = topologyBean(ClusterEventType.IdealStateChange);
+      ObjectName liveInstanceBean = topologyBean(ClusterEventType.LiveInstanceChange);
+      ObjectName clusterConfigBean = topologyBean(ClusterEventType.ClusterConfigChange);
+
+      Assert.assertEquals(server.getAttribute(idealStateBean, "ReceivedCounter"), 2L);
+      Assert.assertEquals(server.getAttribute(idealStateBean, "ProcessedCounter"), 1L);
+      Assert.assertEquals(server.getAttribute(liveInstanceBean, "ReceivedCounter"), 1L);
+      Assert.assertEquals(server.getAttribute(liveInstanceBean, "ProcessedCounter"), 0L);
+      Assert.assertEquals(server.getAttribute(clusterConfigBean, "ReceivedCounter"), 0L);
+      Assert.assertEquals(server.getAttribute(clusterConfigBean, "ProcessedCounter"), 0L);
+
+      // Non-topology types are silently dropped.
+      monitor.incrementTopologyChangeEventReceived(ClusterEventType.MessageChange);
+      monitor.incrementTopologyChangeEventProcessed(ClusterEventType.CurrentStateChange);
+      monitor.incrementTopologyChangeEventReceived(null);
+      // No MBean ever appears for those types -- still only 5 topology MBeans.
+      mbeans = server.queryMBeans(
+          new ObjectName(
+              "ClusterStatus:cluster=" + CLUSTER + ",eventName=TopologyChangeEvent,*"),
+          null);
+      Assert.assertEquals(mbeans.size(),
+          ClusterEventType.topologyChangeEventTypes().size());
+
+      // SensorName is per-type so OTel exporters can uniquely key on it.
+      String sensor = (String) server.getAttribute(idealStateBean, "SensorName");
+      Assert.assertTrue(sensor.contains(CLUSTER),
+          "SensorName should include cluster: " + sensor);
+      Assert.assertTrue(sensor.contains(ClusterEventType.IdealStateChange.name()),
+          "SensorName should include event type: " + sensor);
+    } finally {
+      monitor.reset();
+
+      // After reset the topology MBeans should be unregistered.
+      MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+      Set<ObjectInstance> mbeans = server.queryMBeans(
+          new ObjectName(
+              "ClusterStatus:cluster=" + CLUSTER + ",eventName=TopologyChangeEvent,*"),
+          null);
+      Assert.assertEquals(mbeans.size(), 0,
+          "Topology MBeans should be unregistered after reset()");
+    }
+  }
+
+  @Test
+  public void testConstructorRejectsNonTopologyType() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(CLUSTER + "Reject");
+    try {
+      new TopologyChangeEventMonitor(monitor, ClusterEventType.MessageChange);
+      Assert.fail("Expected IllegalArgumentException for non-topology event type");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testTopologyChangeEventTypesCoverage() {
+    // Lock the topology set in the test so future enum additions are a conscious choice.
+    Set<ClusterEventType> expected = java.util.EnumSet.of(
+        ClusterEventType.IdealStateChange,
+        ClusterEventType.InstanceConfigChange,
+        ClusterEventType.ResourceConfigChange,
+        ClusterEventType.LiveInstanceChange,
+        ClusterEventType.ClusterConfigChange);
+    Assert.assertEquals(ClusterEventType.topologyChangeEventTypes(), expected);
+    for (ClusterEventType t : ClusterEventType.values()) {
+      Assert.assertEquals(t.isTopologyChange(), expected.contains(t),
+          "isTopologyChange mismatch for " + t);
+    }
+  }
+
+  private ObjectName topologyBean(ClusterEventType eventType) throws Exception {
+    return new ObjectName(
+        "ClusterStatus:cluster=" + CLUSTER
+            + ",eventName=TopologyChangeEvent,eventType=" + eventType.name());
+  }
+}


### PR DESCRIPTION
### Issues

- This PR is tracked by ACTIONITEM-18683 (LinkedIn-internal). It addresses the PRR-30 reviewer ask for a metric that surfaces total topology change event count and the count of events being processed by the Helix controller.

### Description

Adds per-`ClusterEventType` `ReceivedCounter` / `ProcessedCounter` MBean attributes under `ClusterStatus:eventName=TopologyChangeEvent` for the five event types the rebalancer treats as topology-affecting:

- `IdealStateChange`
- `InstanceConfigChange`
- `ResourceConfigChange`
- `LiveInstanceChange`
- `ClusterConfigChange`

The set mirrors the topology classification already used by `ResourceChangeDetector.determinePropertyMapByType`, so metric semantics line up with how the rebalancer itself defines a topology change.

`Received` is incremented in `GenericHelixController.pushToEventQueues` before the cluster event queue's dedup. `Processed` is incremented at the end of `handleEvent` on successful non-task pipeline runs. The gap between the two reflects coalescing under load -- the signal needed to correlate controller load with rebalance throughput.

Non-topology event types (`MessageChange`, `CurrentStateChange`, etc.) are filtered at the `ClusterStatusMonitor` boundary so callers stay simple. All five MBeans are registered eagerly in `active()` so dashboards and OTel scrapers see a stable schema before the first event of a given type arrives.

#### MBean shape

```
domain : ClusterStatus
keys   : cluster=<cluster>, eventName=TopologyChangeEvent, eventType=<one of 5>
attrs  : ReceivedCounter (Long), ProcessedCounter (Long), SensorName (String)
```

#### Files changed

- `controller/stages/ClusterEventType.java` -- adds `isTopologyChange()` predicate and `topologyChangeEventTypes()` set as the single source of truth for the filter.
- `monitoring/mbeans/TopologyChangeEventMonitor.java` (new) -- per-event-type MBean built on the existing `DynamicMBeanProvider` pattern (sibling of `ClusterEventMonitor`).
- `monitoring/mbeans/ClusterStatusMonitor.java` -- map of monitors, eager registration in `active()`, unregister in `reset()`, public `incrementTopologyChangeEvent{Received,Processed}` methods that no-op on non-topology types.
- `controller/GenericHelixController.java` -- two hook lines (Received in `pushToEventQueues`, Processed at end of `handleEvent`).

### Tests

The following tests are written for this issue:

- `TestTopologyChangeEventMonitor` (unit, 3 tests):
  - `testEagerRegistrationAndCounters` -- all 5 MBeans registered at `active()`, counters start at zero, increments route to the matching event type, non-topology types are silently dropped, MBeans unregistered on `reset()`.
  - `testConstructorRejectsNonTopologyType` -- monitor construction rejects non-topology `ClusterEventType` values.
  - `testTopologyChangeEventTypesCoverage` -- locks the topology set in tests so future enum additions are a conscious choice.
- `TestTopologyChangeEventMetric` (integration, 1 test): drives a real controller + ZK + 2 participants and asserts that:
  - All 5 topology MBeans are registered as soon as the controller becomes leader.
  - `LiveInstanceChange` and `IdealStateChange` Received/Processed counters move on cluster startup.
  - `IdealStateChange` counters advance past baseline when a new resource is added.
  - `InstanceConfigChange` counters advance past baseline when an instance is disabled.
  - `MessageChange` and other non-topology types never get a topology MBean registered.

The following is the result of running `mvn -pl helix-core test` against the new and adjacent monitor tests:

```
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```

Tests included: `TestTopologyChangeEventMonitor` (3), `TestTopologyChangeEventMetric` (1), `TestClusterStatusMonitor` (7), `TestClusterEventStatusMonitor` (1). No regressions in adjacent monitor tests.

### Changes that Break Backward Compatibility (Optional)

None. Purely additive: a new MBean class, new public methods on `ClusterStatusMonitor`, two new lines in `GenericHelixController`. No existing attributes, methods, or behaviors are changed.

### Documentation (Optional)

None for this PR. Internal follow-up will land an `OtelJmxAdaptor.SENSOR_DIMENSION_NAMES` entry so OTel labels read `Cluster.Name` / `Event.Name` / `Event.Type` instead of the raw lowercase ObjectName keys; metric works without it but with inconsistent label casing.

### Commits

Single commit, follows the standard guidelines (subject in imperative mood under 50 chars, body wraps at 72, explains what and why).

### Code Quality

Diff follows the existing `helix-style.xml` conventions. New code matches the established `_fieldName` underscore convention used throughout the surrounding `ClusterStatusMonitor` / `ClusterEventMonitor` / monitor MBean classes.