### PR TITLE
Add cluster capacity utilization gauge for WAGED

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/CurrentStateComputationStage.java
@@ -40,6 +40,7 @@ import org.apache.helix.controller.rebalancer.util.WagedValidationUtil;
 import org.apache.helix.controller.rebalancer.waged.WagedInstanceCapacity;
 import org.apache.helix.controller.rebalancer.waged.WagedResourceWeightsProvider;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
+import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterModelProvider;
 import org.apache.helix.model.CurrentState;
@@ -359,6 +360,12 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
           clusterStatusMonitor
               .updateInstanceCapacityStatus(instanceName, usage, node.getMaxCapacity());
         }
+
+        // Cluster-wide near-capacity signal: surface the aggregate estimated max utilization so
+        // operators can alert before WAGED exhausts capacity. Computed from the same current-state
+        // cluster model used for the per-instance gauges above.
+        clusterStatusMonitor.updateClusterCapacityUsage(
+            computeClusterCapacityUsage(clusterModel.getContext()));
       } catch (Exception ex) {
         LOG.error("Failed to report instance capacity metrics. Exception message: {}",
             ex.getMessage());
@@ -366,6 +373,26 @@ public class CurrentStateComputationStage extends AbstractBaseStage {
 
       return null;
     });
+  }
+
+  /**
+   * Computes the cluster-wide capacity-usage gauge value from a WAGED cluster context.
+   * <p>
+   * Returns {@link ClusterContext#getEstimatedMaxUtilization()} - the aggregate
+   * {@code sum(usage) / sum(capacity)} maxed across capacity keys - when capacity is configured.
+   * When no capacity is configured, {@code ClusterContext} reports a "treat as fully utilized"
+   * {@code 1.0} sentinel that would surface as a false near-capacity reading, so this returns
+   * {@code 0.0} instead: with no capacity model there is no near-capacity concern to signal.
+   *
+   * @param clusterContext WAGED cluster context built from the current assignment
+   * @return cluster-wide estimated max capacity utilization, or {@code 0.0} when no WAGED capacity
+   *         is configured
+   */
+  static double computeClusterCapacityUsage(ClusterContext clusterContext) {
+    if (clusterContext == null || clusterContext.getEstimateUtilizationMap().isEmpty()) {
+      return 0.0d;
+    }
+    return clusterContext.getEstimatedMaxUtilization();
   }
 
   private void reportResourcePartitionCapacityMetrics(ExecutorService executorService,

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -103,6 +103,11 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   private final AtomicLong _wagedInternalFailureCount = new AtomicLong(0L);
   private volatile boolean _wagedFallbackInUse = false;
 
+  // Cluster-wide estimated max capacity utilization for WAGED resources (see
+  // ClusterStatusMonitorMBean#getEstimatedMaxClusterCapacityUsageGauge). Refreshed every pipeline
+  // run from the current assignment; stays 0.0 when no WAGED capacity is configured.
+  private volatile double _estimatedMaxClusterCapacityUsage = 0.0d;
+
   // WAGED per-HardConstraint failure counters. Pre-populated for every HardConstraint.Type so
   // reads return 0 instead of NPE for constraints that have not yet fired.
   private final Map<HardConstraint.Type, AtomicLong> _wagedHardConstraintFailureCounters =
@@ -569,6 +574,17 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     }
     monitor.updateMaxCapacityUsage(maxUsage);
     monitor.updateCapacity(capacityMap);
