### PR TITLE
Classify WAGED rebalance failures by FailureCategory; enrich logs and exception messages

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixRebalanceException.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixRebalanceException.java
@@ -33,19 +33,80 @@ public class HelixRebalanceException extends Exception {
     UNKNOWN_FAILURE
   }
 
+  /**
+   * Fine-grained classification of a rebalance failure. Independent of {@link Type}: callers
+   * surfacing alerts route on category, while internal control-flow (e.g. fallback decisions)
+   * still keys on {@link Type}.
+   *
+   * Each category carries an {@code isCustomerActionable} flag indicating whether the failure
+   * stems from cluster/resource configuration the customer controls (true) or from internal
+   * Helix infrastructure such as the metadata store or algorithm engine (false).
+   */
+  public enum FailureCategory {
+    // Customer-actionable: customer must adjust cluster/resource configuration.
+    CAPACITY_DEFICIT(true),
+    NO_CANDIDATE_NODE(true),
+    INVALID_RESOURCE_CONFIG(true),
+    INVALID_CLUSTER_CONFIG(true),
+
+    // Helix-team-owned: investigate the controller, metadata store, or algorithm.
+    METADATA_STORE_IO(false),
+    ALGORITHM_INTERNAL(false),
+    ASYNC_EXECUTION(false),
+    UNKNOWN(false);
+
+    private final boolean _customerActionable;
+
+    FailureCategory(boolean customerActionable) {
+      _customerActionable = customerActionable;
+    }
+
+    public boolean isCustomerActionable() {
+      return _customerActionable;
+    }
+  }
+
   private final Type _type;
+  private final FailureCategory _category;
 
   public HelixRebalanceException(String message, Type type, Throwable cause) {
-    super(String.format("%s Failure Type: %s", message, type.name()), cause);
-    _type = type;
+    this(message, type, FailureCategory.UNKNOWN, cause);
   }
 
   public HelixRebalanceException(String message, Type type) {
-    super(String.format("%s Failure Type: %s", message, type.name()));
+    this(message, type, FailureCategory.UNKNOWN);
+  }
+
+  public HelixRebalanceException(String message, Type type, FailureCategory category) {
+    super(buildMessage(message, type, category));
     _type = type;
+    _category = category;
+  }
+
+  public HelixRebalanceException(String message, Type type, FailureCategory category,
+      Throwable cause) {
+    super(buildMessage(message, type, category), cause);
+    _type = type;
+    _category = category;
   }
 
   public Type getFailureType() {
     return _type;
+  }
+
+  public FailureCategory getFailureCategory() {
+    return _category;
+  }
+
+  public boolean isCustomerActionable() {
+    return _category.isCustomerActionable();
+  }
+
+  private static String buildMessage(String message, Type type, FailureCategory category) {
+    // Preserve the historical "<msg> Failure Type: X" format when no category is supplied.
+    if (category == FailureCategory.UNKNOWN) {
+      return String.format("%s Failure Type: %s", message, type.name());
+    }
+    return String.format("%s Failure Type: %s Category: %s", message, type.name(), category.name());
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/AssignmentManager.java
@@ -60,7 +60,8 @@ class AssignmentManager {
       } catch (Exception ex) {
         throw new HelixRebalanceException(
             "Failed to get the current baseline assignment because of unexpected error.",
-            HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
+            HelixRebalanceException.Type.INVALID_REBALANCER_STATUS,
+            HelixRebalanceException.FailureCategory.METADATA_STORE_IO, ex);
       }
     }
     currentBaseline.keySet().retainAll(resources);
@@ -97,7 +98,8 @@ class AssignmentManager {
       } catch (Exception ex) {
         throw new HelixRebalanceException(
             "Failed to get the current best possible assignment because of unexpected error.",
-            HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
+            HelixRebalanceException.Type.INVALID_REBALANCER_STATUS,
+            HelixRebalanceException.FailureCategory.METADATA_STORE_IO, ex);
       }
     }
     currentBestAssignment.keySet().retainAll(resources);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.changedetector.ResourceChangeDetector;
