### PR TITLE
Expose WAGED FailureCategory and HardConstraint counters as cluster-level MBean attributes

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -219,7 +219,11 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
   private final StatefulRebalancerRef _rebalancerRef = new StatefulRebalancerRef() {
     @Override
     protected StatefulRebalancer createRebalancer(HelixManager helixManager) {
-      return new WagedRebalancer(helixManager);
+      WagedRebalancer wagedRebalancer = new WagedRebalancer(helixManager);
+      // Mirror per-FailureCategory and per-HardConstraint failure counters and the fallback
+      // gauge onto the cluster status monitor so they appear under ClusterStatus:cluster=<name>.
+      wagedRebalancer.setClusterStatusMonitor(_clusterStatusMonitor);
+      return wagedRebalancer;
     }
   };
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.changedetector.ResourceChangeDetector;
@@ -74,7 +75,10 @@ class GlobalRebalanceRunner implements AutoCloseable {
   private final LatencyMetric _writeLatency;
   private final CountMetric _baselineCalcCounter;
   private final LatencyMetric _baselineCalcLatency;
-  private final CountMetric _rebalanceFailureCount;
+  // Reporter that ticks RebalanceFailureCounter plus the per-FailureCategory counters on both
+  // the Rebalancer-domain and ClusterStatus-domain MBeans. Owned by WagedRebalancer; injected
+  // so the runner doesn't need a direct ClusterStatusMonitor reference.
+  private final Consumer<HelixRebalanceException> _asyncFailureReporter;
 
   private boolean _asyncGlobalRebalanceEnabled;
   // Captures the original exception thrown inside the executor task so we can preserve its
@@ -85,7 +89,7 @@ class GlobalRebalanceRunner implements AutoCloseable {
       AssignmentMetadataStore assignmentMetadataStore,
       MetricCollector metricCollector,
       LatencyMetric writeLatency,
-      CountMetric rebalanceFailureCount,
+      Consumer<HelixRebalanceException> asyncFailureReporter,
       boolean isAsyncGlobalRebalanceEnabled) {
     _baselineCalculateExecutor = Executors.newSingleThreadExecutor();
     _assignmentManager = assignmentManager;
@@ -98,7 +102,7 @@ class GlobalRebalanceRunner implements AutoCloseable {
     _baselineCalcLatency = metricCollector.getMetric(
         WagedRebalancerMetricCollector.WagedRebalancerMetricNames.GlobalBaselineCalcLatencyGauge.name(),
         LatencyMetric.class);
-    _rebalanceFailureCount = rebalanceFailureCount;
+    _asyncFailureReporter = asyncFailureReporter;
     _asyncGlobalRebalanceEnabled = isAsyncGlobalRebalanceEnabled;
   }
 
@@ -135,7 +139,10 @@ class GlobalRebalanceRunner implements AutoCloseable {
           // re-throw to keep WagedRebalancer.computeNewIdealStates' fallback decision unchanged.
           _lastAsyncFailure.set(e);
           if (_asyncGlobalRebalanceEnabled) {
-            _rebalanceFailureCount.increment(1L);
+            // Async mode: synchronous caller will not see this exception. Tick the aggregate
+            // RebalanceFailureCounter plus the per-FailureCategory counters on both MBeans via
+            // the injected reporter.
+            _asyncFailureReporter.accept(e);
           }
           LOG.error("Failed to calculate baseline assignment! category={}",
               e.getFailureCategory(), e);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/PartialRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/PartialRebalanceRunner.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.util.WagedRebalanceUtil;
@@ -60,7 +61,10 @@ class PartialRebalanceRunner implements AutoCloseable {
   private final AssignmentManager _assignmentManager;
   private final AssignmentMetadataStore _assignmentMetadataStore;
   private final BaselineDivergenceGauge _baselineDivergenceGauge;
-  private final CountMetric _rebalanceFailureCount;
+  // Reporter that ticks RebalanceFailureCounter plus the per-FailureCategory counters on both
+  // the Rebalancer-domain and ClusterStatus-domain MBeans. Owned by WagedRebalancer; injected
+  // so the runner doesn't need a direct ClusterStatusMonitor reference.
+  private final Consumer<HelixRebalanceException> _asyncFailureReporter;
   private final CountMetric _partialRebalanceCounter;
   private final LatencyMetric _partialRebalanceLatency;
 
@@ -73,12 +77,12 @@ class PartialRebalanceRunner implements AutoCloseable {
   public PartialRebalanceRunner(AssignmentManager assignmentManager,
       AssignmentMetadataStore assignmentMetadataStore,
       MetricCollector metricCollector,
-      CountMetric rebalanceFailureCount,
+      Consumer<HelixRebalanceException> asyncFailureReporter,
       boolean isAsyncPartialRebalanceEnabled) {
     _assignmentManager = assignmentManager;
     _assignmentMetadataStore = assignmentMetadataStore;
     _bestPossibleCalculateExecutor = Executors.newSingleThreadExecutor();
-    _rebalanceFailureCount = rebalanceFailureCount;
+    _asyncFailureReporter = asyncFailureReporter;
     _asyncPartialRebalanceEnabled = isAsyncPartialRebalanceEnabled;
 
     _partialRebalanceCounter = metricCollector.getMetric(
@@ -114,7 +118,10 @@ class PartialRebalanceRunner implements AutoCloseable {
         // re-throw to keep WagedRebalancer.computeNewIdealStates' fallback decision unchanged.
         _lastAsyncFailure.set(e);
         if (_asyncPartialRebalanceEnabled) {
-          _rebalanceFailureCount.increment(1L);
+          // Async mode: synchronous caller will not see this exception. Tick the aggregate
+          // RebalanceFailureCounter plus the per-FailureCategory counters on both MBeans via
+          // the injected reporter.
+          _asyncFailureReporter.accept(e);
         }
         LOG.error("Failed to calculate best possible assignment! category={}",
             e.getFailureCategory(), e);

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -22,6 +22,7 @@ package org.apache.helix.controller.rebalancer.waged;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +43,9 @@ import org.apache.helix.controller.rebalancer.internal.MappingCalculator;
 import org.apache.helix.controller.rebalancer.util.DelayedRebalanceUtil;
 import org.apache.helix.controller.rebalancer.util.WagedRebalanceUtil;
 import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
+import org.apache.helix.controller.rebalancer.waged.constraints.ConstraintBasedAlgorithm;
 import org.apache.helix.controller.rebalancer.waged.constraints.ConstraintBasedAlgorithmFactory;
+import org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider;
 import org.apache.helix.controller.stages.CurrentStateOutput;
@@ -52,6 +55,7 @@ import org.apache.helix.model.Partition;
 import org.apache.helix.model.Resource;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
+import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
 import org.apache.helix.monitoring.metrics.MetricCollector;
 import org.apache.helix.monitoring.metrics.WagedRebalancerMetricCollector;
 import org.apache.helix.monitoring.metrics.model.CountMetric;
@@ -74,10 +78,6 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       NOT_CONFIGURED_PREFERENCE = ImmutableMap
       .of(ClusterConfig.GlobalRebalancePreferenceKey.EVENNESS, -1,
           ClusterConfig.GlobalRebalancePreferenceKey.LESS_MOVEMENT, -1);
-  // The default algorithm to use when there is no preference configured.
-  private static final RebalanceAlgorithm DEFAULT_REBALANCE_ALGORITHM =
-      ConstraintBasedAlgorithmFactory
-          .getInstance(ClusterConfig.DEFAULT_GLOBAL_REBALANCE_PREFERENCE);
   // These failure types should be propagated to caller of computeNewIdealStates()
   private static final List<HelixRebalanceException.Type> FAILURE_TYPES_TO_PROPAGATE =
       ImmutableList.of(HelixRebalanceException.Type.INVALID_REBALANCER_STATUS, HelixRebalanceException.Type.UNKNOWN_FAILURE);
@@ -102,6 +102,18 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
   private RebalanceAlgorithm _rebalanceAlgorithm;
   private Map<ClusterConfig.GlobalRebalancePreferenceKey, Integer> _preference = NOT_CONFIGURED_PREFERENCE;
 
+  // Rebalancer-domain per-FailureCategory and per-HardConstraint counters. Pre-resolved at
+  // construction so the failure-reporting hot paths don't repeatedly look them up by name.
+  // ClusterStatusMonitor mirrors the same counts onto its own MBean for cluster-level dashboards.
+  private final EnumMap<HelixRebalanceException.FailureCategory, CountMetric>
+      _failureCategoryMetrics;
+  private final EnumMap<HardConstraint.Type, CountMetric> _hardConstraintFailureMetrics;
+
+  // Mirror of WAGED failure-category counters onto the ClusterStatusMonitor so cluster-level
+  // dashboards see the same signal. May be null when WagedRebalancer is used outside the
+  // pipeline (e.g. ReadOnlyWagedRebalancer for the REST partitionAssignment API).
+  private volatile ClusterStatusMonitor _clusterStatusMonitor;
+
   private static AssignmentMetadataStore constructAssignmentStore(String metadataStoreAddrs,
       String clusterName) {
     if (metadataStoreAddrs != null && clusterName != null) {
@@ -114,7 +126,12 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     this(helixManager == null ? null
             : constructAssignmentStore(helixManager.getMetadataStoreConnectionString(),
                 helixManager.getClusterName()),
-        DEFAULT_REBALANCE_ALGORITHM,
+        // Construct a per-instance algorithm rather than sharing a static singleton across
+        // WagedRebalancers, so the per-cluster hard-constraint failure reporter installed via
+        // setClusterStatusMonitor() does not race when multiple controllers coexist in the JVM.
+        // The shared ForkJoinPool inside the factory is still reused.
+        ConstraintBasedAlgorithmFactory.getInstance(
+            ClusterConfig.DEFAULT_GLOBAL_REBALANCE_PREFERENCE),
         // Use DelayedAutoRebalancer as the mapping calculator for the final assignment output.
         // Mapping calculator will translate the best possible assignment into the applicable state
         // mapping based on the current states.
@@ -189,10 +206,133 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
         WagedRebalancerMetricCollector.WagedRebalancerMetricNames.StateReadLatencyGauge.name(),
         LatencyMetric.class));
 
+    _failureCategoryMetrics = new EnumMap<>(HelixRebalanceException.FailureCategory.class);
+    for (HelixRebalanceException.FailureCategory category :
+        HelixRebalanceException.FailureCategory.values()) {
+      _failureCategoryMetrics.put(category, _metricCollector.getMetric(
+          failureCategoryMetricName(category).name(), CountMetric.class));
+    }
+    _hardConstraintFailureMetrics = new EnumMap<>(HardConstraint.Type.class);
+    for (HardConstraint.Type type : HardConstraint.Type.values()) {
+      _hardConstraintFailureMetrics.put(type, _metricCollector.getMetric(
+          hardConstraintMetricName(type).name(), CountMetric.class));
+    }
+
     _partialRebalanceRunner = new PartialRebalanceRunner(_assignmentManager, assignmentMetadataStore, metricCollector,
-        _rebalanceFailureCount, isAsyncPartialRebalanceEnabled);
+        this::reportAsyncFailure, isAsyncPartialRebalanceEnabled);
     _globalRebalanceRunner = new GlobalRebalanceRunner(_assignmentManager, assignmentMetadataStore, metricCollector,
-        _writeLatency, _rebalanceFailureCount, isAsyncGlobalRebalanceEnabled);
+        _writeLatency, this::reportAsyncFailure, isAsyncGlobalRebalanceEnabled);
+  }
+
+  /**
+   * Map a FailureCategory to its WagedRebalancerMetricNames enum value. Adding a new
+   * FailureCategory requires adding a matching WagedRebalancerMetricNames entry and the case below.
+   */
+  private static WagedRebalancerMetricCollector.WagedRebalancerMetricNames
+      failureCategoryMetricName(HelixRebalanceException.FailureCategory category) {
+    switch (category) {
+      case CAPACITY_DEFICIT:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryCapacityDeficitCounter;
+      case NO_CANDIDATE_NODE:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryNoCandidateNodeCounter;
+      case INVALID_RESOURCE_CONFIG:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryInvalidResourceConfigCounter;
+      case INVALID_CLUSTER_CONFIG:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryInvalidClusterConfigCounter;
+      case METADATA_STORE_IO:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryMetadataStoreIoCounter;
+      case ALGORITHM_INTERNAL:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryAlgorithmInternalCounter;
+      case ASYNC_EXECUTION:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryAsyncExecutionCounter;
+      case UNKNOWN:
+      default:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryUnknownCounter;
+    }
+  }
+
+  /**
+   * Map a HardConstraint.Type to its WagedRebalancerMetricNames enum value.
+   */
+  private static WagedRebalancerMetricCollector.WagedRebalancerMetricNames
+      hardConstraintMetricName(HardConstraint.Type type) {
+    switch (type) {
+      case FAULT_ZONE:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.HardConstraintFaultZoneFailureCounter;
+      case NODE_CAPACITY:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.HardConstraintNodeCapacityFailureCounter;
+      case NODE_MAX_PARTITION_LIMIT:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.HardConstraintNodeMaxPartitionLimitFailureCounter;
+      case REPLICA_ACTIVATE:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.HardConstraintReplicaActivateFailureCounter;
+      case SAME_PARTITION_ON_INSTANCE:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.HardConstraintSamePartitionOnInstanceFailureCounter;
+      case VALID_GROUP_TAG:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.HardConstraintValidGroupTagFailureCounter;
+      case UNKNOWN:
+      default:
+        return WagedRebalancerMetricCollector.WagedRebalancerMetricNames.HardConstraintUnknownFailureCounter;
+    }
+  }
+
+  /**
+   * Attach the cluster-level status monitor so per-FailureCategory and per-HardConstraint counters
+   * get mirrored from the WagedRebalancerMetricCollector (Rebalancer JMX domain) onto
+   * ClusterStatusMonitor (ClusterStatus JMX domain). Also installs the per-HardConstraint reporter
+   * on the algorithm. Safe to call multiple times; subsequent calls replace the reference. May be
+   * null when WAGED is used outside the controller pipeline (e.g. ReadOnlyWagedRebalancer).
+   */
+  public void setClusterStatusMonitor(ClusterStatusMonitor clusterStatusMonitor) {
+    _clusterStatusMonitor = clusterStatusMonitor;
+    installHardConstraintFailureReporter(_rebalanceAlgorithm);
+  }
+
+  /**
+   * Install a per-HardConstraint failure reporter on the algorithm. No-op for algorithm
+   * implementations that are not ConstraintBasedAlgorithm. Called both when the monitor is
+   * attached and when the algorithm is replaced via updateRebalancePreference.
+   */
+  private void installHardConstraintFailureReporter(RebalanceAlgorithm algorithm) {
+    if (algorithm instanceof ConstraintBasedAlgorithm) {
+      ((ConstraintBasedAlgorithm) algorithm).setHardConstraintFailureReporter(
+          this::reportHardConstraintFailure);
+    }
+  }
+
+  /**
+   * Increment the per-FailureCategory counter on both the Rebalancer-domain
+   * WagedRebalancerMetricCollector and the ClusterStatus-domain ClusterStatusMonitor (when
+   * attached). Null-tolerant for ReadOnlyWagedRebalancer / unit-test cases.
+   */
+  protected void reportFailureCategory(HelixRebalanceException ex) {
+    HelixRebalanceException.FailureCategory category = ex.getFailureCategory();
+    _failureCategoryMetrics.get(category).increment(1L);
+    ClusterStatusMonitor monitor = _clusterStatusMonitor;
+    if (monitor != null) {
+      monitor.reportWagedFailureByCategory(category);
+    }
+  }
+
+  /**
+   * Increment the per-HardConstraint counter on both MBeans. Called once per distinct constraint
+   * type that contributed to a partition's failure to find any eligible node.
+   */
+  void reportHardConstraintFailure(HardConstraint.Type type) {
+    _hardConstraintFailureMetrics.get(type).increment(1L);
+    ClusterStatusMonitor monitor = _clusterStatusMonitor;
+    if (monitor != null) {
+      monitor.reportWagedHardConstraintFailure(type);
+    }
+  }
+
+  /**
+   * Full failure reporting for async-runner background threads: ticks RebalanceFailureCounter
+   * plus both the Rebalancer-domain and ClusterStatus-domain per-FailureCategory counters. Used
+   * when the async runner catches an exception that the synchronous catch never sees.
+   */
+  void reportAsyncFailure(HelixRebalanceException ex) {
+    _rebalanceFailureCount.increment(1L);
+    reportFailureCategory(ex);
   }
 
   // Update the global rebalance mode to be asynchronous or synchronous
@@ -212,6 +352,9 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     // 2. if the preference equals to the new preference, no need to update.
     if (!_preference.equals(NOT_CONFIGURED_PREFERENCE) && !_preference.equals(newPreference)) {
       _rebalanceAlgorithm = ConstraintBasedAlgorithmFactory.getInstance(newPreference);
+      // The previous algorithm instance is discarded; rewire the failure reporter onto the new
+      // one so per-HardConstraint counters keep flowing.
+      installHardConstraintFailureReporter(_rebalanceAlgorithm);
       _preference = ImmutableMap.copyOf(newPreference);
     }
   }
@@ -240,9 +383,18 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       Map<String, Resource> resourceMap, final CurrentStateOutput currentStateOutput)
       throws HelixRebalanceException {
     LOG.info("Start computing new ideal states for resources: {}", resourceMap.keySet().toString());
-    validateInput(clusterData, resourceMap);
+    try {
+      validateInput(clusterData, resourceMap);
+    } catch (HelixRebalanceException ex) {
+      // Record validation failures (INVALID_INPUT / INVALID_RESOURCE_CONFIG) too. We do not enter
+      // the fallback path here -- a bad input set must not silently use last-known-good.
+      _rebalanceFailureCount.increment(1L);
+      reportFailureCategory(ex);
+      throw ex;
+    }
 
     Map<String, IdealState> newIdealStates;
+    boolean usedFallback = false;
     try {
       // Calculate the target assignment based on the current cluster status.
       newIdealStates = computeBestPossibleStates(clusterData, resourceMap, currentStateOutput,
@@ -252,6 +404,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
           ex.getFailureCategory(), ex.isCustomerActionable(), ex);
       // Record the failure in metrics.
       _rebalanceFailureCount.increment(1L);
+      reportFailureCategory(ex);
 
       HelixRebalanceException.Type failureType = ex.getFailureType();
       if (failureTypesToPropagate().contains(failureType)) {
@@ -260,6 +413,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
         throw ex;
       } else {
         // return the previously calculated assignment.
+        usedFallback = true;
         LOG.warn(
             "Returning the last known-good best possible assignment from metadata store due to "
                 + "rebalance failure of type: {} category: {}", failureType, ex.getFailureCategory());
@@ -270,6 +424,14 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
                 resourceMap.keySet());
         newIdealStates = convertResourceAssignment(clusterData, assignmentRecord);
       }
+    }
+    // Reflect whether this run produced a fresh assignment or fell back. Always update so that
+    // a previously sticky "true" resets on the next clean run. Capture the volatile once to
+    // avoid racing with a concurrent setClusterStatusMonitor() between the null check and the
+    // method call.
+    ClusterStatusMonitor monitor = _clusterStatusMonitor;
+    if (monitor != null) {
+      monitor.setWagedFallbackInUseGauge(usedFallback);
     }
 
     // Construct the new best possible states according to the current state and target assignment.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -56,18 +57,32 @@ import org.slf4j.LoggerFactory;
  * The goal is to accumulate the most points(rewards) from "soft constraints" while avoiding any
  * "hard constraints"
  */
-class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
+public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
   private static final float DIV_GUARD = 0.01f;
   private static final Logger LOG = LoggerFactory.getLogger(ConstraintBasedAlgorithm.class);
   private final List<HardConstraint> _hardConstraints;
   private final Map<SoftConstraint, Float> _softConstraints;
   private final ForkJoinPool _constraintEvaluationPool;
+  // Optional listener invoked when a partition fails to find any eligible node. Fires once per
+  // distinct HardConstraint.Type that contributed to the failure (set union, not sum), so
+  // observers get partition-level attribution rather than node-rejection counts. May be null
+  // when the algorithm runs outside a pipeline that wants metric attribution.
+  private volatile Consumer<HardConstraint.Type> _hardConstraintFailureReporter;
 
   ConstraintBasedAlgorithm(List<HardConstraint> hardConstraints,
       Map<SoftConstraint, Float> softConstraints, ForkJoinPool constraintEvaluationPool) {
     _hardConstraints = hardConstraints;
     _softConstraints = softConstraints;
     _constraintEvaluationPool = constraintEvaluationPool;
+  }
+
+  /**
+   * Attach a per-partition-failure reporter that fires once per distinct {@link HardConstraint.Type}
+   * that prevented placement. Safe to call from any thread; subsequent calls replace the
+   * reference. May be null to disable reporting.
+   */
+  public void setHardConstraintFailureReporter(Consumer<HardConstraint.Type> reporter) {
+    _hardConstraintFailureReporter = reporter;
   }
 
   @Override
@@ -163,6 +178,18 @@ class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
     if (candidateNodes.isEmpty()) {
       LOG.info("Found no eligible candidate nodes. Enabling hard constraint level logging for cluster: {}", clusterContext.getClusterName());
       enableFullLoggingForCluster();
+      // Report each distinct constraint type that contributed to this partition's failure
+      // exactly once -- partition-level attribution, not per-node-rejection. Computed before
+      // recording the failure so a constraint that rejected many nodes still fires +1 per
+      // failed partition rather than +N.
+      Consumer<HardConstraint.Type> reporter = _hardConstraintFailureReporter;
+      if (reporter != null) {
+        hardConstraintFailures.values().stream()
+            .flatMap(List::stream)
+            .map(HardConstraint::getType)
+            .distinct()
+            .forEach(reporter);
+      }
       optimalAssignment.recordAssignmentFailure(replica,
           Maps.transformValues(hardConstraintFailures, this::convertFailureReasons));
       return Optional.empty();

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/HardConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/HardConstraint.java
@@ -26,8 +26,12 @@ import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
 /**
  * Evaluate a partition allocation proposal and return YES or NO based on the cluster context.
  * Any proposal fails one or more hard constraints will be rejected.
+ *
+ * <p>The class is public so the metric-reporting layer (in {@code monitoring.mbeans}) can
+ * reference {@link Type}; concrete subclasses stay package-private so the actual hard-constraint
+ * implementations remain internal.
  */
-abstract class HardConstraint {
+public abstract class HardConstraint {
 
   /**
    * Stable identifier for a hard constraint. Decoupled from class names so refactors don't break

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -39,8 +39,10 @@ import javax.management.ObjectName;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
+import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
+import org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint;
 import org.apache.helix.controller.stages.BestPossibleStateOutput;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -92,6 +94,19 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   private AtomicLong _continuousResourceRebalanceFailureCount = new AtomicLong(0L);
   private AtomicLong _continuousTaskRebalanceFailureCount = new AtomicLong(0L);
 
+  // WAGED per-FailureCategory counters. Populated in the constructor with a zero AtomicLong per
+  // enum value so reads on never-incremented categories return 0 instead of NPE.
+  private final Map<HelixRebalanceException.FailureCategory, AtomicLong> _wagedFailureCategoryCounters =
+      new ConcurrentHashMap<>();
+  private final AtomicLong _wagedCustomerActionableFailureCount = new AtomicLong(0L);
+  private final AtomicLong _wagedInternalFailureCount = new AtomicLong(0L);
+  private volatile boolean _wagedFallbackInUse = false;
+
+  // WAGED per-HardConstraint failure counters. Pre-populated for every HardConstraint.Type so
+  // reads return 0 instead of NPE for constraints that have not yet fired.
+  private final Map<HardConstraint.Type, AtomicLong> _wagedHardConstraintFailureCounters =
+      new ConcurrentHashMap<>();
+
   // Cluster-level instance operation counts
   private final Map<InstanceConstants.InstanceOperation, AtomicLong> _perOperationInstanceCount =
       new ConcurrentHashMap<>();
@@ -124,6 +139,17 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     // Initialize the map with all operation types
     for (InstanceConstants.InstanceOperation operation : InstanceConstants.InstanceOperation.values()) {
       _perOperationInstanceCount.put(operation, new AtomicLong(0L));
+    }
+
+    // Pre-create one AtomicLong per WAGED failure category so dashboards see a stable 0
+    // for categories that have not yet fired.
+    for (HelixRebalanceException.FailureCategory category :
+        HelixRebalanceException.FailureCategory.values()) {
+      _wagedFailureCategoryCounters.put(category, new AtomicLong(0L));
+    }
+    // Same for per-HardConstraint counters.
+    for (HardConstraint.Type type : HardConstraint.Type.values()) {
+      _wagedHardConstraintFailureCounters.put(type, new AtomicLong(0L));
     }
   }
 
@@ -826,6 +852,15 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       _rebalanceFailureCount.set(0L);
       _continuousResourceRebalanceFailureCount.set(0L);
       _continuousTaskRebalanceFailureCount.set(0L);
+      // Zero the WAGED per-category and per-HardConstraint counters along with the rollup
+      // counters and the fallback gauge. Like the legacy rebalance counters above, these are
+      // reset on leadership change to avoid stale numbers from a prior controller leadership
+      // period being attributed to the new one.
+      _wagedFailureCategoryCounters.values().forEach(c -> c.set(0L));
+      _wagedHardConstraintFailureCounters.values().forEach(c -> c.set(0L));
+      _wagedCustomerActionableFailureCount.set(0L);
+      _wagedInternalFailureCount.set(0L);
+      _wagedFallbackInUse = false;
     } catch (Exception e) {
       LOG.error("Fail to reset ClusterStatusMonitor, cluster: " + _clusterName, e);
     }
@@ -1201,6 +1236,43 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     _rebalanceFailureCount.incrementAndGet();
   }
 
+  /**
+   * Record a WAGED rebalance failure with its classified category. Increments both the
+   * per-category counter and the matching rollup counter (customer-actionable vs internal).
+   * Safe to call from the controller pipeline thread.
+   */
+  public void reportWagedFailureByCategory(HelixRebalanceException.FailureCategory category) {
+    if (category == null) {
+      category = HelixRebalanceException.FailureCategory.UNKNOWN;
+    }
+    _wagedFailureCategoryCounters.get(category).incrementAndGet();
+    if (category.isCustomerActionable()) {
+      _wagedCustomerActionableFailureCount.incrementAndGet();
+    } else {
+      _wagedInternalFailureCount.incrementAndGet();
+    }
+  }
+
+  /**
+   * Record that a partition failed placement because at least one candidate node was rejected
+   * by a hard constraint of the given type. Called once per partition per distinct constraint
+   * type that contributed to the failure (set-union across nodes, not summed).
+   */
+  public void reportWagedHardConstraintFailure(HardConstraint.Type type) {
+    if (type == null) {
+      type = HardConstraint.Type.UNKNOWN;
+    }
+    _wagedHardConstraintFailureCounters.get(type).incrementAndGet();
+  }
+
+  /**
+   * Flip the fallback gauge. Set to true when WAGED returns the last-known-good assignment
+   * instead of a freshly computed one; reset to false when a clean calculation succeeds.
+   */
+  public void setWagedFallbackInUseGauge(boolean inUse) {
+    _wagedFallbackInUse = inUse;
+  }
+
   public void reportContinuousResourceRebalanceFailureCount(long newValue) {
     _continuousResourceRebalanceFailureCount.set(newValue);
   }
@@ -1222,6 +1294,106 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   @Override
   public long getContinuousTaskRebalanceFailureCount() {
     return _continuousTaskRebalanceFailureCount.get();
+  }
+
+  @Override
+  public long getWagedCustomerActionableFailureCounter() {
+    return _wagedCustomerActionableFailureCount.get();
+  }
+
+  @Override
+  public long getWagedInternalFailureCounter() {
+    return _wagedInternalFailureCount.get();
+  }
+
+  @Override
+  public long getWagedFailureCapacityDeficitCounter() {
+    return _wagedFailureCategoryCounters
+        .get(HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT).get();
+  }
+
+  @Override
+  public long getWagedFailureNoCandidateNodeCounter() {
+    return _wagedFailureCategoryCounters
+        .get(HelixRebalanceException.FailureCategory.NO_CANDIDATE_NODE).get();
+  }
+
+  @Override
+  public long getWagedFailureInvalidResourceConfigCounter() {
+    return _wagedFailureCategoryCounters
+        .get(HelixRebalanceException.FailureCategory.INVALID_RESOURCE_CONFIG).get();
+  }
+
+  @Override
+  public long getWagedFailureInvalidClusterConfigCounter() {
+    return _wagedFailureCategoryCounters
+        .get(HelixRebalanceException.FailureCategory.INVALID_CLUSTER_CONFIG).get();
+  }
+
+  @Override
+  public long getWagedFailureMetadataStoreIoCounter() {
+    return _wagedFailureCategoryCounters
+        .get(HelixRebalanceException.FailureCategory.METADATA_STORE_IO).get();
+  }
+
+  @Override
+  public long getWagedFailureAlgorithmInternalCounter() {
+    return _wagedFailureCategoryCounters
+        .get(HelixRebalanceException.FailureCategory.ALGORITHM_INTERNAL).get();
+  }
+
+  @Override
+  public long getWagedFailureAsyncExecutionCounter() {
+    return _wagedFailureCategoryCounters
+        .get(HelixRebalanceException.FailureCategory.ASYNC_EXECUTION).get();
+  }
+
+  @Override
+  public long getWagedFailureUnknownCounter() {
+    return _wagedFailureCategoryCounters
+        .get(HelixRebalanceException.FailureCategory.UNKNOWN).get();
+  }
+
+  @Override
+  public long getWagedFallbackInUseGauge() {
+    return _wagedFallbackInUse ? 1L : 0L;
+  }
+
+  @Override
+  public long getWagedHardConstraintFaultZoneFailureCounter() {
+    return _wagedHardConstraintFailureCounters.get(HardConstraint.Type.FAULT_ZONE).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintNodeCapacityFailureCounter() {
+    return _wagedHardConstraintFailureCounters.get(HardConstraint.Type.NODE_CAPACITY).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintNodeMaxPartitionLimitFailureCounter() {
+    return _wagedHardConstraintFailureCounters
+        .get(HardConstraint.Type.NODE_MAX_PARTITION_LIMIT).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintReplicaActivateFailureCounter() {
+    return _wagedHardConstraintFailureCounters.get(HardConstraint.Type.REPLICA_ACTIVATE).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintSamePartitionOnInstanceFailureCounter() {
+    return _wagedHardConstraintFailureCounters
+        .get(HardConstraint.Type.SAME_PARTITION_ON_INSTANCE).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintValidGroupTagFailureCounter() {
+    return _wagedHardConstraintFailureCounters.get(HardConstraint.Type.VALID_GROUP_TAG).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintUnknownFailureCounter() {
+    return _wagedHardConstraintFailureCounters.get(HardConstraint.Type.UNKNOWN).get();
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -97,6 +97,81 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    */
   long getContinuousTaskRebalanceFailureCount();
 
+  // ---- WAGED failure-category counters (mirror of WagedRebalancerMetricCollector) ----
+  // Each WAGED HelixRebalanceException increments exactly one of these. The pair
+  // {WagedCustomerActionableFailureCounter, WagedInternalFailureCounter} is the recommended
+  // rollup signal for alert routing.
+
+  /**
+   * @return Number of WAGED failures attributable to customer-controlled cluster/resource
+   *         configuration (sum of capacity, candidate-node, resource-config, cluster-config).
+   */
+  long getWagedCustomerActionableFailureCounter();
+
+  /**
+   * @return Number of WAGED failures attributable to Helix-controlled infrastructure
+   *         (metadata store, algorithm engine, async executor, unknown).
+   */
+  long getWagedInternalFailureCounter();
+
+  /** @return Number of WAGED failures caused by cluster capacity being insufficient. */
+  long getWagedFailureCapacityDeficitCounter();
+
+  /** @return Number of WAGED failures where no candidate node satisfied all hard constraints. */
+  long getWagedFailureNoCandidateNodeCounter();
+
+  /** @return Number of WAGED failures caused by invalid resource configuration. */
+  long getWagedFailureInvalidResourceConfigCounter();
+
+  /** @return Number of WAGED failures caused by invalid cluster/instance configuration. */
+  long getWagedFailureInvalidClusterConfigCounter();
+
+  /** @return Number of WAGED failures caused by assignment-metadata-store I/O. */
+  long getWagedFailureMetadataStoreIoCounter();
+
+  /** @return Number of WAGED failures inside the constraint algorithm internals. */
+  long getWagedFailureAlgorithmInternalCounter();
+
+  /** @return Number of WAGED failures originating in the async runner execution. */
+  long getWagedFailureAsyncExecutionCounter();
+
+  /** @return Number of WAGED failures with no specific category attribution. */
+  long getWagedFailureUnknownCounter();
+
+  /**
+   * @return 1 if the most recent WAGED rebalance returned the last-known-good fallback assignment
+   *         instead of a freshly computed one; 0 otherwise. A sustained 1 indicates WAGED is
+   *         silently serving stale assignments and the underlying failure should be investigated.
+   */
+  long getWagedFallbackInUseGauge();
+
+  // ---- WAGED hard-constraint failure sub-breakdown (subset of WagedFailureNoCandidateNodeCounter) ----
+  // When a partition cannot find any eligible node, every hard constraint that rejected at least
+  // one candidate gets its counter incremented once for that partition. These sub-dimensions let
+  // operators distinguish fault-zone failures from tag failures from capacity failures within the
+  // broader "no candidate node" bucket.
+
+  /** @return Partitions that failed placement because the fault-zone constraint rejected every node. */
+  long getWagedHardConstraintFaultZoneFailureCounter();
+
+  /** @return Partitions that failed placement because per-node capacity constraints rejected every node. */
+  long getWagedHardConstraintNodeCapacityFailureCounter();
+
+  /** @return Partitions that failed placement because the max-partitions-per-instance limit rejected every node. */
+  long getWagedHardConstraintNodeMaxPartitionLimitFailureCounter();
+
+  /** @return Partitions that failed placement because every candidate instance was inactive. */
+  long getWagedHardConstraintReplicaActivateFailureCounter();
+
+  /** @return Partitions that failed placement because the same-partition-on-instance rule rejected every node. */
+  long getWagedHardConstraintSamePartitionOnInstanceFailureCounter();
+
+  /** @return Partitions that failed placement because no instance had the required group tag. */
+  long getWagedHardConstraintValidGroupTagFailureCounter();
+
+  /** @return Partitions that failed placement due to a hard constraint with no specific type tag. */
+  long getWagedHardConstraintUnknownFailureCounter();
+
   /**
    * @return number of all resources in this cluster
    */

--- a/helix-core/src/main/java/org/apache/helix/monitoring/metrics/WagedRebalancerMetricCollector.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/metrics/WagedRebalancerMetricCollector.java
@@ -61,6 +61,28 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
     // compute failure. And this fallback logic won't impact this counting.
     RebalanceFailureCounter,
 
+    // Per-category breakdown of RebalanceFailureCounter. Each WAGED failure increments exactly one
+    // of these in addition to RebalanceFailureCounter. See HelixRebalanceException.FailureCategory.
+    FailureCategoryCapacityDeficitCounter,
+    FailureCategoryNoCandidateNodeCounter,
+    FailureCategoryInvalidResourceConfigCounter,
+    FailureCategoryInvalidClusterConfigCounter,
+    FailureCategoryMetadataStoreIoCounter,
+    FailureCategoryAlgorithmInternalCounter,
+    FailureCategoryAsyncExecutionCounter,
+    FailureCategoryUnknownCounter,
+
+    // Per-HardConstraint sub-dimension of FailureCategoryNoCandidateNodeCounter. When a partition
+    // fails to find any eligible node, every hard constraint that rejected at least one candidate
+    // gets its counter ticked once for that partition. See HardConstraint.Type.
+    HardConstraintFaultZoneFailureCounter,
+    HardConstraintNodeCapacityFailureCounter,
+    HardConstraintNodeMaxPartitionLimitFailureCounter,
+    HardConstraintReplicaActivateFailureCounter,
+    HardConstraintSamePartitionOnInstanceFailureCounter,
+    HardConstraintValidGroupTagFailureCounter,
+    HardConstraintUnknownFailureCounter,
+
     // Waged rebalance counters.
     GlobalBaselineCalcCounter,
     PartialRebalanceCounter,
@@ -117,6 +139,36 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
         new BaselineDivergenceGauge(WagedRebalancerMetricNames.BaselineDivergenceGauge.name());
     CountMetric calcFailureCount =
         new RebalanceFailureCount(WagedRebalancerMetricNames.RebalanceFailureCounter.name());
+    CountMetric failureCategoryCapacityDeficitCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.FailureCategoryCapacityDeficitCounter.name());
+    CountMetric failureCategoryNoCandidateNodeCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.FailureCategoryNoCandidateNodeCounter.name());
+    CountMetric failureCategoryInvalidResourceConfigCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.FailureCategoryInvalidResourceConfigCounter.name());
+    CountMetric failureCategoryInvalidClusterConfigCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.FailureCategoryInvalidClusterConfigCounter.name());
+    CountMetric failureCategoryMetadataStoreIoCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.FailureCategoryMetadataStoreIoCounter.name());
+    CountMetric failureCategoryAlgorithmInternalCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.FailureCategoryAlgorithmInternalCounter.name());
+    CountMetric failureCategoryAsyncExecutionCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.FailureCategoryAsyncExecutionCounter.name());
+    CountMetric failureCategoryUnknownCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.FailureCategoryUnknownCounter.name());
+    CountMetric hardConstraintFaultZoneFailureCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.HardConstraintFaultZoneFailureCounter.name());
+    CountMetric hardConstraintNodeCapacityFailureCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.HardConstraintNodeCapacityFailureCounter.name());
+    CountMetric hardConstraintNodeMaxPartitionLimitFailureCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.HardConstraintNodeMaxPartitionLimitFailureCounter.name());
+    CountMetric hardConstraintReplicaActivateFailureCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.HardConstraintReplicaActivateFailureCounter.name());
+    CountMetric hardConstraintSamePartitionOnInstanceFailureCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.HardConstraintSamePartitionOnInstanceFailureCounter.name());
+    CountMetric hardConstraintValidGroupTagFailureCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.HardConstraintValidGroupTagFailureCounter.name());
+    CountMetric hardConstraintUnknownFailureCounter =
+        new RebalanceFailureCount(WagedRebalancerMetricNames.HardConstraintUnknownFailureCounter.name());
     CountMetric globalBaselineCalcCounter =
         new RebalanceCounter(WagedRebalancerMetricNames.GlobalBaselineCalcCounter.name());
     CountMetric partialRebalanceCounter =