+  }
+
+  /**
+   * Updates the cluster-wide estimated max capacity utilization gauge for WAGED resources. See
+   * {@link ClusterStatusMonitorMBean#getEstimatedMaxClusterCapacityUsageGauge()} for the value
+   * semantics and range.
+   *
+   * @param estimatedMaxClusterCapacityUsage cluster aggregate utilization ({@code >= 0.0})
+   */
+  public void updateClusterCapacityUsage(double estimatedMaxClusterCapacityUsage) {
+    _estimatedMaxClusterCapacityUsage = estimatedMaxClusterCapacityUsage;
   }
 
   /**
@@ -1459,6 +1475,11 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   @Override
   public long getWagedHardConstraintUnknownFailureCounter() {
     return _wagedHardConstraintFailureCounters.get(HardConstraint.Type.UNKNOWN).get();
+  }
+
+  @Override
+  public double getEstimatedMaxClusterCapacityUsageGauge() {
+    return _estimatedMaxClusterCapacityUsage;
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -173,6 +173,24 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
   long getWagedHardConstraintUnknownFailureCounter();
 
   /**
+   * Cluster-wide estimated max capacity utilization for WAGED-managed resources, derived from the
+   * current assignment as {@code max} over capacity keys of
+   * {@code sum(replica usage) / sum(node capacity)}.
+   * <ul>
+   *   <li>{@code 0.0} - cluster is empty, or no WAGED capacity is configured (no signal).</li>
+   *   <li>{@code 1.0} - the most-constrained capacity dimension is exactly full.</li>
+   *   <li>{@code > 1.0} - the cluster is over-subscribed on at least one capacity dimension.</li>
+   * </ul>
+   * This is a cluster aggregate ({@code sum(usage) / sum(capacity)}), NOT the maximum of the
+   * per-instance {@code MaxCapacityUsageGauge} values, so a few hot instances can be averaged out
+   * by idle ones. Use it as an early near-capacity signal that ramps up before WAGED begins
+   * failing placement with capacity-deficit / node-capacity errors.
+   *
+   * @return cluster-wide estimated max capacity utilization ({@code >= 0.0})
+   */
+  double getEstimatedMaxClusterCapacityUsageGauge();
+
+  /**
    * @return number of all resources in this cluster
    */
   long getTotalResourceGauge();

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestCurrentStateComputationStageForHandlingCapacity.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestCurrentStateComputationStageForHandlingCapacity.java
@@ -39,6 +39,7 @@ import org.apache.helix.controller.dataproviders.WorkflowControllerDataProvider;
 import org.apache.helix.controller.rebalancer.DelayedAutoRebalancer;
 import org.apache.helix.controller.rebalancer.waged.WagedInstanceCapacity;
 import org.apache.helix.controller.rebalancer.waged.WagedRebalancer;
+import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.IdealState;
@@ -223,6 +224,37 @@ public class TestCurrentStateComputationStageForHandlingCapacity {
         dataProvider, _resourceMap, new ClusterEvent(ClusterEventType.MessageChange)));
     Assert.assertFalse(CurrentStateComputationStage.skipCapacityCalculation(
         dataProvider, _resourceMap, new ClusterEvent(ClusterEventType.PeriodicalRebalance)));
+  }
+
+  @Test
+  public void testComputeClusterCapacityUsage() {
+    // No capacity configured: ClusterContext reports a 1.0 "treat as full" sentinel, but the gauge
+    // must report 0.0 so it does not raise a false near-capacity alert.
+    ClusterContext noCapacityContext = Mockito.mock(ClusterContext.class);
+    Mockito.when(noCapacityContext.getEstimateUtilizationMap()).thenReturn(ImmutableMap.of());
+    Mockito.when(noCapacityContext.getEstimatedMaxUtilization()).thenReturn(1.0f);
+    Assert.assertEquals(
+        CurrentStateComputationStage.computeClusterCapacityUsage(noCapacityContext), 0.0d, 0.0d);
+
+    // A null context (no model built) is treated the same way: no signal.
+    Assert.assertEquals(
+        CurrentStateComputationStage.computeClusterCapacityUsage(null), 0.0d, 0.0d);
+
+    // Capacity configured: the aggregate estimated max utilization is surfaced as-is.
+    ClusterContext nearCapacityContext = Mockito.mock(ClusterContext.class);
+    Mockito.when(nearCapacityContext.getEstimateUtilizationMap())
+        .thenReturn(ImmutableMap.of("CU", 15L));
+    Mockito.when(nearCapacityContext.getEstimatedMaxUtilization()).thenReturn(0.85f);
+    Assert.assertEquals(
+        CurrentStateComputationStage.computeClusterCapacityUsage(nearCapacityContext), 0.85d, 1e-6d);
+
+    // Over-subscription (> 1.0) is passed through unclamped.
+    ClusterContext overSubscribedContext = Mockito.mock(ClusterContext.class);
+    Mockito.when(overSubscribedContext.getEstimateUtilizationMap())
+        .thenReturn(ImmutableMap.of("CU", -5L));
+    Mockito.when(overSubscribedContext.getEstimatedMaxUtilization()).thenReturn(1.2f);
+    Assert.assertEquals(
+        CurrentStateComputationStage.computeClusterCapacityUsage(overSubscribedContext), 1.2d, 1e-6d);
   }
 
   // -- static helpers

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -932,4 +932,44 @@ public class TestClusterStatusMonitor {
     monitor.reportWagedHardConstraintFailure(null);
     Assert.assertEquals(monitor.getWagedHardConstraintUnknownFailureCounter(), 1L);
   }