@@ -76,6 +77,9 @@ class GlobalRebalanceRunner implements AutoCloseable {
   private final CountMetric _rebalanceFailureCount;
 
   private boolean _asyncGlobalRebalanceEnabled;
+  // Captures the original exception thrown inside the executor task so we can preserve its
+  // FailureCategory when re-throwing on the synchronous path. Reset before each submit.
+  private final AtomicReference<HelixRebalanceException> _lastAsyncFailure = new AtomicReference<>();
 
   public GlobalRebalanceRunner(AssignmentManager assignmentManager,
       AssignmentMetadataStore assignmentMetadataStore,
@@ -116,6 +120,7 @@ class GlobalRebalanceRunner implements AutoCloseable {
 
     if (clusterChanges.keySet().stream().anyMatch(GLOBAL_REBALANCE_REQUIRED_CHANGE_TYPES::contains)) {
       final boolean waitForGlobalRebalance = !_asyncGlobalRebalanceEnabled;
+      _lastAsyncFailure.set(null);
       // Calculate the Baseline assignment for global rebalance.
       Future<Boolean> result = _baselineCalculateExecutor.submit(() -> {
         try {
@@ -125,10 +130,15 @@ class GlobalRebalanceRunner implements AutoCloseable {
           doGlobalRebalance(clusterData, resourceMap, allAssignableInstances, algorithm,
               currentStateOutput, !waitForGlobalRebalance, clusterChanges);
         } catch (HelixRebalanceException e) {
+          // Capture the original exception so the synchronous caller can preserve the
+          // FailureCategory when re-throwing. The Type is intentionally NOT preserved on the
+          // re-throw to keep WagedRebalancer.computeNewIdealStates' fallback decision unchanged.
+          _lastAsyncFailure.set(e);
           if (_asyncGlobalRebalanceEnabled) {
             _rebalanceFailureCount.increment(1L);
           }
-          LOG.error("Failed to calculate baseline assignment!", e);
+          LOG.error("Failed to calculate baseline assignment! category={}",
+              e.getFailureCategory(), e);
           return false;
         }
         return true;
@@ -136,12 +146,20 @@ class GlobalRebalanceRunner implements AutoCloseable {
       if (waitForGlobalRebalance) {
         try {
           if (!result.get()) {
+            // Preserve the original FailureCategory for downstream attribution, but
+            // intentionally collapse Type to FAILED_TO_CALCULATE -- this matches the
+            // pre-FailureCategory behavior so the downstream fallback decision is unchanged.
+            HelixRebalanceException original = _lastAsyncFailure.get();
+            HelixRebalanceException.FailureCategory category = original != null
+                ? original.getFailureCategory()
+                : HelixRebalanceException.FailureCategory.ASYNC_EXECUTION;
             throw new HelixRebalanceException("Failed to calculate for the new Baseline.",
-                HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+                HelixRebalanceException.Type.FAILED_TO_CALCULATE, category, original);
           }
         } catch (InterruptedException | ExecutionException e) {
           throw new HelixRebalanceException("Failed to execute new Baseline calculation.",
-              HelixRebalanceException.Type.FAILED_TO_CALCULATE, e);
+              HelixRebalanceException.Type.FAILED_TO_CALCULATE,
+              HelixRebalanceException.FailureCategory.ASYNC_EXECUTION, e);
         }
       }
     }
@@ -173,7 +191,8 @@ class GlobalRebalanceRunner implements AutoCloseable {
           allAssignableInstances, clusterChanges, currentBaseline);
     } catch (Exception ex) {
       throw new HelixRebalanceException("Failed to generate cluster model for global rebalance.",
-          HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, ex);
+          HelixRebalanceException.Type.INVALID_CLUSTER_STATUS,
+          HelixRebalanceException.FailureCategory.INVALID_CLUSTER_CONFIG, ex);
     }
 
     Map<String, ResourceAssignment> newBaseline = WagedRebalanceUtil.calculateAssignment(clusterModel, algorithm);
@@ -187,7 +206,8 @@ class GlobalRebalanceRunner implements AutoCloseable {
         _writeLatency.endMeasuringLatency();
       } catch (Exception ex) {
         throw new HelixRebalanceException("Failed to persist the new baseline assignment.",
-            HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
+            HelixRebalanceException.Type.INVALID_REBALANCER_STATUS,
+            HelixRebalanceException.FailureCategory.METADATA_STORE_IO, ex);
       }
     } else {
       LOG.debug("Assignment Metadata Store is null. Skip persisting the baseline assignment.");

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/PartialRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/PartialRebalanceRunner.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.util.WagedRebalanceUtil;
@@ -65,6 +66,9 @@ class PartialRebalanceRunner implements AutoCloseable {
 
   private boolean _asyncPartialRebalanceEnabled;
   private Future<Boolean> _asyncPartialRebalanceResult;
+  // Captures the original exception thrown inside the executor task so we can preserve its
+  // FailureCategory when re-throwing on the synchronous path. Reset before each submit.
+  private final AtomicReference<HelixRebalanceException> _lastAsyncFailure = new AtomicReference<>();
 
   public PartialRebalanceRunner(AssignmentManager assignmentManager,
       AssignmentMetadataStore assignmentMetadataStore,
@@ -99,15 +103,21 @@ class PartialRebalanceRunner implements AutoCloseable {
       return;
     }
 
+    _lastAsyncFailure.set(null);
     _asyncPartialRebalanceResult = _bestPossibleCalculateExecutor.submit(() -> {
       try {
         doPartialRebalance(clusterData, resourceMap, activeNodes, algorithm,
             currentStateOutput);
       } catch (HelixRebalanceException e) {
+        // Capture the original exception so the synchronous caller can preserve the
+        // FailureCategory when re-throwing. The Type is intentionally NOT preserved on the
+        // re-throw to keep WagedRebalancer.computeNewIdealStates' fallback decision unchanged.
+        _lastAsyncFailure.set(e);
         if (_asyncPartialRebalanceEnabled) {
           _rebalanceFailureCount.increment(1L);
         }
-        LOG.error("Failed to calculate best possible assignment!", e);
+        LOG.error("Failed to calculate best possible assignment! category={}",
+            e.getFailureCategory(), e);
         return false;
       }
       return true;
@@ -115,12 +125,20 @@ class PartialRebalanceRunner implements AutoCloseable {
     if (!_asyncPartialRebalanceEnabled) {
       try {
         if (!_asyncPartialRebalanceResult.get()) {
+          // Preserve the original FailureCategory for downstream attribution, but intentionally
+          // collapse Type to FAILED_TO_CALCULATE -- this matches the pre-FailureCategory
+          // behavior so WagedRebalancer.computeNewIdealStates' fallback decision is unchanged.
+          HelixRebalanceException original = _lastAsyncFailure.get();
+          HelixRebalanceException.FailureCategory category = original != null
+              ? original.getFailureCategory()
+              : HelixRebalanceException.FailureCategory.ASYNC_EXECUTION;
           throw new HelixRebalanceException("Failed to calculate for the new best possible.",
-              HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+              HelixRebalanceException.Type.FAILED_TO_CALCULATE, category, original);
         }
       } catch (InterruptedException | ExecutionException e) {
         throw new HelixRebalanceException("Failed to execute new best possible calculation.",
-            HelixRebalanceException.Type.FAILED_TO_CALCULATE, e);
+            HelixRebalanceException.Type.FAILED_TO_CALCULATE,
+            HelixRebalanceException.FailureCategory.ASYNC_EXECUTION, e);
       }
     }
   }
@@ -159,7 +177,8 @@ class PartialRebalanceRunner implements AutoCloseable {
               currentBaseline, currentBestPossibleAssignment);
     } catch (Exception ex) {
       throw new HelixRebalanceException("Failed to generate cluster model for partial rebalance.",
-          HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, ex);
+          HelixRebalanceException.Type.INVALID_CLUSTER_STATUS,
+          HelixRebalanceException.FailureCategory.INVALID_CLUSTER_CONFIG, ex);
     }
     Map<String, ResourceAssignment> newAssignment = WagedRebalanceUtil.calculateAssignment(clusterModel, algorithm);
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -248,7 +248,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       newIdealStates = computeBestPossibleStates(clusterData, resourceMap, currentStateOutput,
           _rebalanceAlgorithm);
     } catch (HelixRebalanceException ex) {
-      LOG.error("Failed to calculate the new assignments.", ex);
+      LOG.error("Failed to calculate the new assignments. category={} customerActionable={}",
+          ex.getFailureCategory(), ex.isCustomerActionable(), ex);
       // Record the failure in metrics.
       _rebalanceFailureCount.increment(1L);
 
@@ -261,7 +262,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
         // return the previously calculated assignment.
         LOG.warn(
             "Returning the last known-good best possible assignment from metadata store due to "
-                + "rebalance failure of type: {}", failureType);
+                + "rebalance failure of type: {} category: {}", failureType, ex.getFailureCategory());
         // Note that don't return an assignment based on the current state if there is no previously
         // calculated result in this fallback logic.
         Map<String, ResourceAssignment> assignmentRecord =
@@ -368,7 +369,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       } catch (Exception ex) {
         throw new HelixRebalanceException(
             "Failed to calculate the new IdealState for resource: " + resourceName,
-            HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, ex);
+            HelixRebalanceException.Type.INVALID_CLUSTER_STATUS,
+            HelixRebalanceException.FailureCategory.INVALID_CLUSTER_CONFIG, ex);
       }
     }
     return finalIdealStateMap;
@@ -425,7 +427,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     } catch (Exception e) {
       LOG.error("Failed to compute for delayed rebalance overwrites in cluster {}", clusterData.getClusterName());
       throw new HelixRebalanceException("Failed to compute for delayed rebalance overwrites in cluster "
-          + clusterData.getClusterConfig(), HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, e);
+          + clusterData.getClusterConfig(), HelixRebalanceException.Type.INVALID_CLUSTER_STATUS,
+          HelixRebalanceException.FailureCategory.INVALID_CLUSTER_CONFIG, e);
     } finally {
       _rebalanceOverwriteLatency.endMeasuringLatency();
     }