@@ -135,6 +187,21 @@ public class WagedRebalancerMetricCollector extends MetricCollector {
     addMetric(stateWriteLatencyGauge);
     addMetric(baselineDivergenceGauge);
     addMetric(calcFailureCount);
+    addMetric(failureCategoryCapacityDeficitCounter);
+    addMetric(failureCategoryNoCandidateNodeCounter);
+    addMetric(failureCategoryInvalidResourceConfigCounter);
+    addMetric(failureCategoryInvalidClusterConfigCounter);
+    addMetric(failureCategoryMetadataStoreIoCounter);
+    addMetric(failureCategoryAlgorithmInternalCounter);
+    addMetric(failureCategoryAsyncExecutionCounter);
+    addMetric(failureCategoryUnknownCounter);
+    addMetric(hardConstraintFaultZoneFailureCounter);
+    addMetric(hardConstraintNodeCapacityFailureCounter);
+    addMetric(hardConstraintNodeMaxPartitionLimitFailureCounter);
+    addMetric(hardConstraintReplicaActivateFailureCounter);
+    addMetric(hardConstraintSamePartitionOnInstanceFailureCounter);
+    addMetric(hardConstraintValidGroupTagFailureCounter);
+    addMetric(hardConstraintUnknownFailureCounter);
     addMetric(globalBaselineCalcCounter);
     addMetric(partialRebalanceCounter);
     addMetric(emergencyRebalanceCounter);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancer.java
@@ -450,9 +450,17 @@ public class TestWagedRebalancer extends AbstractTestClusterModel {
     Map<String, IdealState> newResult =
         rebalancer.computeNewIdealStates(clusterData, resourceMap, new CurrentStateOutput());
     Assert.assertEquals(newResult, result);
-    // Ensure failure has been recorded
+    // Ensure failure has been recorded on both the aggregate and per-FailureCategory counters.
+    // The mock algorithm throws via the legacy two-arg HelixRebalanceException constructor which
+    // defaults the category to UNKNOWN, so the FailureCategoryUnknownCounter is the one that
+    // should tick. This locks in that the Rebalancer-domain per-category counters are wired
+    // (without this assertion, a regression that registers but does not increment them would go
+    // undetected).
     Assert.assertEquals(rebalancer.getMetricCollector().getMetric(
         WagedRebalancerMetricCollector.WagedRebalancerMetricNames.RebalanceFailureCounter.name(),
+        CountMetric.class).getValue().longValue(), 1L);
+    Assert.assertEquals(rebalancer.getMetricCollector().getMetric(
+        WagedRebalancerMetricCollector.WagedRebalancerMetricNames.FailureCategoryUnknownCounter.name(),
         CountMetric.class).getValue().longValue(), 1L);
   }
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -106,7 +106,7 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
 
     // Check that there exists a non-zero value in the metrics
     Assert.assertTrue(_metricCollector.getMetricMap().values().stream()
-        .anyMatch(metric -> (long) metric.getLastEmittedMetricValue() > 0L));
+        .anyMatch(metric -> ((Number) metric.getLastEmittedMetricValue()).longValue() > 0L));
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
@@ -20,7 +20,9 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
  */
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
@@ -185,6 +187,70 @@ public class TestConstraintBasedAlgorithm {
       algorithm.calculate(clusterModel);
     } catch (HelixRebalanceException ex) {
       Assert.assertEquals(ex.getFailureType(), HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+    }
+  }
+
+  @Test
+  public void testHardConstraintFailureReporterFiresOncePerPartitionAndConstraintType()
+      throws IOException {
+    // Use a real NodeCapacityConstraint forced to reject all candidates so the reporter sees
+    // its Type once per failed partition (set-union semantics across nodes).
+    HardConstraint nodeCapacityConstraint = new NodeCapacityConstraint();
+    SoftConstraint soft1 = new MaxCapacityUsageInstanceConstraint();
+    SoftConstraint soft2 = new InstancePartitionsCountConstraint();
+    ConstraintBasedAlgorithm algorithm = new ConstraintBasedAlgorithm(
+        ImmutableList.of(nodeCapacityConstraint),
+        ImmutableMap.of(soft1, 1f, soft2, 1f),
+        TEST_FORK_JOIN_POOL);
+
+    // Force a capacity overflow that NodeCapacityConstraint will reject on every node.
+    ClusterModel clusterModel = new ClusterModelTestHelper().getMultiNodeClusterModel();
+    Map<String, Set<AssignableReplica>> assignableReplicaMap =
+        new HashMap<>(clusterModel.getAssignableReplicaMap());
+    Set<AssignableReplica> replicas = assignableReplicaMap.get("Resource3");
+    AssignableReplica replica = replicas.iterator().next();
+    replica.getCapacity().put("item3", 40); // available: 30, requested: 40.
+
+    List<HardConstraint.Type> reported = new ArrayList<>();
+    algorithm.setHardConstraintFailureReporter(reported::add);
+
+    try {
+      algorithm.calculate(clusterModel);
+      Assert.fail("Expected HelixRebalanceException for capacity violation");
+    } catch (HelixRebalanceException ex) {
+      Assert.assertEquals(ex.getFailureCategory(),
+          HelixRebalanceException.FailureCategory.NO_CANDIDATE_NODE);
+    }
+    Assert.assertFalse(reported.isEmpty(), "Reporter should have fired at least once");
+    Assert.assertTrue(reported.contains(HardConstraint.Type.NODE_CAPACITY),
+        "Expected NODE_CAPACITY in reported types; got " + reported);
+    // Set-union semantics: each invocation per failed partition should yield NODE_CAPACITY at
+    // most once (a single distinct type rejected every node), not once per node-rejection.
+    long nodeCapacityCount = reported.stream()
+        .filter(t -> t == HardConstraint.Type.NODE_CAPACITY).count();
+    Assert.assertEquals(nodeCapacityCount, 1L,
+        "NODE_CAPACITY should fire exactly once per failed partition, not per node-rejection");
+  }
+
+  @Test
+  public void testHardConstraintFailureReporterIsNoOpWhenUnset() throws IOException {
+    HardConstraint mockHardConstraint = mock(HardConstraint.class);
+    SoftConstraint mockSoftConstraint = mock(SoftConstraint.class);
+    when(mockHardConstraint.isAssignmentValid(any(), any(), any())).thenReturn(false);
+    when(mockHardConstraint.getType()).thenReturn(HardConstraint.Type.UNKNOWN);
+    when(mockSoftConstraint.getAssignmentNormalizedScore(any(), any(), any())).thenReturn(1.0);
+    ConstraintBasedAlgorithm algorithm = new ConstraintBasedAlgorithm(
+        ImmutableList.of(mockHardConstraint),
+        ImmutableMap.of(mockSoftConstraint, 1f),
+        TEST_FORK_JOIN_POOL);
+
+    // No reporter installed -- the failure path must not NPE.
+    ClusterModel clusterModel = new ClusterModelTestHelper().getDefaultClusterModel();
+    try {
+      algorithm.calculate(clusterModel);
+    } catch (HelixRebalanceException ex) {
+      Assert.assertEquals(ex.getFailureCategory(),
+          HelixRebalanceException.FailureCategory.NO_CANDIDATE_NODE);
     }
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -837,4 +837,99 @@ public class TestClusterStatusMonitor {
 
     monitor.reset();
   }
+
+  @Test
+  public void testWagedFailureCategoryCountersStartAtZero() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedCategoriesCluster");
+    Assert.assertEquals(monitor.getWagedFailureCapacityDeficitCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFailureNoCandidateNodeCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFailureInvalidResourceConfigCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFailureInvalidClusterConfigCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFailureMetadataStoreIoCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFailureAlgorithmInternalCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFailureAsyncExecutionCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFailureUnknownCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedInternalFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFallbackInUseGauge(), 0L);
+  }
+
+  @Test
+  public void testWagedFailureCategoryReportRoutesToCorrectCountersAndRollup() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedRoutingCluster");
+
+    monitor.reportWagedFailureByCategory(
+        org.apache.helix.HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT);
+    monitor.reportWagedFailureByCategory(
+        org.apache.helix.HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT);
+    monitor.reportWagedFailureByCategory(
+        org.apache.helix.HelixRebalanceException.FailureCategory.NO_CANDIDATE_NODE);
+    monitor.reportWagedFailureByCategory(
+        org.apache.helix.HelixRebalanceException.FailureCategory.METADATA_STORE_IO);
+
+    Assert.assertEquals(monitor.getWagedFailureCapacityDeficitCounter(), 2L);
+    Assert.assertEquals(monitor.getWagedFailureNoCandidateNodeCounter(), 1L);
+    Assert.assertEquals(monitor.getWagedFailureMetadataStoreIoCounter(), 1L);
+    // Rollup: 3 customer-actionable (2 capacity + 1 candidate-node), 1 internal (metadata store).
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureCounter(), 3L);
+    Assert.assertEquals(monitor.getWagedInternalFailureCounter(), 1L);
+    // Unrelated counters should be untouched.
+    Assert.assertEquals(monitor.getWagedFailureInvalidResourceConfigCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedFailureAsyncExecutionCounter(), 0L);
+  }
+
+  @Test
+  public void testReportWagedFailureByCategoryHandlesNullAsUnknown() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedNullCategoryCluster");
+    monitor.reportWagedFailureByCategory(null);
+    Assert.assertEquals(monitor.getWagedFailureUnknownCounter(), 1L);
+    Assert.assertEquals(monitor.getWagedInternalFailureCounter(), 1L);
+  }
+
+  @Test
+  public void testWagedFallbackInUseGaugeReflectsLatestSetter() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedFallbackGaugeCluster");
+    Assert.assertEquals(monitor.getWagedFallbackInUseGauge(), 0L);
+    monitor.setWagedFallbackInUseGauge(true);
+    Assert.assertEquals(monitor.getWagedFallbackInUseGauge(), 1L);
+    monitor.setWagedFallbackInUseGauge(false);
+    Assert.assertEquals(monitor.getWagedFallbackInUseGauge(), 0L);
+  }
+
+  @Test
+  public void testWagedHardConstraintCountersStartAtZero() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedHardConstraintCluster");
+    Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintNodeMaxPartitionLimitFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintReplicaActivateFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintSamePartitionOnInstanceFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintValidGroupTagFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintUnknownFailureCounter(), 0L);
+  }
+
+  @Test
+  public void testReportWagedHardConstraintFailureIncrementsCorrectCounter() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedHardConstraintReportingCluster");
+
+    monitor.reportWagedHardConstraintFailure(
+        org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint.Type.FAULT_ZONE);
+    monitor.reportWagedHardConstraintFailure(
+        org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint.Type.FAULT_ZONE);
+    monitor.reportWagedHardConstraintFailure(
+        org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint.Type.VALID_GROUP_TAG);
+
+    Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneFailureCounter(), 2L);
+    Assert.assertEquals(monitor.getWagedHardConstraintValidGroupTagFailureCounter(), 1L);
+    // Unrelated buckets stay at zero.
+    Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityFailureCounter(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintReplicaActivateFailureCounter(), 0L);
+  }
+
+  @Test
+  public void testReportWagedHardConstraintFailureHandlesNullAsUnknown() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedHardConstraintNullCluster");
+    monitor.reportWagedHardConstraintFailure(null);
+    Assert.assertEquals(monitor.getWagedHardConstraintUnknownFailureCounter(), 1L);
+  }
 }


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Follow-up to #187. No separate GitHub issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Exposes the `FailureCategory` and `HardConstraint.Type` dimensions introduced by #187 as JMX MBean attributes on both the existing `Rebalancer:cluster=X,entity=WagedRebalancer` MBean (via `WagedRebalancerMetricCollector`) and the existing `ClusterStatus:cluster=X` MBean (via `ClusterStatusMonitor`). Adds a new `WagedFallbackInUseGauge` that flips to 1 when WAGED returns the last-known-good assignment instead of a freshly computed one. Plumbs the cluster monitor reference through `GenericHelixController` -> `WagedRebalancer` -> the async runners.

