### PR TITLE
Exclude slf4j-api from ZooKeeper to keep SLF4J at 1.7.x

### DIFF
--- a/zookeeper-api/pom.xml
+++ b/zookeeper-api/pom.xml
@@ -89,6 +89,15 @@
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-core</artifactId>
         </exclusion>
+        <!-- ZooKeeper 3.8.x's parent pins slf4j.version to 2.0.13. SLF4J 1.8+/2.x
+             is disallowed by LinkedIn build enforcement (go/slf4j-1.8), and Helix
+             binds SLF4J via log4j-slf4j-impl (the 1.7 binding). Exclude ZK's
+             transitive slf4j-api so the slf4j-api:1.7.32 declared directly by the
+             Helix modules is the only version on the classpath. -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
ZooKeeper 3.8.6 (bumped in #192 from 3.6.3) pins slf4j.version=2.0.13 in its parent pom, so helix-core transitively published slf4j-api:2.0.13. LinkedIn build enforcement (go/slf4j-1.8) forbids SLF4J 1.8+/2.x, which broke every downstream consumer (helix-lib, torque, nuage-ambry, helix-cluster-view).

Helix binds SLF4J via log4j-slf4j-impl (the 1.7 binding) and already declares slf4j-api:1.7.32 directly in each module. Exclude ZK's transitive slf4j-api so 1.7.32 is the only version on the classpath, matching the existing slf4j-log4j12/logback exclusions on the same dependency. Verified via mvn dependency:tree that zookeeper-api and helix-core now resolve slf4j-api:1.7.32.

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
