### PR TITLE
Bump vulnerable dependencies to clear oss-canary CVEs

### DIFF
--- a/helix-admin-webapp/pom.xml
+++ b/helix-admin-webapp/pom.xml
@@ -95,12 +95,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/helix-admin-webapp/pom.xml
+++ b/helix-admin-webapp/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.helix</groupId>
@@ -90,17 +90,17 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.21</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.0</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/helix-agent/pom.xml
+++ b/helix-agent/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.helix</groupId>

--- a/helix-common/pom.xml
+++ b/helix-common/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -76,22 +76,22 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.12.7</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/helix-core/pom.xml
+++ b/helix-core/pom.xml
@@ -86,12 +86,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/helix-core/src/test/java/org/apache/helix/ZkTestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/ZkTestHelper.java
@@ -399,9 +399,11 @@ public class ZkTestHelper {
     ZkConnection connection = ((ZkConnection) zkClient.getConnection());
     ZooKeeper zk = connection.getZookeeper();
 
-    java.lang.reflect.Field field = getField(zk.getClass(), "watchManager");
-    field.setAccessible(true);
-    Object watchManager = field.get(zk);
+    // ZooKeeper 3.7+ moved the watch manager from a `watchManager` field to a
+    // package-private getWatchManager() method on ZooKeeper.
+    java.lang.reflect.Method method = zk.getClass().getDeclaredMethod("getWatchManager");
+    method.setAccessible(true);
+    Object watchManager = method.invoke(zk);
 
     java.lang.reflect.Field field2 = getField(watchManager.getClass(), "dataWatches");
     field2.setAccessible(true);

--- a/helix-core/src/test/java/org/apache/helix/mock/MockZkClient.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockZkClient.java
@@ -27,6 +27,7 @@ import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkAsyncCallbacks;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.zookeeper.KeeperException;
 
 public class MockZkClient extends ZkClient implements HelixZkClient {
   Map<String, byte[]> _dataMap;
@@ -42,7 +43,11 @@ public class MockZkClient extends ZkClient implements HelixZkClient {
       final ZkAsyncCallbacks.GetDataCallbackHandler cb) {
     if (_dataMap.containsKey(path)) {
       if (_dataMap.get(path) == null) {
-        cb.processResult(4, path, null, _dataMap.get(path), null);
+        // Simulate a read failure for a null-data node with a valid ZK error code
+        // (non-OK / non-NONODE). ZooKeeper 3.7+ makes KeeperException.Code.get() throw on
+        // unrecognized codes, whereas 3.6 returned null for the previous literal 4.
+        cb.processResult(KeeperException.Code.MARSHALLINGERROR.intValue(), path, null,
+            _dataMap.get(path), null);
       } else {
         cb.processResult(0, path, null, _dataMap.get(path), null);
       }

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -124,12 +124,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.57.v20241219</version>
+      <version>9.4.58.v20250814</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.57.v20241219</version>
+      <version>9.4.58.v20250814</version>
     </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.48.v20220622</version>
+      <version>9.4.57.v20241219</version>
     </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.helix</groupId>
@@ -84,12 +84,12 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.56.v20240826</version>
+      <version>9.4.57.v20241219</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
@@ -119,17 +119,17 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.21</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.12.7</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/helix-view-aggregator/pom.xml
+++ b/helix-view-aggregator/pom.xml
@@ -65,12 +65,12 @@ under the License.
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.helix</groupId>
@@ -79,12 +79,12 @@ under the License.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.0</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/helix-view-aggregator/pom.xml
+++ b/helix-view-aggregator/pom.xml
@@ -79,12 +79,12 @@ under the License.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestUtil.java
+++ b/meta-client/src/test/java/org/apache/helix/metaclient/impl/zk/TestUtil.java
@@ -65,9 +65,11 @@ public class TestUtil {
     ZkConnection connection = ((ZkConnection) zkClient.getConnection());
     ZooKeeper zk = connection.getZookeeper();
 
-    java.lang.reflect.Field field = getField(zk.getClass(), "watchManager");
-    field.setAccessible(true);
-    Object watchManager = field.get(zk);
+    // ZooKeeper 3.7+ moved the watch manager from a `watchManager` field to a
+    // package-private getWatchManager() method on ZooKeeper.
+    java.lang.reflect.Method method = zk.getClass().getDeclaredMethod("getWatchManager");
+    method.setAccessible(true);
+    Object watchManager = method.invoke(zk);
 
     java.lang.reflect.Field field2 = getField(watchManager.getClass(), "dataWatches");
     field2.setAccessible(true);

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/metadata-store-directory-common/pom.xml
+++ b/metadata-store-directory-common/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -72,12 +72,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/metrics-common/pom.xml
+++ b/metrics-common/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.18.6</version>
+        <version>2.15.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -511,7 +511,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>9.4.57.v20241219</version>
+        <version>9.4.58.v20250814</version>
       </dependency>
       <dependency>
         <groupId>org.apache.helix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -486,17 +486,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.17.1</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.17.1</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.17.1</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.restlet.jse</groupId>
@@ -511,7 +511,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>9.4.56.v20240826</version>
+        <version>9.4.57.v20241219</version>
       </dependency>
       <dependency>
         <groupId>org.apache.helix</groupId>
@@ -542,8 +542,37 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-codec</artifactId>
-        <version>4.1.68.Final</version>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.133.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.18.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>32.1.3-jre</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.18.6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>1.4.21</version>
+      </dependency>
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>2.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/recipes/distributed-lock-manager/pom.xml
+++ b/recipes/distributed-lock-manager/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
   </dependencies>
   <build>

--- a/recipes/rabbitmq-consumer-group/pom.xml
+++ b/recipes/rabbitmq-consumer-group/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/recipes/rsync-replicated-file-system/pom.xml
+++ b/recipes/rsync-replicated-file-system/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/recipes/service-discovery/pom.xml
+++ b/recipes/service-discovery/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/recipes/task-execution/pom.xml
+++ b/recipes/task-execution/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
+      <version>2.18.6</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.6.3</version>
+      <version>3.8.6</version>
       <exclusions>
         <exclusion>
           <groupId>junit</groupId>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -78,6 +78,17 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <!-- ZK 3.8.x defaults to logback for logging; Helix routes SLF4J through
+             log4j2 (log4j-slf4j-impl), so exclude logback to avoid a dual binding
+             and the logback-core CVEs (CVE-2025-11226, CVE-2026-1225). -->
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.6</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/introspect/CodehausJacksonIntrospector.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/introspect/CodehausJacksonIntrospector.java
@@ -26,12 +26,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties.Value;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Typing;
-import com.fasterxml.jackson.databind.annotation.NoClass;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
@@ -54,19 +52,6 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
       return Value.forIgnoreUnknown(ignoreAnnotation.ignoreUnknown());
     }
     return super.findPropertyIgnorals(a);
-  }
-
-  @SuppressWarnings("deprecation")
-  @Override
-  public Class<?> findDeserializationContentType(Annotated a, JavaType baseContentType) {
-    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
-    if (serializeAnnotation != null) {
-      Class<?> serClass = serializeAnnotation.contentAs();
-      if (serClass != NoClass.class) {
-        return serClass;
-      }
-    }
-    return null;
   }
 
   @Override
@@ -105,19 +90,6 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
     return null;
   }
 
-  @SuppressWarnings("deprecation")
-  @Override
-  public Class<?> findSerializationContentType(Annotated a, JavaType baseType) {
-    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
-    if (serializeAnnotation != null) {
-      Class<?> serClass = serializeAnnotation.contentAs();
-      if (serClass != NoClass.class) {
-        return serClass;
-      }
-    }
-    return null;
-  }
-
   /*
    * Handles JsonSerialize.Inclusion
    */
@@ -132,48 +104,6 @@ public class CodehausJacksonIntrospector extends NopAnnotationIntrospector {
       }
     }
     return JsonInclude.Value.empty();
-  }
-
-  @SuppressWarnings("deprecation")
-  @Override
-  public Include findSerializationInclusion(Annotated a, Include defValue) {
-    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
-    return serializeAnnotation == null ? defValue
-        : Include.valueOf(serializeAnnotation.include().name());
-  }
-
-  @SuppressWarnings("deprecation")
-  @Override
-  public Include findSerializationInclusionForContent(Annotated a, JsonInclude.Include defValue) {
-    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
-    return serializeAnnotation == null ? defValue
-        : Include.valueOf(serializeAnnotation.include().name());
-  }
-
-  @SuppressWarnings("deprecation")
-  @Override
-  public Class<?> findSerializationKeyType(Annotated a, JavaType baseType) {
-    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
-    if (serializeAnnotation != null) {
-      Class<?> serClass = serializeAnnotation.keyAs();
-      if (serClass != NoClass.class) {
-        return serClass;
-      }
-    }
-    return null;
-  }
-
-  @SuppressWarnings("deprecation")
-  @Override
-  public Class<?> findSerializationType(Annotated a) {
-    JsonSerialize serializeAnnotation = a.getAnnotation(JsonSerialize.class);
-    if (serializeAnnotation != null) {
-      Class<?> serClass = serializeAnnotation.as();
-      if (serClass != NoClass.class) {
-        return serClass;
-      }
-    }
-    return null;
   }
 
   @Override

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestHelper.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/impl/ZkTestHelper.java
@@ -360,9 +360,11 @@ public class ZkTestHelper {
     ZkConnection connection = ((ZkConnection) zkClient.getConnection());
     ZooKeeper zk = connection.getZookeeper();
 
-    java.lang.reflect.Field field = getField(zk.getClass(), "watchManager");
-    field.setAccessible(true);
-    Object watchManager = field.get(zk);
+    // ZooKeeper 3.7+ moved the watch manager from a `watchManager` field to a
+    // package-private getWatchManager() method on ZooKeeper.
+    java.lang.reflect.Method method = zk.getClass().getDeclaredMethod("getWatchManager");
+    method.setAccessible(true);
+    Object watchManager = method.invoke(zk);
 
     java.lang.reflect.Field field2 = getField(watchManager.getClass(), "dataWatches");
     field2.setAccessible(true);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #200

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Upgrades the dependencies flagged by `oss-canary` to non-vulnerable versions, plus two
supporting code changes (a Jackson introspector migration and a logback exclusion). This takes the
flagged set from **12 vulnerable dependencies down to 1** (Jetty), and resolves **26 of 28 CVEs**.
The 2 remaining are `jetty-http` CVEs that are fixed only in Jetty 12.x (which requires Java 17,
while Helix targets Java 11); they are tracked as a documented exception below.

**Dependency / build changes:**

| Library | From | To |
|---|---|---|
| `log4j-api` / `log4j-core` / `log4j-slf4j-impl` | 2.17.1 | 2.25.4 |
| `commons-lang3` | 3.8.1 | 3.18.0 |
| `guava` | 27.0.1-android | 32.1.3-jre |
| `xstream` | 1.4.19 | 1.4.21 |
| `jackson` (BOM + all module pins) | 2.11.1 / 2.12.7 / 2.13.0 | 2.15.4 |
| `netty` (via `netty-bom`) | 4.1.63 / 4.1.68 | 4.1.133.Final |
| `jetty-server` / `jetty-servlet` | 9.4.48 / 9.4.56 | 9.4.58.v20250814 |
| `zookeeper` | 3.6.3 | 3.8.6 |
| `logback-core` / `logback-classic` | 1.3.15 (transitive via ZK) | **excluded** |

**Supporting code changes (not just version bumps):**

1. **`CodehausJacksonIntrospector` migration (zookeeper-api).** Jackson `2.13+` removed six
   `AnnotationIntrospector` methods this ZNRecord Jackson-1-annotation shim overrode
   (`findSerialization{Type,KeyType,ContentType,Inclusion,InclusionForContent}` and
   `findDeserializationContentType`); they were deleted. `ZNRecord`'s only `@JsonSerialize`
   attribute is `include = NON_NULL`, preserved by the retained `findPropertyInclusion` override.
2. **Exclude logback from ZooKeeper (zookeeper-api).** ZooKeeper 3.8.x defaults its logging
   backend to logback, so the `3.6.3 → 3.8.6` bump pulled in `logback-core` / `logback-classic`
   `1.3.15` (which carry the 2 logback CVEs below). Helix routes SLF4J through log4j2, so logback
   is excluded — removing the CVEs and a dual SLF4J binding. ZK logging continues via log4j2.
3. **Test compatibility fixes for the ZooKeeper upgrade (test-only).** ZooKeeper 3.7+ changed two
   internals the tests relied on: `ZooKeeper.watchManager` became a package-private
   `getWatchManager()` method (the watcher-leak test helpers now invoke the method instead of
   reflecting the field), and `KeeperException.Code.get(int)` now throws on an unrecognized code
   (the `MockZkClient` test mock now injects a valid `MARSHALLINGERROR` code instead of a literal
   `4`). No product code changed.

#### ✅ Resolved CVEs (26)

| CVE | Severity | Component | Vulnerability | Fixed in | Cleared by |
|---|---|---|---|---|---|
| CVE-2023-44981 | **Critical** | zookeeper | SASL quorum-peer authorization bypass | 3.8.3 | zookeeper 3.8.6 |
| CVE-2025-49128 | High | jackson-core | Memory disclosure via source snippet in exception | 2.13.0 | jackson 2.15.4 |
| CVE-2025-52999 | High | jackson-core | StackOverflow on deeply nested input | 2.15.0 | jackson 2.15.4 |
| CVE-2026-42583 | High | netty-codec | `Lz4FrameDecoder` resource exhaustion | 4.1.133 | netty 4.1.133 |
| CVE-2021-37136 | High | netty-codec | `Bzip2Decoder` unbounded decompression DoS | 4.1.68 | netty 4.1.133 |
| CVE-2021-37137 | High | netty-codec | `SnappyFrameDecoder` unbounded chunk DoS | 4.1.68 | netty 4.1.133 |
| CVE-2022-41966 | High | xstream | Stack-overflow DoS | 1.4.20 | xstream 1.4.21 |
| CVE-2022-40151 | High | xstream | Deeply-nested-object DoS | 1.4.20 | xstream 1.4.21 |
| CVE-2024-47072 | High | xstream | BinaryStreamDriver stack-overflow DoS | 1.4.21 | xstream 1.4.21 |
| CVE-2024-13009 | High | jetty-server | `GzipHandler` request-body cross-contamination | 9.4.57 | jetty 9.4.58 |
| CVE-2024-8184 | High | jetty-server | `ThreadLimitHandler` remote OOM DoS | 9.4.56 | jetty 9.4.58 |
| CVE-2025-48924 | Moderate | commons-lang3 | Uncontrolled recursion in `ClassUtils.getClass` | 3.18.0 | commons-lang3 3.18.0 |
| CVE-2023-2976 | Moderate | guava | Insecure temp-directory (`Files.createTempDir`) | 32.0.0 | guava 32.1.3-jre |
| CVE-2020-8908 | Low | guava | Temp-dir info disclosure (`FileBackedOutputStream`) | 32.0.0 | guava 32.1.3-jre |
| CVE-2025-58057 | Moderate | netty-codec | Zip-bomb decoder DoS | 4.1.125 | netty 4.1.133 |
| CVE-2023-34462 | Moderate | netty-handler | `SniHandler` 16MB per-connection allocation DoS | 4.1.94 | netty 4.1.133 |
| CVE-2025-68161 | Moderate | log4j-core | Socket Appender skips TLS hostname verification (MITM) | 2.25.3 | log4j 2.25.4 |
| CVE-2026-34477 | Moderate | log4j-core | `verifyHostName` silently ignored (MITM) | 2.25.4 | log4j 2.25.4 |
| CVE-2026-34480 | Low | log4j-core | `XmlLayout` silent log-event loss | 2.25.4 | log4j 2.25.4 |
| CVE-2023-26048 | Low | jetty-server | Multipart-without-filename OOM DoS | 9.4.51 | jetty 9.4.58 |
| CVE-2023-26049 | Low | jetty-server | Quoted-cookie value exfiltration | 9.4.51 | jetty 9.4.58 |
| CVE-2023-40167 | Low | jetty-http | Accepts `+`-prefixed `Content-Length` (smuggling) | 9.4.52 | jetty 9.4.58 |
| CVE-2025-11143 | Low | jetty-http | Divergent invalid-URI parsing | 9.4.x* | jetty 9.4.58 |
| CVE-2024-23944 | Moderate | zookeeper | Persistent-watcher info disclosure (missing ACL) | 3.8.4 | zookeeper 3.8.6 |
| CVE-2025-11226 | Moderate | logback-core | Arbitrary code execution via config injection | 1.3.16 / 1.5.19 | **excluded** |
| CVE-2026-1225 | Low | logback-core | Instantiation of arbitrary classpath classes | 1.5.25 | **excluded** |

\* CVE-2025-11143: OSV lists the formal fix in 12.0.31, but the released `9.4.58.v20250814`
artifact is not flagged for it (confirmed by re-scan); the EOL 9.4 line received the fix.

#### ❌ Not resolved (2) - and why

| CVE | Severity | Component | Vulnerability | Why not resolved |
|---|---|---|---|---|
| CVE-2026-2332 | **High** | jetty-http 9.4.58 | HTTP request smuggling via chunked-extension quoted-string parsing | Fixed **only in Jetty 12.0.33 / 12.1.7**. Jetty 9.4 / 10 / 11 are all EOL with no public fix (9.4.60 exists only as a commercial HeroDevs/Tuxcare backport, not on Maven Central). Jetty 12 requires **Java 17** (Helix is Java 11) plus a `javax`→`jakarta` servlet migration. Mitigated operationally: helix-rest is an internal control-plane API behind the edge/proxy layer. |
| CVE-2024-6763 | Moderate | jetty-http 9.4.58 | `HttpURI` invalid-authority parsing (SSRF/redirect) | Fixed **only in Jetty 12.0.12** — no 9.4/10/11 fix exists. **Not exploitable in Helix**: the advisory states impact is limited to code using `org.eclipse.jetty.http.HttpURI` directly as a validator; verified Helix has **zero** `HttpURI` usage (only `HttpVersion`). |

**Why not Jetty 10/11 instead of 12?** Evaluated and rejected: Jetty 10/11 are EOL; `11.0.26`
(the latest public 11.0.x) is still affected by both CVE-2026-2332 and CVE-2024-6763 **and**
re-introduces CVE-2025-11143 — a net regression — while also requiring the `jakarta.servlet`
migration. `9.4.58.v20250814` (latest public 9.4.x) is the most that can be cleared on Java 11.

### Tests

- [x] The following tests are written for this issue:

No new permanent tests were added; the changes are dependency upgrades plus an internal-shim
migration covered by existing serialization tests. The introspector migration was validated
against `TestZNRecordSerializeWriteSizeLimit` and a temporary `ZNRecord` serialize→deserialize
round-trip (NON_NULL omission, field naming, equality) that passed and was removed. The ZooKeeper
3.8 upgrade additionally required the test-helper compatibility fixes in item 3 above; the 11
tests it originally broke (8 in helix-core, 3 in meta-client) were re-run locally and pass.

- The following is the result of the "mvn test" command on the appropriate module:

```
$ mvn -pl zookeeper-api test -Dtest=TestZNRecordSerializeWriteSizeLimit
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS

$ mvn -Dmaven.test.skip=true clean install        # full reactor, all changes applied
[INFO] Reactor Summary:
[INFO] Apache Helix ........................... SUCCESS
[INFO] ... (all 16 reactor modules) ........... SUCCESS
[INFO] BUILD SUCCESS

# the tests the ZK 3.8 upgrade originally broke, re-run after the test-helper fixes:
$ mvn -pl helix-core  test -Dtest='TestZkBasis,TestZKWatch,TestWatcherLeakageOnController,TestZkCallbackHandlerLeak,TestHelixDataAccessor#...'
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0      # helix-core
$ mvn -pl meta-client test -Dtest='TestZkMetaClient#testChildChangeListener+testDataChangeListener+testDirectChildChangeListener'
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0      # meta-client
```

Post-change OSV scan of the built artifact: the only remaining CVEs are the **2** deferred
`jetty-http` ones. jackson, ZooKeeper, logback, netty, log4j, guava, commons-lang3 and xstream are
all clear.

### Changes that Break Backward Compatibility (Optional)

- `org.apache.helix.zookeeper.introspect.CodehausJacksonIntrospector` (an internal `ZNRecord`
  serialization helper) loses six `public` methods that overrode now-removed Jackson APIs. Not
  Helix public API; `ZNRecord` wire format is unchanged.
- `ch.qos.logback:logback-core` / `logback-classic` are no longer on the classpath (excluded from
  the ZooKeeper dependency). Helix binds SLF4J to log4j2, so logging is unaffected; consumers
  relying on logback arriving transitively via Helix would need to add it explicitly.
- Transitive dependency versions move forward (jackson / netty / jetty / log4j / guava /
  commons-lang3 / xstream / zookeeper).

### Documentation (Optional)

- N/A — no new functionality. The Jetty-12 / Java-17 rationale for the two deferred CVEs is in the
  Description above for reviewer context.

### Commits

- [x] My commits follow the "How to write a good git commit message" guidelines:
  - `Bump dependencies to clear oss-canary CVEs`
  - `Align helix-rest jetty-servlet to 9.4.57`
  - `Bump ZooKeeper to 3.8.6 to clear CVE-2023-44981 and CVE-2024-23944`
  - `Bump Jetty to 9.4.58.v20250814 to clear CVE-2025-11143`
  - `Exclude logback from ZooKeeper to clear logback-core CVEs`
  - `Fix tests broken by the ZooKeeper 3.6 -> 3.8 upgrade`
  - `Pin jackson to 2.15.4 - minimal 2.15.x clearing the reachable CVEs`

### Code Quality

- [x] My diff has been formatted using helix-style.xml. Changes are limited to pom version edits,
  dependency exclusions, and method removals that preserve the surrounding file's formatting.