**Why:** #187 added the categorization data to `HelixRebalanceException` and surfaced it in logs, but cluster-level dashboards still see only the dimensionless `RebalanceFailureCounter`. Customers cannot author alerts that route on category from the existing JMX surface; on-call cannot distinguish customer-actionable failures from Helix-team-owned failures without scraping logs. This PR closes that gap by mirroring the typed counters onto both MBean domains. The two rollup counters (`WagedCustomerActionableFailureCounter`, `WagedInternalFailureCounter`) are the recommended alert-routing signals.

The new `WagedFallbackInUseGauge` closes a separate silent-failure gap: today, when a WAGED failure with `Type` in the non-propagating set occurs, the rebalancer falls back to the last-known-good assignment and the controller pipeline succeeds. No cluster-level signal indicates that WAGED is serving stale data. This PR introduces a binary gauge that flips to 1 on the next pipeline run that uses the fallback, and back to 0 when a fresh calc succeeds.

**How:**

1. **`WagedRebalancerMetricCollector`** -- adds 15 new `CountMetric` entries to the existing `WagedRebalancerMetricNames` enum:
   - 8 per-`FailureCategory` counters: `FailureCategoryCapacityDeficitCounter`, `FailureCategoryNoCandidateNodeCounter`, `FailureCategoryInvalidResourceConfigCounter`, `FailureCategoryInvalidClusterConfigCounter`, `FailureCategoryMetadataStoreIoCounter`, `FailureCategoryAlgorithmInternalCounter`, `FailureCategoryAsyncExecutionCounter`, `FailureCategoryUnknownCounter`.
   - 7 per-`HardConstraint.Type` counters: `HardConstraintFaultZoneFailureCounter`, `HardConstraintNodeCapacityFailureCounter`, `HardConstraintNodeMaxPartitionLimitFailureCounter`, `HardConstraintReplicaActivateFailureCounter`, `HardConstraintSamePartitionOnInstanceFailureCounter`, `HardConstraintValidGroupTagFailureCounter`, `HardConstraintUnknownFailureCounter`.