@@ -481,7 +484,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
                 currentBestPossibleAssignment);
       } catch (Exception ex) {
         throw new HelixRebalanceException("Failed to generate cluster model for emergency rebalance.",
-            HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, ex);
+            HelixRebalanceException.Type.INVALID_CLUSTER_STATUS,
+            HelixRebalanceException.FailureCategory.INVALID_CLUSTER_CONFIG, ex);
       }
       newAssignment = WagedRebalanceUtil.calculateAssignment(clusterModel, algorithm);
     } else {
@@ -549,7 +553,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     if (!nonCompatibleResources.isEmpty()) {
       throw new HelixRebalanceException(String.format(
           "Input contains invalid resource(s) that cannot be rebalanced by the WAGED rebalancer. %s",
-          nonCompatibleResources.toString()), HelixRebalanceException.Type.INVALID_INPUT);
+          nonCompatibleResources.toString()), HelixRebalanceException.Type.INVALID_INPUT,
+          HelixRebalanceException.FailureCategory.INVALID_RESOURCE_CONFIG);
     }
   }
 
@@ -582,7 +587,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
         _writeLatency.endMeasuringLatency();
       } catch (Exception ex) {
         throw new HelixRebalanceException("Failed to persist the new best possible assignment.",
-            HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, ex);
+            HelixRebalanceException.Type.INVALID_REBALANCER_STATUS,
+            HelixRebalanceException.FailureCategory.METADATA_STORE_IO, ex);
       }
     } else {
       LOG.debug("Assignment Metadata Store is null. Skip persisting the best possible assignment.");

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -90,7 +90,8 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
         throw new HelixRebalanceException(String
             .format("The cluster '%s' does not have enough %s capacity for all partitions. Total capacity: %d, Required: %d, Deficit: %d",
                 clusterModel.getContext().getClusterName(), capacityKey, totalCapacity, totalUsage, Math.abs(remainingCapacity)),
-            HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+            HelixRebalanceException.Type.FAILED_TO_CALCULATE,
+            HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT);
       }
       // estimate remain capacity after assignment + %1 of current cluster capacity before assignment
       positiveEstimateClusterRemainCap.put(capacityKey,
@@ -120,7 +121,8 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
             optimalAssignment.getFailureSummary(),
             optimalAssignment.getFailures());
         throw new HelixRebalanceException(errorMessage,
-            HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+            HelixRebalanceException.Type.FAILED_TO_CALCULATE,
+            HelixRebalanceException.FailureCategory.NO_CANDIDATE_NODE);
       }
       AssignableNode bestNode = maybeBestNode.get();
       // Assign the replica and update the cluster model.
