### PR TITLE
Remove unused xstream dependency to unblock ELR

### DIFF
--- a/helix-rest/pom.xml
+++ b/helix-rest/pom.xml
@@ -117,11 +117,6 @@
       <version>9.4.58.v20250814</version>
     </dependency>
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>1.4.21</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.15.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -565,11 +565,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>1.4.21</version>
-      </dependency>
-      <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>2.2</version>


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Follow-up to #200 (the `oss-canary` CVE dependency bump), which moved `xstream` `1.4.19 -> 1.4.21`.
That bump pushed `xstream` into the `1.4.18+` range, which is on LinkedIn's permanent **ELR denylist**
([TOOLS-315581](https://linkedin.atlassian.net/browse/TOOLS-315581), `externalLibraryBlacklists/7`),
so the helix ELR now fails validation with:

```
com.thoughtworks.xstream:xstream 1.4.18+ contains backward incompatible changes.
Please add it to deny list. See https://github.com/x-stream/xstream/issues/270 for detail
```

### Description

- [x] Here are some details about my PR:

**What:** Removes the unused `com.thoughtworks.xstream:xstream` dependency from `helix-rest`, and
drops its (now-orphaned) version pin from the root `pom.xml` `<dependencyManagement>`.

**Why:** `xstream 1.4.18+` is denylisted at LinkedIn because xstream introduced a
backward-incompatible security change (deny-all-types-by-default) in a *patch* release
([xstream #270](https://github.com/x-stream/xstream/issues/270)), which previously reached PROD via
an automatic patch bump and caused an incident. The denylist blocks the helix ELR from importing the
release. At the same time `oss-canary` flags older `xstream` for CVEs, so no in-range version can
satisfy both gates. The dependency is **unused**, so removing it resolves both: the ELR no longer
sees a denylisted artifact, and the `xstream` CVE surface is eliminated entirely.

**How / why it is safe:** `xstream` was a declared dependency but is **not referenced anywhere in the
source** - `git grep` for `com.thoughtworks.xstream` / `XStream` across all `*.java` returns **0
matches**. `helix-rest` serializes via Jackson, not xstream. The root `pom.xml` entry was a
`<dependencyManagement>` version pin only (not an inherited dependency), so removing it changes no
other module. Both edited POMs remain well-formed XML.

**Files changed (10 lines removed, no code changes):**

| File | Change |
|---|---|
| `helix-rest/pom.xml` | Remove unused `xstream` `1.4.21` `<dependency>` |
| `pom.xml` | Remove orphaned `xstream` `1.4.21` pin from `<dependencyManagement>` |

### Tests

- [x] The following tests are written for this issue:

None. This removes an unused dependency declaration with no production-code change, so no new tests
apply.

- The following is the result of the "mvn test" command on the appropriate module:

Validation performed (JDK 11):
- `git grep -i 'thoughtworks.xstream\|XStream' -- '*.java'` -> 0 usages in main or test sources.
- XML well-formedness verified for all three POMs.
- `mvn -B -pl helix-rest -am clean test-compile` -> **BUILD SUCCESS** (~34s). The full upstream
  chain compiled main + test sources with xstream removed from the classpath: `metrics-common`,
  `metadata-store-directory-common`, `zookeeper-api`, `helix-common`, `helix-core`, and
  `helix-rest` all SUCCESS.
- Note: `helix-admin-webapp` also declares the same unused `xstream`, but it is **not** a `<module>`
  in the `dev` reactor (not built or published from `dev`), so it is intentionally left out of this
  PR and can be cleaned up separately.

### Changes that Break Backward Compatibility (Optional)

- `xstream` is removed from the **transitive runtime/compile classpath** of `helix-rest`. Helix
  itself does not use it, but any downstream consumer that was implicitly relying on xstream arriving
  transitively via this module would no longer receive it and should declare
  `com.thoughtworks.xstream:xstream` as a direct dependency themselves (at a version that satisfies
  their own policy). No Helix public method or API behavior changes.

### Documentation (Optional)

- N/A (dependency cleanup; no new functionality).

### Commits

- [x] Commit `Remove unused xstream dependency to unblock ELR` follows the commit-message guidelines
  (imperative subject, blank line, body explaining what/why).

### Code Quality

- [x] Diff is a POM-only dependency removal; no Java formatting applies. Indentation preserved,
  no blank lines introduced.