2. **`ClusterStatusMonitorMBean` + `ClusterStatusMonitor`** -- 18 new MBean attributes mirroring the same dimensions, plus two rollup counters and the fallback gauge:
   - Per-category and per-HardConstraint counters use `Map<Enum, AtomicLong>` pre-populated for every enum value in the constructor, so dashboards see a stable 0 for unused dimensions.
   - `WagedCustomerActionableFailureCounter` / `WagedInternalFailureCounter` -- rollup counters; `reportWagedFailureByCategory` increments both the per-category counter and the appropriate rollup based on `FailureCategory.isCustomerActionable()`.
   - `WagedFallbackInUseGauge` -- 0/1 flag set by `setWagedFallbackInUseGauge(boolean)` from `WagedRebalancer`.
   - `reset()` extended to zero all new counters/gauge on leadership change.

3. **`HardConstraint` and `ConstraintBasedAlgorithm`** -- widened from package-private to public so the metric-reporting layer in `monitoring.mbeans` can reference `HardConstraint.Type` and install a `Consumer<HardConstraint.Type>` reporter on `ConstraintBasedAlgorithm`. Concrete `HardConstraint` subclasses stay package-private; no new operational surface beyond the type identifier.

4. **`ConstraintBasedAlgorithm`** -- adds `setHardConstraintFailureReporter(Consumer<HardConstraint.Type>)`. Inside the existing "no eligible candidate" branch (the same branch that already builds the per-node-per-constraint failure map), the reporter is invoked once per distinct constraint type that contributed to the partition's failure (set union across nodes, not summed). This ensures partition-level attribution: a constraint that rejected 50 nodes for a single partition fires the counter `+1`, not `+50`.

