### PR TITLE
Add auto-logout on session expiry for helix-front

### DIFF
--- a/helix-front/server/controllers/d.ts
+++ b/helix-front/server/controllers/d.ts
@@ -11,4 +11,5 @@ interface HelixSession {
   identityToken: any;
   username: string;
   isAdmin: boolean;
+  destroy(callback?: (err?: any) => void): void;
 }

--- a/helix-front/server/controllers/helix.ts
+++ b/helix-front/server/controllers/helix.ts
@@ -46,6 +46,15 @@ export class HelixCtrl {
       return;
     }
 
+    if (
+      IDENTITY_TOKEN_SOURCE &&
+      method !== 'GET' &&
+      !res.locals.cookie?.['helixui_identity.token']
+    ) {
+      res.status(401).send('Session expired. Please log in again.');
+      return;
+    }
+
     let apiPrefix: string | null = null;
     if (HELIX_ENDPOINTS[group]) {
       HELIX_ENDPOINTS[group].forEach((section) => {

--- a/helix-front/server/controllers/user.ts
+++ b/helix-front/server/controllers/user.ts
@@ -41,8 +41,9 @@ export class UserCtrl {
 
   protected logout(req: HelixRequest, res: Response) {
     res.clearCookie('helixui_identity.token');
-    req.session = null;
-    res.json(true);
+    req.session.destroy(() => {
+      res.json(true);
+    });
   }
 
   //

--- a/helix-front/server/controllers/user.ts
+++ b/helix-front/server/controllers/user.ts
@@ -40,8 +40,13 @@ export class UserCtrl {
   }
 
   protected logout(req: HelixRequest, res: Response) {
-    res.clearCookie('helixui_identity.token');
-    req.session.destroy(() => {
+    req.session.destroy((err) => {
+      if (err) {
+        res.status(500).json({ error: 'Logout failed' });
+        return;
+      }
+      res.clearCookie('connect.sid', { path: '/' });
+      res.clearCookie('helixui_identity.token');
       res.json(true);
     });
   }

--- a/helix-front/server/controllers/user.ts
+++ b/helix-front/server/controllers/user.ts
@@ -34,8 +34,15 @@ export class UserCtrl {
     // uncomment the following line to use customized login
     // router.route('/user/authorize').get(this.authorize);
     router.route('/user/login').post(this.login.bind(this));
+    router.route('/user/logout').post(this.logout);
     router.route('/user/current').get(this.current);
     router.route('/user/can').get(this.can);
+  }
+
+  protected logout(req: HelixRequest, res: Response) {
+    res.clearCookie('helixui_identity.token');
+    req.session = null;
+    res.json(true);
   }
 
   //

--- a/helix-front/src/app/app.component.ts
+++ b/helix-front/src/app/app.component.ts
@@ -27,6 +27,7 @@ export class AppComponent implements OnInit {
   footerEnabled = true;
   isLoading = true;
   currentUser: any;
+  private expiryCheckHandle?: ReturnType<typeof setInterval>;
 
   constructor(
     // protected angulartics2Piwik: Angulartics2Piwik,
@@ -70,13 +71,14 @@ export class AppComponent implements OnInit {
   }
 
   private watchTokenExpiry() {
+    if (this.expiryCheckHandle) clearInterval(this.expiryCheckHandle);
     if (!this.hasIdentityToken()) return;
-    const check = setInterval(() => {
+    this.expiryCheckHandle = setInterval(() => {
       if (
         !this.hasIdentityToken() &&
         this.dialog.openDialogs.length === 0
       ) {
-        clearInterval(check);
+        clearInterval(this.expiryCheckHandle!);
         this.dialog
           .open(AlertDialogComponent, {
             data: {

--- a/helix-front/src/app/app.component.ts
+++ b/helix-front/src/app/app.component.ts
@@ -73,7 +73,11 @@ export class AppComponent implements OnInit {
   private watchTokenExpiry() {
     if (!this.hasIdentityToken()) return;
     const check = setInterval(() => {
-      if (!this.hasIdentityToken() && !this.sessionExpiredShown) {
+      if (
+        !this.hasIdentityToken() &&
+        !this.sessionExpiredShown &&
+        this.dialog.openDialogs.length === 0
+      ) {
         this.sessionExpiredShown = true;
         clearInterval(check);
         this.dialog

--- a/helix-front/src/app/app.component.ts
+++ b/helix-front/src/app/app.component.ts
@@ -13,6 +13,7 @@ import { MatDialog } from '@angular/material/dialog';
 
 import { UserService } from './core/user.service';
 import { InputDialogComponent } from './shared/dialog/input-dialog/input-dialog.component';
+import { AlertDialogComponent } from './shared/dialog/alert-dialog/alert-dialog.component';
 import { HelperService } from './shared/helper.service';
 
 @Component({
@@ -26,6 +27,7 @@ export class AppComponent implements OnInit {
   footerEnabled = true;
   isLoading = true;
   currentUser: any;
+  private sessionExpiredShown = false;
 
   constructor(
     // protected angulartics2Piwik: Angulartics2Piwik,
@@ -60,6 +62,36 @@ export class AppComponent implements OnInit {
         this.headerEnabled = this.footerEnabled = false;
       }
     });
+
+    this.watchTokenExpiry();
+  }
+
+  private hasIdentityToken(): boolean {
+    return document.cookie.includes('helixui_identity.token');
+  }
+
+  private watchTokenExpiry() {
+    if (!this.hasIdentityToken()) return;
+    const check = setInterval(() => {
+      if (!this.hasIdentityToken() && !this.sessionExpiredShown) {
+        this.sessionExpiredShown = true;
+        clearInterval(check);
+        this.dialog
+          .open(AlertDialogComponent, {
+            data: {
+              title: 'Session Expired',
+              message:
+                'Your session has expired. Please sign in again to continue.',
+            },
+          })
+          .afterClosed()
+          .subscribe(() => {
+            fetch('/api/user/logout', { method: 'POST' }).finally(() =>
+              window.location.reload()
+            );
+          });
+      }
+    }, 30000);
   }
 
   login() {

--- a/helix-front/src/app/app.component.ts
+++ b/helix-front/src/app/app.component.ts
@@ -27,7 +27,6 @@ export class AppComponent implements OnInit {
   footerEnabled = true;
   isLoading = true;
   currentUser: any;
-  private sessionExpiredShown = false;
 
   constructor(
     // protected angulartics2Piwik: Angulartics2Piwik,
@@ -67,7 +66,7 @@ export class AppComponent implements OnInit {
   }
 
   private hasIdentityToken(): boolean {
-    return document.cookie.includes('helixui_identity.token');
+    return document.cookie.split(';').some(c => c.trim().startsWith('helixui_identity.token='));
   }
 
   private watchTokenExpiry() {
@@ -75,10 +74,8 @@ export class AppComponent implements OnInit {
     const check = setInterval(() => {
       if (
         !this.hasIdentityToken() &&
-        !this.sessionExpiredShown &&
         this.dialog.openDialogs.length === 0
       ) {
-        this.sessionExpiredShown = true;
         clearInterval(check);
         this.dialog
           .open(AlertDialogComponent, {
@@ -130,6 +127,7 @@ export class AppComponent implements OnInit {
                   }
 
                   this.currentUser = this.service.getCurrentUser();
+                  this.watchTokenExpiry();
                 },
                 (error) => {
                   // since rest API simply throws 404 instead of empty config when config is not initialized yet

--- a/helix-front/src/app/app.module.ts
+++ b/helix-front/src/app/app.module.ts
@@ -1,7 +1,8 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { AuthInterceptor } from './core/auth.interceptor';
 
 // import { Angulartics2Module } from 'angulartics2';
 // import { Angulartics2Piwik } from 'angulartics2/piwik';
@@ -39,7 +40,9 @@ import { DashboardModule } from './dashboard/dashboard.module';
     ChooserModule,
     DashboardModule,
   ],
-  providers: [],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/helix-front/src/app/core/auth.interceptor.ts
+++ b/helix-front/src/app/core/auth.interceptor.ts
@@ -6,13 +6,14 @@ import {
   HttpEvent,
   HttpErrorResponse,
 } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
+import { Observable, EMPTY } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatDialog } from '@angular/material/dialog';
+import { AlertDialogComponent } from '../shared/dialog/alert-dialog/alert-dialog.component';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  constructor(private snackBar: MatSnackBar) {}
+  constructor(private dialog: MatDialog) {}
 
   intercept(
     req: HttpRequest<any>,
@@ -21,14 +22,25 @@ export class AuthInterceptor implements HttpInterceptor {
     return next.handle(req).pipe(
       catchError((error: HttpErrorResponse) => {
         if (error.status === 401) {
-          this.snackBar
-            .open('Session expired. Please sign in again.', 'Sign In', {
-              duration: 10000,
+          this.dialog
+            .open(AlertDialogComponent, {
+              data: {
+                title: 'Session Expired',
+                message:
+                  'Your session has expired. Please sign in again to continue.',
+              },
             })
-            .onAction()
-            .subscribe(() => window.location.reload());
+            .afterClosed()
+            .subscribe(() => {
+              fetch('/api/user/logout', { method: 'POST' }).finally(() =>
+                window.location.reload()
+              );
+            });
+          return EMPTY;
         }
-        return throwError(error);
+        return new Observable<HttpEvent<any>>((subscriber) =>
+          subscriber.error(error)
+        );
       })
     );
   }

--- a/helix-front/src/app/core/auth.interceptor.ts
+++ b/helix-front/src/app/core/auth.interceptor.ts
@@ -13,18 +13,19 @@ import { AlertDialogComponent } from '../shared/dialog/alert-dialog/alert-dialog
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  private sessionExpiredShown = false;
-
   constructor(private dialog: MatDialog) {}
 
   intercept(
     req: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
+    if (req.url.includes('/api/user/login') || req.url.includes('/api/user/logout')) {
+      return next.handle(req);
+    }
+
     return next.handle(req).pipe(
       catchError((error: HttpErrorResponse) => {
-        if (error.status === 401 && !this.sessionExpiredShown) {
-          this.sessionExpiredShown = true;
+        if (error.status === 401 && this.dialog.openDialogs.length === 0) {
           this.dialog
             .open(AlertDialogComponent, {
               data: {

--- a/helix-front/src/app/core/auth.interceptor.ts
+++ b/helix-front/src/app/core/auth.interceptor.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpInterceptor,
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private snackBar: MatSnackBar) {}
+
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 401) {
+          this.snackBar
+            .open('Session expired. Please sign in again.', 'Sign In', {
+              duration: 10000,
+            })
+            .onAction()
+            .subscribe(() => window.location.reload());
+        }
+        return throwError(error);
+      })
+    );
+  }
+}

--- a/helix-front/src/app/core/auth.interceptor.ts
+++ b/helix-front/src/app/core/auth.interceptor.ts
@@ -6,13 +6,15 @@ import {
   HttpEvent,
   HttpErrorResponse,
 } from '@angular/common/http';
-import { Observable, EMPTY } from 'rxjs';
+import { Observable, EMPTY, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { AlertDialogComponent } from '../shared/dialog/alert-dialog/alert-dialog.component';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
+  private sessionExpiredShown = false;
+
   constructor(private dialog: MatDialog) {}
 
   intercept(
@@ -21,7 +23,8 @@ export class AuthInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(
       catchError((error: HttpErrorResponse) => {
-        if (error.status === 401) {
+        if (error.status === 401 && !this.sessionExpiredShown) {
+          this.sessionExpiredShown = true;
           this.dialog
             .open(AlertDialogComponent, {
               data: {
@@ -36,11 +39,11 @@ export class AuthInterceptor implements HttpInterceptor {
                 window.location.reload()
               );
             });
+        }
+        if (error.status === 401) {
           return EMPTY;
         }
-        return new Observable<HttpEvent<any>>((subscriber) =>
-          subscriber.error(error)
-        );
+        return throwError(error);
       })
     );
   }


### PR DESCRIPTION
## Summary
When a user's identity token expires, helix-front currently shows cryptic error messages (e.g., "403 OK") with no indication that re-login is needed. The user appears logged in (username still shown) but all write operations fail silently. This was reported in [#incident-11807](https://grid-linkedin-randd.enterprise.slack.com/archives/C0B1Z2VQML7) [SEV-2] and in-person chat.
<img width="876" height="255" alt="Screenshot 2026-05-19 at 2 09 23 PM" src="https://github.com/user-attachments/assets/7a125390-8050-416c-bc0f-28920279670f" />

This PR adds both proactive and reactive session expiry handling:

- **Proactive detection**: Polls for the `helixui_identity.token` cookie every 30 seconds. When the cookie disappears (token expired), immediately shows a "Session Expired" dialog - even if the user is idle.
- **Reactive detection**: HTTP interceptor catches 401 responses on all API calls and shows the same dialog
- **Server-side guard**: Returns 401 when identity token cookie is missing on write requests (instead of forwarding a stale/empty token to the Helix REST API)
<img width="1726" height="992" alt="Screenshot 2026-05-19 at 12 57 45 PM" src="https://github.com/user-attachments/assets/89f1500b-ba76-48f5-bf22-22c1f1b92ced" />

- **Clean logout**: On dialog close, calls `/api/user/logout` to destroy the server session + clear cookies, then reloads the page so the UI reflects logged-out state
- **Logout endpoint**: Added `/api/user/logout` server route

### Before vs After
| Before | After |
|--------|-------|
| User sees cryptic "403 OK" error | User sees clear "Session Expired" dialog |
| User still appears logged in | User is logged out and shown "Sign In" |
| No guidance on what to do | Dialog prompts re-login, auto-logs out on close |

## Testing Done

https://github.com/user-attachments/assets/f9e64246-6425-4e87-a021-be1c349ab6d4


https://github.com/user-attachments/assets/4ba2a0e9-751a-45a3-b4ee-8b6db86dc453


1. Started helix-front locally with mock mode (mock Helix REST + mock LDAP login)
2. Logged in as `gkabra` with identity token cookie set to expire in 1 minute
3. Navigated to TestCluster > Configuration tab
4. **Proactive test**: Waited ~1 minute without any action. "Session Expired" dialog appeared automatically after cookie expired
5. **Reactive test**: Tried editing a config field after token expired. "Session Expired" dialog appeared
6. Closed dialog -> logged out -> page reloaded -> showed "Sign In" button (fully logged out)

## Files changed
| File | Change |
|------|--------|
| `src/app/core/auth.interceptor.ts` | **New** - HTTP interceptor: catches 401, shows "Session Expired" dialog, calls logout on close |
| `src/app/app.module.ts` | Register interceptor via `HTTP_INTERCEPTORS` |
| `src/app/app.component.ts` | Proactive token cookie watch (30s poll interval) |
| `server/controllers/helix.ts` | Return 401 when identity token missing on write requests |
| `server/controllers/user.ts` | Add `/api/user/logout` endpoint to clear session + cookies |