@@ -354,7 +356,8 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
       LOG.error("Constraint evaluation failed during {}: {}", errorContext, e.getMessage(), e);
       throw new HelixRebalanceException(
           String.format("Failed during %s: %s", errorContext, e.getMessage()),
-          HelixRebalanceException.Type.FAILED_TO_CALCULATE, e);
+          HelixRebalanceException.Type.FAILED_TO_CALCULATE,
+          HelixRebalanceException.FailureCategory.ALGORITHM_INTERNAL, e);
     }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/FaultZoneAwareConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/FaultZoneAwareConstraint.java
@@ -55,4 +55,9 @@ class FaultZoneAwareConstraint extends HardConstraint {
   String getDescription() {
     return "A fault zone cannot contain more than 1 replica of same partition";
   }
+
+  @Override
+  Type getType() {
+    return Type.FAULT_ZONE;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/HardConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/HardConstraint.java
@@ -29,6 +29,21 @@ import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
  */
 abstract class HardConstraint {
 
+  /**
+   * Stable identifier for a hard constraint. Decoupled from class names so refactors don't break
+   * downstream consumers (logging, metric attribution). Add a value here when introducing a new
+   * HardConstraint subclass.
+   */
+  public enum Type {
+    FAULT_ZONE,
+    NODE_CAPACITY,
+    NODE_MAX_PARTITION_LIMIT,
+    REPLICA_ACTIVATE,
+    SAME_PARTITION_ON_INSTANCE,
+    VALID_GROUP_TAG,
+    UNKNOWN
+  }
+
   protected boolean enableLogging = false;
 
   /**
@@ -45,6 +60,14 @@ abstract class HardConstraint {
    */
   String getDescription() {
     return getClass().getName();
+  }
+
+  /**
+   * @return A stable {@link Type} identifying this hard constraint. Default is
+   *         {@link Type#UNKNOWN}; subclasses should override to return their specific type.
+   */
+  Type getType() {
+    return Type.UNKNOWN;
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/NodeCapacityConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/NodeCapacityConstraint.java
@@ -55,4 +55,9 @@ class NodeCapacityConstraint extends HardConstraint {
   String getDescription() {
     return "Node has insufficient capacity";
   }
+
+  @Override
+  Type getType() {
+    return Type.NODE_CAPACITY;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/NodeMaxPartitionLimitConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/NodeMaxPartitionLimitConstraint.java
@@ -61,4 +61,9 @@ class NodeMaxPartitionLimitConstraint extends HardConstraint {
   String getDescription() {
     return "Cannot exceed the maximum number of partitions limitation on node";
   }
+
+  @Override
+  Type getType() {
+    return Type.NODE_MAX_PARTITION_LIMIT;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ReplicaActivateConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ReplicaActivateConstraint.java
@@ -63,4 +63,9 @@ class ReplicaActivateConstraint extends HardConstraint {
   String getDescription() {
     return "Cannot assign the inactive replica";
   }
+
+  @Override
+  Type getType() {
+    return Type.REPLICA_ACTIVATE;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/SamePartitionOnInstanceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/SamePartitionOnInstanceConstraint.java
@@ -49,4 +49,9 @@ class SamePartitionOnInstanceConstraint extends HardConstraint {
   String getDescription() {
     return "Same partition of different states cannot co-exist in one instance";
   }
+
+  @Override
+  Type getType() {
+    return Type.SAME_PARTITION_ON_INSTANCE;
+  }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ValidGroupTagConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ValidGroupTagConstraint.java
@@ -50,4 +50,9 @@ class ValidGroupTagConstraint extends HardConstraint {
   String getDescription() {
     return "Instance doesn't have the tag of the replica";
   }
+
+  @Override
+  Type getType() {
+    return Type.VALID_GROUP_TAG;
+  }
 }

--- a/helix-core/src/test/java/org/apache/helix/TestHelixRebalanceException.java
+++ b/helix-core/src/test/java/org/apache/helix/TestHelixRebalanceException.java
@@ -1,0 +1,96 @@
+package org.apache.helix;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestHelixRebalanceException {
+
+  @Test
+  public void testLegacyTwoArgConstructorPreservesMessageAndDefaultsToUnknownCategory() {
+    HelixRebalanceException ex = new HelixRebalanceException("boom",
+        HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+    // Backward-compat: when no category is given, the message must match the historical format
+    // so existing log scrapers and tests don't break.
+    Assert.assertEquals(ex.getMessage(), "boom Failure Type: FAILED_TO_CALCULATE");
+    Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+    Assert.assertEquals(ex.getFailureCategory(), HelixRebalanceException.FailureCategory.UNKNOWN);
+    Assert.assertFalse(ex.isCustomerActionable());
+  }
+
+  @Test
+  public void testLegacyThreeArgConstructorWithCausePreservesMessageAndDefaults() {
+    Throwable cause = new RuntimeException("root");
+    HelixRebalanceException ex = new HelixRebalanceException("boom",
+        HelixRebalanceException.Type.INVALID_CLUSTER_STATUS, cause);
+    Assert.assertEquals(ex.getMessage(), "boom Failure Type: INVALID_CLUSTER_STATUS");
+    Assert.assertSame(ex.getCause(), cause);
+    Assert.assertEquals(ex.getFailureCategory(), HelixRebalanceException.FailureCategory.UNKNOWN);
+  }
+
+  @Test
+  public void testNewThreeArgConstructorAppendsCategoryToMessage() {
+    HelixRebalanceException ex = new HelixRebalanceException("not enough storage",
+        HelixRebalanceException.Type.FAILED_TO_CALCULATE,
+        HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT);
+    Assert.assertEquals(ex.getMessage(),
+        "not enough storage Failure Type: FAILED_TO_CALCULATE Category: CAPACITY_DEFICIT");
+    Assert.assertEquals(ex.getFailureCategory(),
+        HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT);
+    Assert.assertTrue(ex.isCustomerActionable());
+  }
+
+  @Test
+  public void testNewFourArgConstructorWithCauseAppendsCategory() {
+    Throwable cause = new IllegalStateException("zk down");
+    HelixRebalanceException ex = new HelixRebalanceException("read failed",
+        HelixRebalanceException.Type.INVALID_REBALANCER_STATUS,
+        HelixRebalanceException.FailureCategory.METADATA_STORE_IO, cause);
+    Assert.assertEquals(ex.getMessage(),
+        "read failed Failure Type: INVALID_REBALANCER_STATUS Category: METADATA_STORE_IO");
+    Assert.assertSame(ex.getCause(), cause);
+    Assert.assertEquals(ex.getFailureCategory(),
+        HelixRebalanceException.FailureCategory.METADATA_STORE_IO);
+    Assert.assertFalse(ex.isCustomerActionable());
+  }
+
+  @Test
+  public void testCustomerActionableCategoriesAreTaggedCorrectly() {
+    Assert.assertTrue(HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT.isCustomerActionable());
+    Assert.assertTrue(HelixRebalanceException.FailureCategory.NO_CANDIDATE_NODE.isCustomerActionable());
+    Assert.assertTrue(
+        HelixRebalanceException.FailureCategory.INVALID_RESOURCE_CONFIG.isCustomerActionable());
+    Assert.assertTrue(
+        HelixRebalanceException.FailureCategory.INVALID_CLUSTER_CONFIG.isCustomerActionable());
+  }
+
+  @Test
+  public void testInternalCategoriesAreTaggedCorrectly() {
+    Assert.assertFalse(
+        HelixRebalanceException.FailureCategory.METADATA_STORE_IO.isCustomerActionable());
+    Assert.assertFalse(
+        HelixRebalanceException.FailureCategory.ALGORITHM_INTERNAL.isCustomerActionable());
+    Assert.assertFalse(
+        HelixRebalanceException.FailureCategory.ASYNC_EXECUTION.isCustomerActionable());
+    Assert.assertFalse(HelixRebalanceException.FailureCategory.UNKNOWN.isCustomerActionable());
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -340,7 +340,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     Assert.assertEquals(_metadataStore.getBestPossibleAssignment(), testResourceAssignmentMap);
   }
 
-  @Test(dependsOnMethods = "testRebalance", expectedExceptions = HelixRebalanceException.class, expectedExceptionsMessageRegExp = "Input contains invalid resource\\(s\\) that cannot be rebalanced by the WAGED rebalancer. \\[Resource1\\] Failure Type: INVALID_INPUT")
+  @Test(dependsOnMethods = "testRebalance", expectedExceptions = HelixRebalanceException.class, expectedExceptionsMessageRegExp = "Input contains invalid resource\\(s\\) that cannot be rebalanced by the WAGED rebalancer. \\[Resource1\\] Failure Type: INVALID_INPUT Category: INVALID_RESOURCE_CONFIG")
   public void testNonCompatibleConfiguration()
       throws IOException, HelixRebalanceException {
     _metadataStore.reset();
@@ -380,7 +380,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     } catch (HelixRebalanceException ex) {
       Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
       Assert.assertEquals(ex.getMessage(),
-          "Failed to calculate for the new best possible. Failure Type: FAILED_TO_CALCULATE");
+          "Failed to calculate for the new best possible. Failure Type: FAILED_TO_CALCULATE Category: INVALID_CLUSTER_CONFIG");
     }
 
     // The rebalance will be done with empty mapping result since there is no previously calculated
@@ -409,7 +409,7 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
       Assert.assertEquals(ex.getFailureType(),
           HelixRebalanceException.Type.INVALID_REBALANCER_STATUS);
       Assert.assertEquals(ex.getMessage(),
-          "Failed to get the current best possible assignment because of unexpected error. Failure Type: INVALID_REBALANCER_STATUS");
+          "Failed to get the current best possible assignment because of unexpected error. Failure Type: INVALID_REBALANCER_STATUS Category: METADATA_STORE_IO");
     }
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
@@ -160,7 +160,7 @@ public class TestConstraintBasedAlgorithm {
       Assert.fail("Should have thrown HelixRebalanceException for insufficient capacity");
     } catch (HelixRebalanceException ex) {
       Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
-      String expectedPattern = "The cluster 'TestCluster' does not have enough item1 capacity for all partitions\\. Total capacity: \\d+, Required: \\d+, Deficit: \\d+ Failure Type: FAILED_TO_CALCULATE";
+      String expectedPattern = "The cluster 'TestCluster' does not have enough item1 capacity for all partitions\\. Total capacity: \\d+, Required: \\d+, Deficit: \\d+ Failure Type: FAILED_TO_CALCULATE Category: CAPACITY_DEFICIT";
       Assert.assertTrue(ex.getMessage().matches(expectedPattern),
           "Expected message to match pattern: " + expectedPattern + ", but got: " + ex.getMessage());
     }


### PR DESCRIPTION

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

No linked GitHub issue. This PR closes a long-standing observability gap in WAGED failure attribution surfaced during on-call triage.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Adds a `FailureCategory` enum to `HelixRebalanceException` and a typed `HardConstraint.Type` enum, then plumbs the categorization through every WAGED throw site and enriches the controller's log output. **Zero new MBean attributes** -- this is the data-model + log-enrichment slice. Metric exposure lands in a follow-up PR on top of this one.

**Why:** Today, every WAGED `HelixRebalanceException` collapses into one of 5 generic `Type` values, so a capacity deficit (customer config), a constraint mismatch (customer config), a metadata-store IO failure (Helix infra), and an algorithm crash (Helix infra) are indistinguishable in controller logs. On-call has to read the message text and inspect surrounding stack frames to figure out who owns the failure. This PR moves that information into structured fields on the exception and the log line, so:

1. Customer-actionable failures (capacity, fault zones, tags, config) are routable to the cluster owner.
2. Helix-team-owned failures (metadata-store IO, algorithm internals) are routable to the Helix on-call.
3. Both audiences can author log-based alerts that key on `category=...` without parsing message strings.

The follow-up PR will expose these dimensions as JMX MBean attributes on both `WagedRebalancerMetricCollector` (Rebalancer domain) and `ClusterStatusMonitor` (ClusterStatus domain), but the data model needs to land first so the metric path has something well-typed to attribute.

**How:**

1. New `HelixRebalanceException.FailureCategory` enum with 8 values and an `isCustomerActionable()` flag. The 8 categories map customer-vs-Helix ownership:
   - Customer-actionable: `CAPACITY_DEFICIT`, `NO_CANDIDATE_NODE`, `INVALID_RESOURCE_CONFIG`, `INVALID_CLUSTER_CONFIG`
   - Helix-team-owned: `METADATA_STORE_IO`, `ALGORITHM_INTERNAL`, `ASYNC_EXECUTION`, `UNKNOWN`
2. The legacy 2-arg and 3-arg constructors on `HelixRebalanceException` are preserved byte-for-byte. New 3-arg and 4-arg constructors take a `FailureCategory`. The message format includes `Category: X` only when the category is set; legacy callers see byte-identical `getMessage()` output.
3. All 17 WAGED throw sites updated to declare their `FailureCategory`:
   - `ConstraintBasedAlgorithm` -> `CAPACITY_DEFICIT`, `NO_CANDIDATE_NODE`, `ALGORITHM_INTERNAL`
   - `WagedRebalancer` -> `INVALID_CLUSTER_CONFIG` (x3), `INVALID_RESOURCE_CONFIG`, `METADATA_STORE_IO`
   - `PartialRebalanceRunner` and `GlobalRebalanceRunner` -> mix of categories
   - `AssignmentManager` -> `METADATA_STORE_IO`
4. `HardConstraint` gains a typed `Type` enum (`FAULT_ZONE`, `NODE_CAPACITY`, `NODE_MAX_PARTITION_LIMIT`, `REPLICA_ACTIVATE`, `SAME_PARTITION_ON_INSTANCE`, `VALID_GROUP_TAG`, `UNKNOWN`) and a default `getType()` method. Each of the 6 concrete subclasses overrides `getType()` to return its stable type. The class stays package-private -- no metric consumer needs it cross-package in this PR.
5. `WagedRebalancer.computeNewIdealStates` catch block now logs structured `category=... customerActionable=...` fields. The fallback-path warn log also includes the category. Operators can grep logs immediately.
6. The async runners (`GlobalRebalanceRunner`, `PartialRebalanceRunner`) capture the inner-thread exception via `AtomicReference` and preserve the original `FailureCategory` when the synchronous caller re-throws. **The `Type` is intentionally collapsed back to `FAILED_TO_CALCULATE`** so the downstream fallback decision in `WagedRebalancer.computeNewIdealStates`' catch is unchanged from pre-PR behavior. Category drives observability; Type drives control flow.

### Tests

- [x] The following tests are written for this issue:

**New test class:** `helix-core/src/test/java/org/apache/helix/TestHelixRebalanceException.java`
- `testLegacyTwoArgConstructorPreservesMessageAndDefaultsToUnknownCategory`
- `testLegacyThreeArgConstructorWithCausePreservesMessageAndDefaults`
- `testNewThreeArgConstructorAppendsCategoryToMessage`
- `testNewFourArgConstructorWithCauseAppendsCategory`
- `testCustomerActionableCategoriesAreTaggedCorrectly`
- `testInternalCategoriesAreTaggedCorrectly`

**Updated test assertions** (reflect the new `Category: X` suffix on throws that declare a category):
- `TestConstraintBasedAlgorithm.testSortingEarlyQuitLackCapacity` -- regex updated
- `TestWagedRebalancer.testNonCompatibleConfiguration` -- regex updated
- `TestWagedRebalancer.testInvalidClusterStatus` -- literal updated
- `TestWagedRebalancer.testInvalidRebalancerStatus` -- literal updated

- The following is the result of the `mvn test` command on the appropriate module:

| Suite | Tests | Result |
| --- | --- | --- |
| WAGED unit + constraint package | 67 | passed |
| Controller stages (BestPossibleStateCalcStage, IntermediateStateCalcStage, RebalancePipeline) | 14 | passed |
| `TestHelixRebalanceException` (new) | 6 | passed |
| `TestWagedRebalance` (real-ZK integration) | 12 | passed |
| `TestAbnormalStatesResolver` (integration) | 2 | passed |
| **Total** | **101** | **all passed** |

Sample integration log line confirming end-to-end category propagation through the async runner:

```
HelixRebalanceException: Failed to calculate for the new Baseline.
  Failure Type: FAILED_TO_CALCULATE Category: CAPACITY_DEFICIT
Caused by: HelixRebalanceException: The cluster 'CLUSTER_TestWagedRebalance' does not have
  enough key capacity for all partitions. Total capacity: 9, Required: 360, Deficit: 351
  Failure Type: FAILED_TO_CALCULATE Category: CAPACITY_DEFICIT
```

### Changes that Break Backward Compatibility (Optional)

- [ ] My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

**No breaking changes to public API.** Specifically:
- All existing `HelixRebalanceException` constructors are preserved verbatim. `getMessage()` returns byte-for-byte the same string for any caller that does not pass the new `FailureCategory` argument (the message helper special-cases `FailureCategory.UNKNOWN` to omit the new suffix).
- `getFailureType()` behavior is unchanged.
- `StatefulRebalancer.computeNewIdealStates` signature is unchanged.
- `HardConstraint` and all its subclasses keep their original visibility (package-private). The new `Type` enum is `public` for future cross-package consumption but is currently only used in-package.

**Behavior guarantee on rebalancing logic:**
Rebalancing decisions are bitwise identical to pre-PR. Every `Type` value at every throw site is preserved; the `FAILURE_TYPES_TO_PROPAGATE` decision in `WagedRebalancer.computeNewIdealStates` is unchanged; the fallback path runs in the same scenarios; the algorithm computation is untouched. The async-runner sync re-throw deliberately collapses `Type` back to `FAILED_TO_CALCULATE` precisely to maintain this guarantee.

**Behavior changes that are not API breaks but worth noting:**
- Exception messages constructed via the new 3/4-arg constructors include `Category: X` after `Failure Type: X`. Existing callers using the 2/3-arg constructors see no change. Log scrapers parsing the full message text may want to opt into the new suffix.

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

N/A. The new `FailureCategory` and `HardConstraint.Type` enums are self-documenting via Javadoc on the enum values.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  2. Subject is limited to 50 characters (not including Jira issue reference) -- the descriptive subject runs slightly longer to capture the full intent
  3. Subject does not end with a period
  4. Subject uses the imperative mood ("Classify", not "Classifying")
  5. Body wraps at 72 characters
  6. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml
(helix-style-intellij.xml if IntelliJ IDE is used)

Code style follows the surrounding conventions in each touched file (existing import order, indentation, brace placement, Javadoc style). No formatter run was applied to unmodified lines.

---

### Follow-up

A second PR (`lzd/wagedFailureMetrics` -- to be opened after this one merges) will layer the JMX MBean exposure on top: per-`FailureCategory` and per-`HardConstraint.Type` counters on both `WagedRebalancerMetricCollector` (Rebalancer domain) and `ClusterStatusMonitor` (ClusterStatus domain), plus a `WagedFallbackInUseGauge`. That PR depends on this one for the data model and is intentionally split out to keep review scope small.