5. **`WagedRebalancer`** -- substantial wiring:
   - Pre-resolves `EnumMap<FailureCategory, CountMetric>` and `EnumMap<HardConstraint.Type, CountMetric>` at construction; subsequent reporting paths increment by `_failureCategoryMetrics.get(category).increment(1L)` instead of looking up by name on every failure.
   - New methods `reportFailureCategory(HelixRebalanceException)`, `reportHardConstraintFailure(HardConstraint.Type)`, `reportAsyncFailure(HelixRebalanceException)` -- each ticks both the Rebalancer-domain and ClusterStatus-domain counters via a single call. `reportAsyncFailure` additionally ticks the aggregate `RebalanceFailureCounter`.
   - `setClusterStatusMonitor(ClusterStatusMonitor)` installs the monitor and wires the per-HardConstraint reporter onto the algorithm via `installHardConstraintFailureReporter`. `updateRebalancePreference` re-installs the reporter on the new algorithm instance.
   - `computeNewIdealStates` now wraps `validateInput` in a try-catch that increments the aggregate + per-category counters before rethrowing, so `INVALID_INPUT` / `INVALID_RESOURCE_CONFIG` failures are no longer silent at the cluster level. A `usedFallback` boolean tracks whether the catch block returned the last-known-good fallback; `setWagedFallbackInUseGauge` is called at the end of the method to reflect the outcome.
   - **Per-instance algorithm refactor**: drops the static `DEFAULT_REBALANCE_ALGORITHM` singleton in favor of `ConstraintBasedAlgorithmFactory.getInstance(DEFAULT_GLOBAL_REBALANCE_PREFERENCE)` in the constructor. The previous singleton was shared across all `WagedRebalancer` instances in the JVM, which would have caused the per-cluster failure reporter to race. The shared `ForkJoinPool` inside the factory is still reused; the only cost is one extra `ConstraintBasedAlgorithm` allocation at controller startup.