+
+  @Test
+  public void testClusterCapacityUsageGauge() throws Exception {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String clusterName = className + "_" + methodName;
+
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
+    monitor.active();
+    ObjectName clusterMonitorObjName = monitor.getObjectName(monitor.clusterBeanName());
+    Assert.assertTrue(_server.isRegistered(clusterMonitorObjName));
+
+    // Before any update the gauge is 0.0 and is exposed over JMX as a Double attribute.
+    Object initial =
+        _server.getAttribute(clusterMonitorObjName, "EstimatedMaxClusterCapacityUsageGauge");
+    Assert.assertTrue(initial instanceof Double);
+    Assert.assertEquals((double) initial, 0.0d, 0.0d);
+
+    // A normal near-capacity reading round-trips through both the getter and the MBean attribute.
+    monitor.updateClusterCapacityUsage(0.83d);
+    Assert.assertEquals(monitor.getEstimatedMaxClusterCapacityUsageGauge(), 0.83d, 0.0d);
+    Object usage =
+        _server.getAttribute(clusterMonitorObjName, "EstimatedMaxClusterCapacityUsageGauge");
+    Assert.assertTrue(usage instanceof Double);
+    Assert.assertEquals((double) usage, 0.83d, 0.0d);
+
+    // Over-subscription (> 1.0) is preserved, not clamped, so operators see how far over capacity.
+    monitor.updateClusterCapacityUsage(1.25d);
+    Object oversubscribed =
+        _server.getAttribute(clusterMonitorObjName, "EstimatedMaxClusterCapacityUsageGauge");
+    Assert.assertEquals((double) oversubscribed, 1.25d, 0.0d);
+
+    monitor.reset();
+    Assert.assertFalse(_server.isRegistered(clusterMonitorObjName),
+        "Cluster monitor should be unregistered after reset");
+
+    System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
+  }
 }


### PR DESCRIPTION
## Summary

Surface a cluster-wide near-capacity signal for WAGED-managed resources: a new `EstimatedMaxClusterCapacityUsageGauge` on the cluster-level `ClusterStatus` MBean. It exposes the aggregate estimated max utilization (`max` over capacity keys of `sum(usage) / sum(capacity)`) that WAGED already computes in `ClusterContext` but previously discarded.

Today WAGED only exposes a per-instance `MaxCapacityUsageGauge` plus *reactive* failure counters (`FailureCategoryCapacityDeficitCounter`, `HardConstraintNodeCapacityFailureCounter`) that fire only **after** capacity is exhausted. This adds a *proactive*, cluster-wide utilization gauge that ramps up before WAGED starts failing placement, so operators can alert on approaching capacity instead of on the cliff.

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

N/A - there is no separate tracking issue for this enhancement.

### Description

- [x] Here are some details about my PR (no UI changes):

