### PR TITLE
Skip Codecov upload on non-apache forks in PR CI

### DIFF
--- a/.github/workflows/Helix-PR-CI.yml
+++ b/.github/workflows/Helix-PR-CI.yml
@@ -25,7 +25,9 @@ jobs:
     - name: Run All Tests
       run: mvn -q -fae test
     - name: Upload coverage to Codecov
-      if: ${{ success() || failure() }}
+      # Skip on forks: no CODECOV_TOKEN -> tokenless uploads are rejected and
+      # fail_ci_if_error would fail the whole check. Same guard as Helix-CI.yml.
+      if: ${{ github.repository == 'apache/helix' && (success() || failure()) }}
       uses: codecov/codecov-action@v5
       with:
         files: '**/target/site/jacoco/jacoco.xml'


### PR DESCRIPTION
### Issues

- Every PR against `linkedin/helix` is being marked red by the `Upload coverage to Codecov` step, even when all tests pass. Confirmed across PRs #185, #190, and on every recent run.
- No JIRA/GitHub issue tracks this directly; surfaced while investigating CI on PR #190.

### Description

`Helix-PR-CI.yml` has a Codecov step with `fail_ci_if_error: true` and **no `github.repository` guard**. On `linkedin/helix` (and any other fork) there is no `CODECOV_TOKEN` configured, so the action runs `codecov upload-coverage` with `Token length: 0`, codecov's API rejects the upload with `Token required because branch is protected`, and the action exits 1 — marking the entire `PR_CI` job as `FAILURE` despite every test passing.

The matching workflow `Helix-CI.yml` (master / scheduled CI) already gates its Codecov step to the upstream Apache repository:

```yaml
# Helix-CI.yml
- name: Upload to Codecov
  uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
  if: ${{ github.repository == 'apache/helix' && github.event_name == 'push' && (success() || failure()) }}
```

This PR mirrors the same guard in `Helix-PR-CI.yml` so the Codecov step only runs on `apache/helix`, where the token is configured. Coverage enforcement on the upstream Apache repo is unchanged. Forks just stop emitting spurious red marks.

#### Why the PR_CI step was missing the guard

PR #158 (`Enforce code coverage checks on pull requests`, March 31 2026) added the Codecov step to PR CI and intentionally set `fail_ci_if_error: true` to avoid silent bypass of coverage enforcement. The intent makes sense on `apache/helix`. The guard that already existed in `Helix-CI.yml` was simply not carried over to the new step in `Helix-PR-CI.yml`.

#### Diff

```diff
     - name: Upload coverage to Codecov
-      if: ${{ success() || failure() }}
+      # Skip on forks: no CODECOV_TOKEN -> tokenless uploads are rejected and
+      # fail_ci_if_error would fail the whole check. Same guard as Helix-CI.yml.
+      if: ${{ github.repository == 'apache/helix' && (success() || failure()) }}
       uses: codecov/codecov-action@v5
       with:
         files: '**/target/site/jacoco/jacoco.xml'
         fail_ci_if_error: true
```

### Tests

The following tests are written for this issue:

No tests added; this is a one-line workflow gate. CI itself is the validation surface.

The following is the result of running `mvn test` against the affected test classes:

N/A — workflow file change only, no Java code touched.

### Changes that Break Backward Compatibility (Optional)

None. On `apache/helix` the Codecov step runs exactly as before (the guard short-circuits to true). On forks the step is skipped, which is the desired behavior since uploads were failing anyway.

### Documentation (Optional)

None.

### Commits

Single commit. Subject in imperative mood under 80 chars; body explains the **what** and **why** with reference to the introducing PR (#158) and the matching pattern in `Helix-CI.yml`.

### Code Quality

One-line `if:` change plus a 2-line comment. No new style warnings; YAML formatting matches the surrounding workflow file.