6. **Async runners (`GlobalRebalanceRunner`, `PartialRebalanceRunner`)** -- constructor signatures change from `CountMetric rebalanceFailureCount` to `Consumer<HelixRebalanceException> asyncFailureReporter`. The injected Consumer is `WagedRebalancer::reportAsyncFailure` and handles all three counter increments uniformly. Removes the duplicate cluster-monitor plumbing that #187's intermediate design had on each runner.

7. **`GenericHelixController.createRebalancer()`** -- after constructing the `WagedRebalancer`, calls `setClusterStatusMonitor(_clusterStatusMonitor)` so the rebalancer can attribute failures to the cluster's monitor.

### Tests

- [x] The following tests are written for this issue:

**Added to `TestClusterStatusMonitor`** (7 new tests):
- `testWagedFailureCategoryCountersStartAtZero`
- `testWagedFailureCategoryReportRoutesToCorrectCountersAndRollup`
- `testReportWagedFailureByCategoryHandlesNullAsUnknown`
- `testWagedFallbackInUseGaugeReflectsLatestSetter`
- `testWagedHardConstraintCountersStartAtZero`
- `testReportWagedHardConstraintFailureIncrementsCorrectCounter`
- `testReportWagedHardConstraintFailureHandlesNullAsUnknown`

**Added to `TestConstraintBasedAlgorithm`** (2 new tests):
- `testHardConstraintFailureReporterFiresOncePerPartitionAndConstraintType` -- exercises a real `NodeCapacityConstraint` forced to reject every candidate, asserts the installed reporter fires exactly once per failed partition with the `NODE_CAPACITY` type (set-union semantics).
- `testHardConstraintFailureReporterIsNoOpWhenUnset` -- confirms the algorithm fails gracefully when no reporter is installed (no NPE on a null reporter).