**What:** a new cluster-level JMX gauge, `EstimatedMaxClusterCapacityUsageGauge`, on the cluster `ClusterStatus` MBean.

**Why:** there is currently no proactive, cluster-wide "near capacity" signal for WAGED. The per-instance `MaxCapacityUsageGauge` forces consumers to scrape and aggregate every instance bean themselves, and the capacity-related failure counters only increment once capacity is already exhausted. This gauge fills the early-warning gap in between.

**How:**
- `ClusterContext.getEstimatedMaxUtilization()` already computes the cluster aggregate during rebalancing; it was simply never emitted.
- `CurrentStateComputationStage.reportInstanceCapacityMetrics(...)` already builds the current-state `ClusterModel` that feeds the per-instance gauges. It now also pushes the cluster aggregate via a new `ClusterStatusMonitor.updateClusterCapacityUsage(double)`, so the gauge refreshes every controller pipeline run from the live (current) assignment.
- A small guarded helper, `CurrentStateComputationStage.computeClusterCapacityUsage(...)`, maps the "no capacity configured" `1.0` sentinel that `ClusterContext` returns to `0.0`, so an unconfigured cluster does not report a false 100%-full reading.

**Value semantics:**
- `0.0` - cluster empty, or no WAGED capacity configured (no signal)
- `1.0` - the most-constrained capacity dimension is exactly full
- `> 1.0` - the cluster is over-subscribed on at least one capacity dimension (not clamped, so you can see how far over)

This is a cluster **aggregate** (`sum(usage) / sum(capacity)`), not the maximum of the per-instance `MaxCapacityUsageGauge` values, so a few hot instances can be averaged out by idle ones.

**Consuming it:** read the `EstimatedMaxClusterCapacityUsageGauge` attribute on `ClusterStatus:cluster=<clusterName>` and threshold it in the alerting layer (e.g. `> 0.85`). The near-capacity threshold is intentionally kept in alerting rather than in Helix, so **no new `ClusterConfig` is introduced**.

Works well locally.
<img width="1032" height="223" alt="image" src="https://github.com/user-attachments/assets/77b8e4f7-0f09-4a1b-9332-90d2cbce7b90" />


### Tests

- [x] The following tests are written for this issue:

- `TestClusterStatusMonitor#testClusterCapacityUsageGauge` - round-trips the gauge through both the getter and the live `MBeanServer`, asserting it registers and reads back as a `double` attribute (default `0.0`, a normal `0.83` reading, and an over-subscribed `1.25` value that is preserved, not clamped).
- `TestCurrentStateComputationStageForHandlingCapacity#testComputeClusterCapacityUsage` - covers the sentinel guard (no capacity -> `0.0`), a null context, a normal in-range value, and an over-subscription (`> 1.0`) value passed through unclamped.

- The following is the result of the `mvn test` command on the appropriate module:

```
mvn -pl helix-core test -Dtest='TestCurrentStateComputationStageForHandlingCapacity,TestClusterStatusMonitor'

Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Changes that Break Backward Compatibility (Optional)

This PR adds `getEstimatedMaxClusterCapacityUsageGauge()` to the `ClusterStatusMonitorMBean` interface. This is an internal JMX MBean interface whose only implementer is `ClusterStatusMonitor`; it is not intended to be implemented by external code. The change is purely additive (a new JMX attribute) - no existing attribute, method signature, or behavior is changed - so monitoring consumers that read attributes over JMX are unaffected. No backward-incompatible behavior is introduced.

### Documentation (Optional)

No wiki page is required. The new metric is documented inline via Javadoc on `ClusterStatusMonitorMBean#getEstimatedMaxClusterCapacityUsageGauge()`, including the value range and how it differs from the per-instance gauge.

### Commits

The single commit follows the "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)" guidelines (imperative 48-char subject, blank line, body explaining what/why). It does not reference a Helix issue because none is tracked for this change.

### Code Quality

- [x] My diff has been formatted consistent with the surrounding code and `helix-style.xml`.