**Updated assertions:**
- `TestWagedRebalancer.testAlgorithmException` -- now also asserts the Rebalancer-domain `FailureCategoryUnknownCounter` ticks alongside the existing aggregate counter assertion. Locks in that the new per-category counters are wired (without this assertion, a regression that registers but does not increment them would go undetected).
- `TestWagedRebalancerMetrics.testMetricValuePropagation` -- cast hardened from `(long) metric.getLastEmittedMetricValue()` to `((Number) ...).longValue()`. The new metrics changed `HashMap` iteration order and surfaced a latent bug where a `Double`-typed metric (`BaselineDivergenceGauge`) could now appear before the first `Long` counter and trigger `ClassCastException`.

- The following is the result of the `mvn test` command on the appropriate module:

| Suite | Tests | Result |
| --- | --- | --- |
| WAGED unit + constraint package | 65 | passed |
| Controller stages (BestPossibleStateCalcStage, RebalancePipeline) | 13 | passed |
| `TestClusterStatusMonitor` (now includes 7 new tests) | 14 | passed |
| `TestHelixRebalanceException` | 6 | passed |
| `TestWagedRebalance` (real-ZK integration) | 12 | passed |
| `TestAbnormalStatesResolver` (integration) | 2 | passed |
| **Total** | **112** | **all passed** |

Sample integration log line confirming end-to-end attribution through both the async runner and the new metric layer:

```
HelixRebalanceException: Failed to calculate for the new Baseline.
  Failure Type: FAILED_TO_CALCULATE Category: CAPACITY_DEFICIT
Caused by: HelixRebalanceException: The cluster 'CLUSTER_TestWagedRebalance' does not have
  enough key capacity for all partitions. Total capacity: 9, Required: 360, Deficit: 351
  Failure Type: FAILED_TO_CALCULATE Category: CAPACITY_DEFICIT
```

### Changes that Break Backward Compatibility (Optional)

- [ ] My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

**No breaking changes to public API.** Specifically:
- `ClusterStatusMonitorMBean` only gains new methods; nothing is renamed or removed. Existing JMX scrapers see the original attributes plus 18 new ones.
- `WagedRebalancerMetricCollector` only gains new entries in its `WagedRebalancerMetricNames` enum (which is already public). New metrics are additive.
- `HardConstraint` was widened from package-private to public. The class is still `abstract` and all 6 concrete subclasses keep their original visibility (package-private), so no new operational surface is exposed beyond the type identifier needed by the metric layer.
- `ConstraintBasedAlgorithm` was widened from package-private to public for the same reason -- so `WagedRebalancer` can install the failure reporter via an `instanceof` check. The class is not intended for direct external instantiation; `ConstraintBasedAlgorithmFactory` remains the entry point.
- `WagedRebalancer.setClusterStatusMonitor(ClusterStatusMonitor)` is additive. `ReadOnlyWagedRebalancer` and any external caller that does not call it continue to operate -- all metric-publication code paths null-check the reference.

**Behavior guarantee on rebalancing logic:**
Rebalancing decisions are bitwise identical to pre-PR. The per-instance `ConstraintBasedAlgorithm` instance is a fresh allocation of the same code, sharing the same `ForkJoinPool` inside the factory. The `FAILURE_TYPES_TO_PROPAGATE` decision in `WagedRebalancer.computeNewIdealStates` is unchanged; the fallback path runs in the same scenarios as before; the algorithm computation is untouched.

**Behavior changes that are not API breaks but worth noting:**
- `validateInput` failures now tick `RebalanceFailureCounter` and the matching per-category counter (previously they were not counted at the cluster level). The counter is monotonic so the step-up is observable but does not regress any contract.
- The `WagedRebalancer` constructor allocates a fresh `ConstraintBasedAlgorithm` instead of sharing the previously static `DEFAULT_REBALANCE_ALGORITHM` field. This is a one-time cost at controller startup; the shared `ForkJoinPool` inside the factory is still reused, so steady-state behavior is identical.

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

N/A. New MBean attributes are self-documenting via Javadoc on `ClusterStatusMonitorMBean` and the `WagedRebalancerMetricCollector.WagedRebalancerMetricNames` enum.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines.

### Code Quality

- [x] My diff has been formatted using helix-style.xml
(helix-style-intellij.xml if IntelliJ IDE is used)

Code style follows the surrounding conventions in each touched file (existing import order, indentation, brace placement, Javadoc style).

---

### Performance impact

- **Hot path** (`ConstraintBasedAlgorithm.calculate()` scoring loop): untouched. The new code only runs in catch blocks or the existing "no eligible candidate" branch.
- **Success path overhead per pipeline event**: ~10-20 nanoseconds. The added work is one volatile read of `_clusterStatusMonitor`, one null check, and one volatile boolean write to flip the fallback gauge to `false`. Zero new allocations on the success path.
- **Per-HardConstraint reporter overhead**: runs only inside the existing `if (candidateNodes.isEmpty())` branch -- i.e., only when a partition has already failed to find any eligible node. The work is a `stream().distinct().forEach()` over the constraints that contributed (typically < 10 elements). Zero overhead on the success path; sub-microsecond on the failure path.
- **Per-WagedRebalancer algorithm instance**: one extra `ConstraintBasedAlgorithm` allocation at controller startup vs. sharing the static singleton. The shared `ForkJoinPool` is still reused. Negligible.
- **Memory**: ~400 bytes added per `ClusterStatusMonitor` instance (one per cluster) for the per-category and per-HardConstraint counter maps plus rollup atomics.
- **JMX surface**: 18 new attributes on `ClusterStatusMonitor` (8 per-category + 2 rollup + 1 gauge + 7 per-HardConstraint), 15 new attributes on `WagedRebalancerMetricCollector` (8 per-category + 7 per-HardConstraint). Each getter is `AtomicLong.get()` or `Map.get(...).get()` -- microsecond-scale and only polled by external scrapers at typical 30-60s intervals.
