### PR TITLE
Add reversible per-reason gauges for WAGED rebalance failures

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/GlobalRebalanceRunner.java
@@ -82,8 +82,14 @@ class GlobalRebalanceRunner implements AutoCloseable {
   private final LatencyMetric _baselineCalcLatency;
   // Reporter that ticks RebalanceFailureCounter plus the per-FailureCategory counters on both
   // the Rebalancer-domain and ClusterStatus-domain MBeans. Owned by WagedRebalancer; injected
-  // so the runner doesn't need a direct ClusterStatusMonitor reference.
+  // so the runner doesn't need a direct ClusterStatusMonitor reference. For the Baseline phase this
+  // reporter is counter-only: it must NOT light the serving rollup gauges (serving can be healthy
+  // while the baseline is stale).
   private final Consumer<HelixRebalanceException> _asyncFailureReporter;
+  // Reporter invoked with the Baseline computation outcome (true = success, false = failure) to
+  // drive the reversible WagedBaselineComputeFailingGauge. Owned by WagedRebalancer. Fires in both
+  // async and sync modes so the gauge reflects baseline health regardless of mode.
+  private final Consumer<Boolean> _baselineComputeStatusReporter;
 
   private boolean _asyncGlobalRebalanceEnabled;
   // Captures the original exception thrown inside the executor task so we can preserve its
@@ -95,6 +101,7 @@ class GlobalRebalanceRunner implements AutoCloseable {
       MetricCollector metricCollector,
       LatencyMetric writeLatency,
       Consumer<HelixRebalanceException> asyncFailureReporter,
+      Consumer<Boolean> baselineComputeStatusReporter,
       boolean isAsyncGlobalRebalanceEnabled) {
     _baselineCalculateExecutor = Executors.newSingleThreadExecutor();
     _assignmentManager = assignmentManager;
@@ -108,6 +115,7 @@ class GlobalRebalanceRunner implements AutoCloseable {
         WagedRebalancerMetricCollector.WagedRebalancerMetricNames.GlobalBaselineCalcLatencyGauge.name(),
         LatencyMetric.class);
     _asyncFailureReporter = asyncFailureReporter;
+    _baselineComputeStatusReporter = baselineComputeStatusReporter;
     _asyncGlobalRebalanceEnabled = isAsyncGlobalRebalanceEnabled;
   }
 
@@ -147,10 +155,13 @@ class GlobalRebalanceRunner implements AutoCloseable {
           // FailureCategory when re-throwing. The Type is intentionally NOT preserved on the
           // re-throw to keep WagedRebalancer.computeNewIdealStates' fallback decision unchanged.
           _lastAsyncFailure.set(e);
+          // Light the reversible baseline gauge in both modes -- the gauge reflects baseline health
+          // independent of whether the failure also propagates synchronously.
+          _baselineComputeStatusReporter.accept(false);
           if (_asyncGlobalRebalanceEnabled) {
             // Async mode: synchronous caller will not see this exception. Tick the aggregate
             // RebalanceFailureCounter plus the per-FailureCategory counters on both MBeans via
-            // the injected reporter.
+            // the injected (counter-only, baseline-scoped) reporter.
             _asyncFailureReporter.accept(e);
           }
           LOG.error("Failed to calculate baseline assignment for cluster {}! category={}",
@@ -159,6 +170,8 @@ class GlobalRebalanceRunner implements AutoCloseable {
         } finally {
           currentThread.setName(originalThreadName);
         }
+        // Baseline computation succeeded -- clear the reversible baseline gauge.
+        _baselineComputeStatusReporter.accept(true);
         return true;
       });
       if (waitForGlobalRebalance) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/PartialRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/PartialRebalanceRunner.java
@@ -75,7 +75,7 @@ class PartialRebalanceRunner implements AutoCloseable {
   // rollup gauges. Owned by WagedRebalancer. Driving the reset from the partial outcome (not the
   // synchronous fallback path) is what keeps the rollup reversible under async mode, where partial
   // failures never reach WagedRebalancer.computeNewIdealStates' synchronous catch.
-  private final Runnable _partialSuccessReporter;
+  private final Runnable _partialRebalanceSuccessReporter;
   private final CountMetric _partialRebalanceCounter;
   private final LatencyMetric _partialRebalanceLatency;
 
@@ -89,13 +89,13 @@ class PartialRebalanceRunner implements AutoCloseable {
       AssignmentMetadataStore assignmentMetadataStore,
       MetricCollector metricCollector,
       Consumer<HelixRebalanceException> asyncFailureReporter,
-      Runnable partialSuccessReporter,
+      Runnable partialRebalanceSuccessReporter,
       boolean isAsyncPartialRebalanceEnabled) {
     _assignmentManager = assignmentManager;
     _assignmentMetadataStore = assignmentMetadataStore;
     _bestPossibleCalculateExecutor = Executors.newSingleThreadExecutor();
     _asyncFailureReporter = asyncFailureReporter;
-    _partialSuccessReporter = partialSuccessReporter;
+    _partialRebalanceSuccessReporter = partialRebalanceSuccessReporter;
     _asyncPartialRebalanceEnabled = isAsyncPartialRebalanceEnabled;
 
     _partialRebalanceCounter = metricCollector.getMetric(
@@ -147,7 +147,7 @@ class PartialRebalanceRunner implements AutoCloseable {
         currentThread.setName(originalThreadName);
       }
       // Partial (serving) computation succeeded -- reset the reversible serving rollup gauges.
-      _partialSuccessReporter.run();
+      _partialRebalanceSuccessReporter.run();
       return true;
     });
     if (!_asyncPartialRebalanceEnabled) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/PartialRebalanceRunner.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/PartialRebalanceRunner.java
@@ -67,9 +67,15 @@ class PartialRebalanceRunner implements AutoCloseable {
   private final AssignmentMetadataStore _assignmentMetadataStore;
   private final BaselineDivergenceGauge _baselineDivergenceGauge;
   // Reporter that ticks RebalanceFailureCounter plus the per-FailureCategory counters on both
-  // the Rebalancer-domain and ClusterStatus-domain MBeans. Owned by WagedRebalancer; injected
-  // so the runner doesn't need a direct ClusterStatusMonitor reference.
+  // the Rebalancer-domain and ClusterStatus-domain MBeans, and lights the reversible serving rollup
+  // gauge. Owned by WagedRebalancer; injected so the runner doesn't need a direct
+  // ClusterStatusMonitor reference.
   private final Consumer<HelixRebalanceException> _asyncFailureReporter;
+  // Reporter invoked when a partial (serving) computation succeeds, to reset the reversible serving
+  // rollup gauges. Owned by WagedRebalancer. Driving the reset from the partial outcome (not the
+  // synchronous fallback path) is what keeps the rollup reversible under async mode, where partial
+  // failures never reach WagedRebalancer.computeNewIdealStates' synchronous catch.
+  private final Runnable _partialSuccessReporter;
   private final CountMetric _partialRebalanceCounter;
   private final LatencyMetric _partialRebalanceLatency;
 
@@ -83,11 +89,13 @@ class PartialRebalanceRunner implements AutoCloseable {
       AssignmentMetadataStore assignmentMetadataStore,
       MetricCollector metricCollector,
       Consumer<HelixRebalanceException> asyncFailureReporter,
+      Runnable partialSuccessReporter,
       boolean isAsyncPartialRebalanceEnabled) {
     _assignmentManager = assignmentManager;
     _assignmentMetadataStore = assignmentMetadataStore;
     _bestPossibleCalculateExecutor = Executors.newSingleThreadExecutor();
     _asyncFailureReporter = asyncFailureReporter;
+    _partialSuccessReporter = partialSuccessReporter;
     _asyncPartialRebalanceEnabled = isAsyncPartialRebalanceEnabled;
 
     _partialRebalanceCounter = metricCollector.getMetric(
@@ -138,6 +146,8 @@ class PartialRebalanceRunner implements AutoCloseable {
       } finally {
         currentThread.setName(originalThreadName);
       }
+      // Partial (serving) computation succeeded -- reset the reversible serving rollup gauges.
+      _partialSuccessReporter.run();
       return true;
     });
     if (!_asyncPartialRebalanceEnabled) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -296,6 +296,8 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     if (algorithm instanceof ConstraintBasedAlgorithm) {
       ((ConstraintBasedAlgorithm) algorithm).setHardConstraintFailureReporter(
           this::reportHardConstraintFailure);
+      ((ConstraintBasedAlgorithm) algorithm).setBlockingSnapshotReporter(
+          this::reportHardConstraintBlockingSnapshot);
     }
   }
 
@@ -322,6 +324,19 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     ClusterStatusMonitor monitor = _clusterStatusMonitor;
     if (monitor != null) {
       monitor.reportWagedHardConstraintFailure(type);
+    }
+  }
+
+  /**
+   * Publish the reversible per-run "currently blocking" snapshot onto ClusterStatusMonitor: for each
+   * HardConstraint.Type, set its blocking gauge to 1 if it blocked placement in the most recent WAGED
+   * computation, 0 otherwise. An empty set (a clean run) resets every gauge to 0, so the signal tells
+   * a transient blip apart from a persistent failure by value. Null-tolerant.
+   */
+  void reportHardConstraintBlockingSnapshot(Set<HardConstraint.Type> currentlyBlocking) {
+    ClusterStatusMonitor monitor = _clusterStatusMonitor;
+    if (monitor != null) {
+      monitor.updateWagedHardConstraintBlocking(currentlyBlocking);
     }
   }
 
@@ -432,6 +447,11 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     ClusterStatusMonitor monitor = _clusterStatusMonitor;
     if (monitor != null) {
       monitor.setWagedFallbackInUseGauge(usedFallback);
+      if (!usedFallback) {
+        // A clean computation: clear the reversible rollup failure gauges so a prior customer/internal
+        // "currently failing" reading resets on recovery. The monotonic rollup counters are untouched.
+        monitor.resetWagedFailureRollupGauges();
+      }
     }
 
     // Construct the new best possible states according to the current state and target assignment.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -219,9 +219,10 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     }
 
     _partialRebalanceRunner = new PartialRebalanceRunner(_assignmentManager, assignmentMetadataStore, metricCollector,
-        this::reportAsyncFailure, isAsyncPartialRebalanceEnabled);
+        this::reportAsyncFailure, this::reportPartialRebalanceSuccess, isAsyncPartialRebalanceEnabled);
     _globalRebalanceRunner = new GlobalRebalanceRunner(_assignmentManager, assignmentMetadataStore, metricCollector,
-        _writeLatency, this::reportAsyncFailure, isAsyncGlobalRebalanceEnabled);
+        _writeLatency, this::reportBaselineAsyncFailure, this::reportBaselineComputeStatus,
+        isAsyncGlobalRebalanceEnabled);
   }
 
   /**
@@ -331,9 +332,21 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
    * Publish the reversible per-run "currently blocking" snapshot onto ClusterStatusMonitor: for each
    * HardConstraint.Type, set its blocking gauge to 1 if it blocked placement in the most recent WAGED
    * computation, 0 otherwise. An empty set (a clean run) resets every gauge to 0, so the signal tells
-   * a transient blip apart from a persistent failure by value. Null-tolerant.
+   * a transient blip apart from a persistent failure by value.
+   *
+   * <p>Scoped to the PARTIAL phase only. The serving (best-possible) assignment is produced by the
+   * partial computation, so its per-reason blocking gauges must be driven by one writer -- partial --
+   * and nothing else. Baseline / emergency / overwrite snapshots are intentionally dropped here:
+   * baseline has its own reversible gauge ({@link ClusterStatusMonitor#updateWagedBaselineComputeFailing}),
+   * and emergency / overwrite failures surface via WagedFallbackInUseGauge. Baseline and partial run
+   * on separate executors, so without this scoping a concurrent baseline run would clobber the
+   * serving gauges (the masking the per-reason gauges are meant to avoid). Null-tolerant.
    */
-  void reportHardConstraintBlockingSnapshot(Set<HardConstraint.Type> currentlyBlocking) {
+  void reportHardConstraintBlockingSnapshot(ClusterModel.RebalanceScopeType scope,
+      Set<HardConstraint.Type> currentlyBlocking) {
+    if (scope != ClusterModel.RebalanceScopeType.PARTIAL) {
+      return;
+    }
     ClusterStatusMonitor monitor = _clusterStatusMonitor;
     if (monitor != null) {
       monitor.updateWagedHardConstraintBlocking(currentlyBlocking);
@@ -341,13 +354,59 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
   }
 
   /**
-   * Full failure reporting for async-runner background threads: ticks RebalanceFailureCounter
-   * plus both the Rebalancer-domain and ClusterStatus-domain per-FailureCategory counters. Used
-   * when the async runner catches an exception that the synchronous catch never sees.
+   * Full failure reporting for the partial (serving) async runner: ticks RebalanceFailureCounter
+   * plus both the Rebalancer-domain and ClusterStatus-domain per-FailureCategory counters, and
+   * lights the reversible serving rollup gauge (via reportFailureCategory). Used when the async
+   * partial runner catches an exception that the synchronous catch never sees.
    */
   void reportAsyncFailure(HelixRebalanceException ex) {
     _rebalanceFailureCount.increment(1L);
     reportFailureCategory(ex);
+  }
+
+  /**
+   * Counter-only failure reporting for the Baseline (global) async runner. Ticks
+   * RebalanceFailureCounter, the per-FailureCategory counters on both MBeans, and the monotonic
+   * customer/internal rollup counters -- but does NOT light the reversible serving rollup gauges,
+   * which are owned by the partial phase (serving can be healthy while the baseline is stale). The
+   * Baseline phase's reversible signal is the separate WagedBaselineComputeFailingGauge, driven by
+   * {@link #reportBaselineComputeStatus}.
+   */
+  void reportBaselineAsyncFailure(HelixRebalanceException ex) {
+    _rebalanceFailureCount.increment(1L);
+    HelixRebalanceException.FailureCategory category = ex.getFailureCategory();
+    _failureCategoryMetrics.get(category).increment(1L);
+    ClusterStatusMonitor monitor = _clusterStatusMonitor;
+    if (monitor != null) {
+      monitor.incrementWagedFailureCategoryCount(category);
+    }
+  }
+
+  /**
+   * Drive the reversible WagedBaselineComputeFailingGauge from the Baseline phase outcome: clear it
+   * when a Baseline computation succeeds, set it when one fails. Owned exclusively by the
+   * GLOBAL_BASELINE phase, so it is reversible regardless of async mode. Null-tolerant.
+   */
+  void reportBaselineComputeStatus(boolean clean) {
+    ClusterStatusMonitor monitor = _clusterStatusMonitor;
+    if (monitor != null) {
+      monitor.updateWagedBaselineComputeFailing(!clean);
+    }
+  }
+
+  /**
+   * Reset the reversible serving rollup gauges when the partial (serving) computation succeeds. The
+   * per-reason serving blocking gauges already reset via the empty snapshot; this clears the
+   * customer/internal rollup that {@link #reportAsyncFailure} sets on a partial failure. Driving the
+   * reset from the partial outcome -- not the synchronous fallback path -- is what makes the rollup
+   * reversible under async mode, where partial failures never reach the synchronous catch.
+   * Null-tolerant.
+   */
+  void reportPartialRebalanceSuccess() {
+    ClusterStatusMonitor monitor = _clusterStatusMonitor;
+    if (monitor != null) {
+      monitor.resetWagedFailureRollupGauges();
+    }
   }
 
   // Update the global rebalance mode to be asynchronous or synchronous
@@ -444,14 +503,15 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     // a previously sticky "true" resets on the next clean run. Capture the volatile once to
     // avoid racing with a concurrent setClusterStatusMonitor() between the null check and the
     // method call.
+    //
+    // Note: the reversible rollup failure gauges are intentionally NOT reset here. In production
+    // (async global + partial), partial failures never reach this synchronous path, so resetting on
+    // a clean synchronous compute would clear a rollup that a still-failing async partial had set --
+    // the gauge would flicker to 0 while serving is broken. The rollup reset is therefore driven by
+    // the partial (serving) computation succeeding; see reportPartialRebalanceSuccess.
     ClusterStatusMonitor monitor = _clusterStatusMonitor;
     if (monitor != null) {
       monitor.setWagedFallbackInUseGauge(usedFallback);
-      if (!usedFallback) {
-        // A clean computation: clear the reversible rollup failure gauges so a prior customer/internal
-        // "currently failing" reading resets on recovery. The monotonic rollup counters are untouched.
-        monitor.resetWagedFailureRollupGauges();
-      }
     }
 
     // Construct the new best possible states according to the current state and target assignment.

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -334,17 +334,21 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
    * computation, 0 otherwise. An empty set (a clean run) resets every gauge to 0, so the signal tells
    * a transient blip apart from a persistent failure by value.
    *
-   * <p>Scoped to the PARTIAL phase only. The serving (best-possible) assignment is produced by the
-   * partial computation, so its per-reason blocking gauges must be driven by one writer -- partial --
-   * and nothing else. Baseline / emergency / overwrite snapshots are intentionally dropped here:
-   * baseline has its own reversible gauge ({@link ClusterStatusMonitor#updateWagedBaselineComputeFailing}),
-   * and emergency / overwrite failures surface via WagedFallbackInUseGauge. Baseline and partial run
-   * on separate executors, so without this scoping a concurrent baseline run would clobber the
-   * serving gauges (the masking the per-reason gauges are meant to avoid). Null-tolerant.
+   * <p>Scoped to the serving phases: PARTIAL and EMERGENCY. Both produce the assignment that is
+   * actually persisted and served, so both own these gauges. Crucially they do not race: within a
+   * pass emergency runs first and, when it fails, throws before partial is reached -- so partial does
+   * not run, making emergency the sole serving writer exactly when it is the phase that failed (and
+   * its per-reason attribution would otherwise be lost). GLOBAL_BASELINE and DELAYED_REBALANCE_OVERWRITES
+   * snapshots are intentionally dropped here: baseline has its own reversible gauge
+   * ({@link ClusterStatusMonitor#updateWagedBaselineComputeFailing}) and runs concurrently with partial
+   * on a separate executor (so without this gate a baseline run would clobber the serving gauges -- the
+   * masking the per-reason gauges are meant to avoid), and the delayed-overwrite branch is a temporary,
+   * non-persisted top-up that surfaces via WagedFallbackInUseGauge. Null-tolerant.
    */
   void reportHardConstraintBlockingSnapshot(ClusterModel.RebalanceScopeType scope,
       Set<HardConstraint.Type> currentlyBlocking) {
-    if (scope != ClusterModel.RebalanceScopeType.PARTIAL) {
+    if (scope != ClusterModel.RebalanceScopeType.PARTIAL
+        && scope != ClusterModel.RebalanceScopeType.EMERGENCY) {
       return;
     }
     ClusterStatusMonitor monitor = _clusterStatusMonitor;

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/WagedRebalancer.java
@@ -399,6 +399,20 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
   }
 
   /**
+   * Drive the reversible WagedRebalanceOverwriteFailingGauge from the delayed-rebalance-overwrite
+   * phase outcome: clear it when the overwrite computation succeeds or is not needed, set it when one
+   * fails. Owned exclusively by the DELAYED_REBALANCE_OVERWRITES phase -- this is the only reversible
+   * signal for that phase, which otherwise shares WagedFallbackInUseGauge with emergency.
+   * Null-tolerant.
+   */
+  void reportOverwriteComputeStatus(boolean clean) {
+    ClusterStatusMonitor monitor = _clusterStatusMonitor;
+    if (monitor != null) {
+      monitor.updateWagedRebalanceOverwriteFailing(!clean);
+    }
+  }
+
+  /**
    * Reset the reversible serving rollup gauges when the partial (serving) computation succeeds. The
    * per-reason serving blocking gauges already reset via the empty snapshot; this clears the
    * customer/internal rollup that {@link #reportAsyncFailure} sets on a partial failure. Driving the
@@ -652,12 +666,16 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
     final Set<String> enabledLiveInstances = clusterData.getEnabledLiveInstances();
 
     if (activeNodes.equals(enabledLiveInstances) || !requireRebalanceOverwrite(clusterData, currentResourceAssignment)) {
-      // no need for additional process, return the current resource assignment
+      // no need for additional process -- the overwrite phase is not failing, so clear its gauge.
+      reportOverwriteComputeStatus(true);
       return currentResourceAssignment;
     }
     _rebalanceOverwriteCounter.increment(1L);
     _rebalanceOverwriteLatency.startMeasuringLatency();
     LOG.info("Start delayed rebalance overwrites in emergency rebalance.");
+    // Drive the reversible overwrite gauge from this phase's outcome. Reported once in finally so
+    // both catch blocks are covered: false (failing) unless we reach the success point below.
+    boolean overwriteClean = false;
     try {
       // use the "real" live and enabled instances for calculation
       ClusterModel clusterModel = ClusterModelProvider.generateClusterModelForDelayedRebalanceOverwrites(
@@ -666,6 +684,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
       // keep only the resource entries requiring changes for minActiveReplica
       assignment.keySet().retainAll(clusterModel.getAssignableReplicaMap().keySet());
       DelayedRebalanceUtil.mergeAssignments(assignment, currentResourceAssignment);
+      overwriteClean = true;
       return currentResourceAssignment;
     } catch (HelixRebalanceException e) {
       LOG.error("Failed to compute for delayed rebalance overwrites in cluster {}", clusterData.getClusterName());
@@ -677,6 +696,7 @@ public class WagedRebalancer implements StatefulRebalancer<ResourceControllerDat
           HelixRebalanceException.FailureCategory.INVALID_CLUSTER_CONFIG, e);
     } finally {
       _rebalanceOverwriteLatency.endMeasuringLatency();
+      reportOverwriteComputeStatus(overwriteClean);
     }
   }
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -68,12 +69,15 @@ public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
   // observers get partition-level attribution rather than node-rejection counts. May be null
   // when the algorithm runs outside a pipeline that wants metric attribution.
   private volatile Consumer<HardConstraint.Type> _hardConstraintFailureReporter;
-  // Optional listener invoked once per calculate() run with the complete set of HardConstraint.Types
-  // that blocked placement that run (empty when the run placed everything). Unlike the cumulative
-  // _hardConstraintFailureReporter, this is a reversible per-run snapshot, so observers can drive a
-  // "currently blocking" gauge that resets to 0 on the next clean run -- letting a transient blip be
-  // told apart from a persistent failure by value. May be null.
-  private volatile Consumer<Set<HardConstraint.Type>> _blockingSnapshotReporter;
+  // Optional listener invoked once per calculate() run with the rebalance scope that produced the
+  // model plus the complete set of HardConstraint.Types that blocked placement that run (empty when
+  // the run placed everything). Unlike the cumulative _hardConstraintFailureReporter, this is a
+  // reversible per-run snapshot, so observers can drive a "currently blocking" gauge that resets to
+  // 0 on the next clean run -- letting a transient blip be told apart from a persistent failure by
+  // value. The scope lets the observer attribute the snapshot to a single rebalance phase (e.g.
+  // partial vs baseline) so concurrent phases don't clobber each other's gauge. May be null.
+  private volatile BiConsumer<ClusterModel.RebalanceScopeType, Set<HardConstraint.Type>>
+      _blockingSnapshotReporter;
 
   ConstraintBasedAlgorithm(List<HardConstraint> hardConstraints,
       Map<SoftConstraint, Float> softConstraints, ForkJoinPool constraintEvaluationPool) {
@@ -93,12 +97,14 @@ public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
 
   /**
    * Attach a per-run blocking-snapshot reporter. It fires exactly once per {@link #calculate} run
-   * with the complete set of {@link HardConstraint.Type}s that blocked placement that run -- empty
-   * when the run placed everything. This is a reversible "currently blocking" view (resets on the
-   * next clean run), complementing the monotonic per-type counters from
-   * {@link #setHardConstraintFailureReporter}. Safe to call from any thread; null disables it.
+   * with the rebalance scope and the complete set of {@link HardConstraint.Type}s that blocked
+   * placement that run -- empty when the run placed everything. This is a reversible "currently
+   * blocking" view (resets on the next clean run), complementing the monotonic per-type counters
+   * from {@link #setHardConstraintFailureReporter}. The scope lets observers route the snapshot to a
+   * single owning phase. Safe to call from any thread; null disables it.
    */
-  public void setBlockingSnapshotReporter(Consumer<Set<HardConstraint.Type>> reporter) {
+  public void setBlockingSnapshotReporter(
+      BiConsumer<ClusterModel.RebalanceScopeType, Set<HardConstraint.Type>> reporter) {
     _blockingSnapshotReporter = reporter;
   }
 
@@ -110,9 +116,10 @@ public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
     try {
       return calculateInternal(clusterModel, blockingTypes);
     } finally {
-      Consumer<Set<HardConstraint.Type>> snapshotReporter = _blockingSnapshotReporter;
+      BiConsumer<ClusterModel.RebalanceScopeType, Set<HardConstraint.Type>> snapshotReporter =
+          _blockingSnapshotReporter;
       if (snapshotReporter != null) {
-        snapshotReporter.accept(blockingTypes);
+        snapshotReporter.accept(clusterModel.getRebalanceScopeType(), blockingTypes);
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/ConstraintBasedAlgorithm.java
@@ -68,6 +68,12 @@ public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
   // observers get partition-level attribution rather than node-rejection counts. May be null
   // when the algorithm runs outside a pipeline that wants metric attribution.
   private volatile Consumer<HardConstraint.Type> _hardConstraintFailureReporter;
+  // Optional listener invoked once per calculate() run with the complete set of HardConstraint.Types
+  // that blocked placement that run (empty when the run placed everything). Unlike the cumulative
+  // _hardConstraintFailureReporter, this is a reversible per-run snapshot, so observers can drive a
+  // "currently blocking" gauge that resets to 0 on the next clean run -- letting a transient blip be
+  // told apart from a persistent failure by value. May be null.
+  private volatile Consumer<Set<HardConstraint.Type>> _blockingSnapshotReporter;
 
   ConstraintBasedAlgorithm(List<HardConstraint> hardConstraints,
       Map<SoftConstraint, Float> softConstraints, ForkJoinPool constraintEvaluationPool) {
@@ -85,8 +91,34 @@ public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
     _hardConstraintFailureReporter = reporter;
   }
 
+  /**
+   * Attach a per-run blocking-snapshot reporter. It fires exactly once per {@link #calculate} run
+   * with the complete set of {@link HardConstraint.Type}s that blocked placement that run -- empty
+   * when the run placed everything. This is a reversible "currently blocking" view (resets on the
+   * next clean run), complementing the monotonic per-type counters from
+   * {@link #setHardConstraintFailureReporter}. Safe to call from any thread; null disables it.
+   */
+  public void setBlockingSnapshotReporter(Consumer<Set<HardConstraint.Type>> reporter) {
+    _blockingSnapshotReporter = reporter;
+  }
+
   @Override
   public OptimalAssignment calculate(ClusterModel clusterModel) throws HelixRebalanceException {
+    // Track every HardConstraint.Type that blocks placement during this run, then publish the
+    // complete set once (success or failure) as a reversible "currently blocking" snapshot.
+    Set<HardConstraint.Type> blockingTypes = ConcurrentHashMap.newKeySet();
+    try {
+      return calculateInternal(clusterModel, blockingTypes);
+    } finally {
+      Consumer<Set<HardConstraint.Type>> snapshotReporter = _blockingSnapshotReporter;
+      if (snapshotReporter != null) {
+        snapshotReporter.accept(blockingTypes);
+      }
+    }
+  }
+
+  private OptimalAssignment calculateInternal(ClusterModel clusterModel,
+      Set<HardConstraint.Type> blockingTypes) throws HelixRebalanceException {
     OptimalAssignment optimalAssignment = new OptimalAssignment();
     List<AssignableNode> nodes = new ArrayList<>(clusterModel.getAssignableNodes().values());
     Set<String> busyInstances =
@@ -124,7 +156,7 @@ public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
       AssignableReplica replica = replicaWithScore.getAssignableReplica();
       Optional<AssignableNode> maybeBestNode =
           getNodeWithHighestPoints(replica, nodes, clusterModel.getContext(), busyInstances,
-              optimalAssignment);
+              optimalAssignment, blockingTypes);
       // stop immediately if any replica cannot find best assignable node
       if (!maybeBestNode.isPresent() || optimalAssignment.hasAnyFailure()) {
         String errorMessage = String.format(
@@ -151,7 +183,8 @@ public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
 
   private Optional<AssignableNode> getNodeWithHighestPoints(AssignableReplica replica,
       List<AssignableNode> assignableNodes, ClusterContext clusterContext, Set<String> busyInstances,
-      OptimalAssignment optimalAssignment) throws HelixRebalanceException {
+      OptimalAssignment optimalAssignment, Set<HardConstraint.Type> blockingTypes)
+      throws HelixRebalanceException {
     Map<AssignableNode, List<HardConstraint>> hardConstraintFailures = new ConcurrentHashMap<>(assignableNodes.size());
 
     // Execute first parallelStream within custom ForkJoinPool context
@@ -178,17 +211,18 @@ public class ConstraintBasedAlgorithm implements RebalanceAlgorithm {
     if (candidateNodes.isEmpty()) {
       LOG.info("Found no eligible candidate nodes. Enabling hard constraint level logging for cluster: {}", clusterContext.getClusterName());
       enableFullLoggingForCluster();
-      // Report each distinct constraint type that contributed to this partition's failure
-      // exactly once -- partition-level attribution, not per-node-rejection. Computed before
-      // recording the failure so a constraint that rejected many nodes still fires +1 per
-      // failed partition rather than +N.
+      // Distinct constraint types that contributed to this partition's failure -- partition-level
+      // attribution, not per-node-rejection. Feed both the cumulative per-type reporter (+1 per
+      // failed partition, not +N nodes) and this run's reversible blocking snapshot.
+      Set<HardConstraint.Type> partitionBlockingTypes = hardConstraintFailures.values().stream()
+          .flatMap(List::stream)
+          .map(HardConstraint::getType)
+          .map(type -> type == null ? HardConstraint.Type.UNKNOWN : type)
+          .collect(Collectors.toSet());
+      blockingTypes.addAll(partitionBlockingTypes);
       Consumer<HardConstraint.Type> reporter = _hardConstraintFailureReporter;
       if (reporter != null) {
-        hardConstraintFailures.values().stream()
-            .flatMap(List::stream)
-            .map(HardConstraint::getType)
-            .distinct()
-            .forEach(reporter);
+        partitionBlockingTypes.forEach(reporter);
       }
       optimalAssignment.recordAssignmentFailure(replica,
           Maps.transformValues(hardConstraintFailures, this::convertFailureReasons));

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModel.java
@@ -32,6 +32,25 @@ import org.apache.helix.HelixException;
  * This class wraps the required input for the rebalance algorithm.
  */
 public class ClusterModel {
+  /**
+   * The rebalance scope (phase) that produced this cluster model. It lets downstream consumers --
+   * e.g. the rebalance algorithm's blocking-snapshot reporter -- attribute a computation to the
+   * phase it belongs to, so a reversible metric can be scoped to a single writer instead of being
+   * clobbered by a different phase's concurrent computation (baseline and partial run on separate
+   * executors).
+   */
+  public enum RebalanceScopeType {
+    // Cover the difference between the current assignment and the Baseline assignment only.
+    PARTIAL,
+    // Cover all replicas that need relocation based on the cluster changes.
+    GLOBAL_BASELINE,
+    // Cover only replicas that are assigned to downed instances.
+    EMERGENCY,
+    // A temporary overwrite for partition replicas on a downed instance still within the delayed
+    // window but missing minActiveReplicas.
+    DELAYED_REBALANCE_OVERWRITES
+  }
+
   private final ClusterContext _clusterContext;
   // Map to track all the assignable replications. <Resource Name, Set<Replicas>>
   private final Map<String, Set<AssignableReplica>> _assignableReplicaMap;
@@ -41,16 +60,21 @@ public class ClusterModel {
   private final Map<String, AssignableNode> _assignableNodeMap;
   private final Set<String> _assignableNodeLogicalIds;
   private final Map<String, Set<String>> _assignableLogicalIdsByInstanceTag;
+  // The rebalance scope that produced this model. Used to route per-run reversible metrics to a
+  // single owning phase. Never null.
+  private final RebalanceScopeType _rebalanceScopeType;
 
   /**
    * @param clusterContext         The initialized cluster context.
    * @param assignableReplicas     The replicas to be assigned.
    *                               Note that the replicas in this list shall not be included while initializing the context and assignable nodes.
    * @param assignableNodes        The active instances.
+   * @param rebalanceScopeType     The rebalance scope (phase) that produced this model.
    */
   ClusterModel(ClusterContext clusterContext, Set<AssignableReplica> assignableReplicas,
-      Set<AssignableNode> assignableNodes) {
+      Set<AssignableNode> assignableNodes, RebalanceScopeType rebalanceScopeType) {
     _clusterContext = clusterContext;
+    _rebalanceScopeType = rebalanceScopeType;
 
     // Save all the to be assigned replication
     _assignableReplicaMap = assignableReplicas.stream()
@@ -80,6 +104,13 @@ public class ClusterModel {
 
   public ClusterContext getContext() {
     return _clusterContext;
+  }
+
+  /**
+   * @return the rebalance scope (phase) that produced this cluster model. Never null.
+   */
+  public RebalanceScopeType getRebalanceScopeType() {
+    return _rebalanceScopeType;
   }
 
   public Map<String, AssignableNode> getAssignableNodes() {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelProvider.java
@@ -52,19 +52,9 @@ import org.slf4j.LoggerFactory;
 public class ClusterModelProvider {
   private static Logger logger = LoggerFactory.getLogger(ClusterModelProvider.class);
 
-  private enum RebalanceScopeType {
-    // Set the rebalance scope to cover the difference between the current assignment and the
-    // Baseline assignment only.
-    PARTIAL,
-    // Set the rebalance scope to cover all replicas that need relocation based on the cluster
-    // changes.
-    GLOBAL_BASELINE,
-    // Set the rebalance scope to cover only replicas that are assigned to downed instances.
-    EMERGENCY,
-    // A temporary overwrites for partition replicas on downed instance but still within the delayed window but missing
-    // minActiveReplicas
-    DELAYED_REBALANCE_OVERWRITES
-  }
+  // The rebalance scope enum now lives on ClusterModel so the produced model can carry its own
+  // scope (see ClusterModel.RebalanceScopeType). Referenced here to determine the to-be-assigned
+  // replica set per phase.
 
   /**
    * TODO: On integration with WAGED, have to integrate with counter and latency metrics -- qqu
@@ -85,7 +75,7 @@ public class ClusterModelProvider {
       Map<String, ResourceAssignment> resourceAssignment) {
     return generateClusterModel(dataProvider, resourceMap, activeInstances, Collections.emptyMap(),
         Collections.emptyMap(), resourceAssignment,
-        RebalanceScopeType.DELAYED_REBALANCE_OVERWRITES);
+        ClusterModel.RebalanceScopeType.DELAYED_REBALANCE_OVERWRITES);
   }
 
   /**
@@ -107,7 +97,7 @@ public class ClusterModelProvider {
       Map<String, Resource> resourceMap, Set<String> activeInstances,
       Map<String, ResourceAssignment> bestPossibleAssignment) {
     return generateClusterModel(dataProvider, resourceMap, activeInstances, Collections.emptyMap(),
-        Collections.emptyMap(), bestPossibleAssignment, RebalanceScopeType.EMERGENCY);
+        Collections.emptyMap(), bestPossibleAssignment, ClusterModel.RebalanceScopeType.EMERGENCY);
   }
 
   /**
@@ -131,7 +121,7 @@ public class ClusterModelProvider {
       Set<String> activeInstances, Map<String, ResourceAssignment> baselineAssignment,
       Map<String, ResourceAssignment> bestPossibleAssignment) {
     return generateClusterModel(dataProvider, resourceMap, activeInstances, Collections.emptyMap(),
-        baselineAssignment, bestPossibleAssignment, RebalanceScopeType.PARTIAL);
+        baselineAssignment, bestPossibleAssignment, ClusterModel.RebalanceScopeType.PARTIAL);
   }
 
   /**
@@ -151,7 +141,7 @@ public class ClusterModelProvider {
       Set<String> allInstances, Map<HelixConstants.ChangeType, Set<String>> clusterChanges,
       Map<String, ResourceAssignment> baselineAssignment) {
     return generateClusterModel(dataProvider, resourceMap, allInstances, clusterChanges,
-        Collections.emptyMap(), baselineAssignment, RebalanceScopeType.GLOBAL_BASELINE);
+        Collections.emptyMap(), baselineAssignment, ClusterModel.RebalanceScopeType.GLOBAL_BASELINE);
   }
 
   /**
@@ -170,7 +160,7 @@ public class ClusterModelProvider {
     return generateClusterModel(dataProvider, resourceMap,
         dataProvider.getEnabledLiveInstances(), Collections.emptyMap(),
         Collections.emptyMap(), currentStateAssignment,
-        RebalanceScopeType.GLOBAL_BASELINE);
+        ClusterModel.RebalanceScopeType.GLOBAL_BASELINE);
   }
 
   /**
@@ -192,7 +182,8 @@ public class ClusterModelProvider {
       Map<String, Resource> resourceMap, Set<String> activeInstances,
       Map<HelixConstants.ChangeType, Set<String>> clusterChanges,
       Map<String, ResourceAssignment> idealAssignment,
-      Map<String, ResourceAssignment> currentAssignment, RebalanceScopeType scopeType) {
+      Map<String, ResourceAssignment> currentAssignment,
+      ClusterModel.RebalanceScopeType scopeType) {
     Map<String, InstanceConfig> assignableInstanceConfigMap = dataProvider.getAssignableInstanceConfigMap();
     // Construct all the assignable nodes and initialize with the allocated replicas.
     Set<AssignableNode> assignableNodes =
@@ -278,7 +269,7 @@ public class ClusterModelProvider {
     // Initial the cluster context with the allocated assignments.
     context.setAssignmentForFaultZoneMap(mapAssignmentToFaultZone(assignableNodes));
 
-    return new ClusterModel(context, toBeAssignedReplicas, assignableNodes);
+    return new ClusterModel(context, toBeAssignedReplicas, assignableNodes, scopeType);
   }
 
   private static Map<String, ResourceAssignment> generateResourceAssignmentMapLogicalIdView(

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -115,6 +115,11 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   // WAGED can no longer recompute the ideal target. Distinct from the serving rollup gauges above,
   // which are owned by the PARTIAL phase.
   private volatile boolean _wagedBaselineComputeFailing = false;
+  // Reversible gauge: 1 while the most recent delayed-rebalance-overwrite computation failed, reset
+  // to 0 when one next succeeds or is not needed. Owned exclusively by the DELAYED_REBALANCE_OVERWRITES
+  // phase -- its only dedicated reversible signal (it otherwise shares the fallback gauge with
+  // emergency). This is the temporary min-active-replica top-up applied during the delayed window.
+  private volatile boolean _wagedRebalanceOverwriteFailing = false;
 
   // WAGED per-HardConstraint failure counters. Pre-populated for every HardConstraint.Type so
   // reads return 0 instead of NPE for constraints that have not yet fired.
@@ -896,6 +901,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       _wagedCustomerActionableFailure = false;
       _wagedInternalFailure = false;
       _wagedBaselineComputeFailing = false;
+      _wagedRebalanceOverwriteFailing = false;
     } catch (Exception e) {
       LOG.error("Fail to reset ClusterStatusMonitor, cluster: " + _clusterName, e);
     }
@@ -1392,6 +1398,15 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   /**
+   * Flip the reversible delayed-rebalance-overwrite-failing gauge. Set true when the overwrite
+   * computation fails, false when it next succeeds or is not needed. Owned exclusively by the
+   * DELAYED_REBALANCE_OVERWRITES phase.
+   */
+  public void updateWagedRebalanceOverwriteFailing(boolean failing) {
+    _wagedRebalanceOverwriteFailing = failing;
+  }
+
+  /**
    * Record that a partition failed placement because at least one candidate node was rejected
    * by a hard constraint of the given type. Called once per partition per distinct constraint
    * type that contributed to the failure (set-union across nodes, not summed).
@@ -1474,6 +1489,11 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   @Override
   public long getWagedBaselineComputeFailingGauge() {
     return _wagedBaselineComputeFailing ? 1L : 0L;
+  }
+
+  @Override
+  public long getWagedRebalanceOverwriteFailingGauge() {
+    return _wagedRebalanceOverwriteFailing ? 1L : 0L;
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -102,10 +102,24 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   private final AtomicLong _wagedCustomerActionableFailureCount = new AtomicLong(0L);
   private final AtomicLong _wagedInternalFailureCount = new AtomicLong(0L);
   private volatile boolean _wagedFallbackInUse = false;
+  // Reversible rollup gauges: 1 while WAGED's most recent computation failed for a customer-actionable
+  // reason (capacity / candidate-node / resource-config / cluster-config) vs a Helix-internal reason
+  // (metadata-store / algorithm / async / unknown); reset to 0 on the next clean computation. Drives
+  // "who to page right now" and self-clears on recovery. The *Count fields above stay the monotonic
+  // "how often" tally.
+  private volatile boolean _wagedCustomerActionableFailure = false;
+  private volatile boolean _wagedInternalFailure = false;
 
   // WAGED per-HardConstraint failure counters. Pre-populated for every HardConstraint.Type so
   // reads return 0 instead of NPE for constraints that have not yet fired.
   private final Map<HardConstraint.Type, AtomicLong> _wagedHardConstraintFailureCounters =
+      new ConcurrentHashMap<>();
+
+  // WAGED per-HardConstraint "currently blocking" gauges (0/1). Unlike the cumulative counters
+  // above, these are reversible: 1 while a constraint blocked placement in the most recent WAGED
+  // computation, reset to 0 on the next clean computation. Lets a transient blip be told apart from
+  // a persistent failure by value, per reason. Pre-populated for every type to avoid NPE.
+  private final Map<HardConstraint.Type, AtomicLong> _wagedHardConstraintBlockingGauges =
       new ConcurrentHashMap<>();
 
   // Cluster-level instance operation counts
@@ -152,9 +166,10 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
         HelixRebalanceException.FailureCategory.values()) {
       _wagedFailureCategoryCounters.put(category, new AtomicLong(0L));
     }
-    // Same for per-HardConstraint counters.
+    // Same for per-HardConstraint counters and the reversible per-HardConstraint blocking gauges.
     for (HardConstraint.Type type : HardConstraint.Type.values()) {
       _wagedHardConstraintFailureCounters.put(type, new AtomicLong(0L));
+      _wagedHardConstraintBlockingGauges.put(type, new AtomicLong(0L));
     }
   }
 
@@ -868,9 +883,12 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       // period being attributed to the new one.
       _wagedFailureCategoryCounters.values().forEach(c -> c.set(0L));
       _wagedHardConstraintFailureCounters.values().forEach(c -> c.set(0L));
+      _wagedHardConstraintBlockingGauges.values().forEach(g -> g.set(0L));
       _wagedCustomerActionableFailureCount.set(0L);
       _wagedInternalFailureCount.set(0L);
       _wagedFallbackInUse = false;
+      _wagedCustomerActionableFailure = false;
+      _wagedInternalFailure = false;
     } catch (Exception e) {
       LOG.error("Fail to reset ClusterStatusMonitor, cluster: " + _clusterName, e);
     }
@@ -1313,9 +1331,20 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     _wagedFailureCategoryCounters.get(category).incrementAndGet();
     if (category.isCustomerActionable()) {
       _wagedCustomerActionableFailureCount.incrementAndGet();
+      _wagedCustomerActionableFailure = true;
     } else {
       _wagedInternalFailureCount.incrementAndGet();
+      _wagedInternalFailure = true;
     }
+  }
+
+  /**
+   * Reset the reversible rollup failure gauges to 0. Called on a clean WAGED computation so a prior
+   * "currently failing" reading clears on recovery. The monotonic rollup counters are untouched.
+   */
+  public void resetWagedFailureRollupGauges() {
+    _wagedCustomerActionableFailure = false;
+    _wagedInternalFailure = false;
   }
 
   /**
@@ -1328,6 +1357,23 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       type = HardConstraint.Type.UNKNOWN;
     }
     _wagedHardConstraintFailureCounters.get(type).incrementAndGet();
+  }
+
+  /**
+   * Publish the reversible per-HardConstraint "currently blocking" snapshot from the most recent
+   * WAGED computation: each type in {@code currentlyBlocking} is set to 1, every other type to 0.
+   * An empty (or null) set -- a clean computation -- resets all gauges to 0, so the signal tells a
+   * transient blip apart from a persistent failure by value. See
+   * {@link ClusterStatusMonitorMBean#getWagedHardConstraintFaultZoneBlockingGauge()}.
+   * @param currentlyBlocking HardConstraint.Types that blocked placement in the latest computation
+   */
+  public void updateWagedHardConstraintBlocking(Set<HardConstraint.Type> currentlyBlocking) {
+    Set<HardConstraint.Type> blocking =
+        currentlyBlocking == null ? Collections.emptySet() : currentlyBlocking;
+    for (Map.Entry<HardConstraint.Type, AtomicLong> entry : _wagedHardConstraintBlockingGauges
+        .entrySet()) {
+      entry.getValue().set(blocking.contains(entry.getKey()) ? 1L : 0L);
+    }
   }
 
   /**
@@ -1369,6 +1415,16 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   @Override
   public long getWagedInternalFailureCounter() {
     return _wagedInternalFailureCount.get();
+  }
+
+  @Override
+  public long getWagedCustomerActionableFailureGauge() {
+    return _wagedCustomerActionableFailure ? 1L : 0L;
+  }
+
+  @Override
+  public long getWagedInternalFailureGauge() {
+    return _wagedInternalFailure ? 1L : 0L;
   }
 
   @Override
@@ -1459,6 +1515,41 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   @Override
   public long getWagedHardConstraintUnknownFailureCounter() {
     return _wagedHardConstraintFailureCounters.get(HardConstraint.Type.UNKNOWN).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintFaultZoneBlockingGauge() {
+    return _wagedHardConstraintBlockingGauges.get(HardConstraint.Type.FAULT_ZONE).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintNodeCapacityBlockingGauge() {
+    return _wagedHardConstraintBlockingGauges.get(HardConstraint.Type.NODE_CAPACITY).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintNodeMaxPartitionLimitBlockingGauge() {
+    return _wagedHardConstraintBlockingGauges.get(HardConstraint.Type.NODE_MAX_PARTITION_LIMIT).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintReplicaActivateBlockingGauge() {
+    return _wagedHardConstraintBlockingGauges.get(HardConstraint.Type.REPLICA_ACTIVATE).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintSamePartitionOnInstanceBlockingGauge() {
+    return _wagedHardConstraintBlockingGauges.get(HardConstraint.Type.SAME_PARTITION_ON_INSTANCE).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintValidGroupTagBlockingGauge() {
+    return _wagedHardConstraintBlockingGauges.get(HardConstraint.Type.VALID_GROUP_TAG).get();
+  }
+
+  @Override
+  public long getWagedHardConstraintUnknownBlockingGauge() {
+    return _wagedHardConstraintBlockingGauges.get(HardConstraint.Type.UNKNOWN).get();
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -109,6 +109,12 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   // "how often" tally.
   private volatile boolean _wagedCustomerActionableFailure = false;
   private volatile boolean _wagedInternalFailure = false;
+  // Reversible gauge: 1 while WAGED's most recent Baseline (global) computation failed, reset to 0
+  // when a Baseline computation next succeeds. Owned exclusively by the GLOBAL_BASELINE phase. This
+  // is the latent signal -- serving may be fine (partial succeeds off the last-good baseline) while
+  // WAGED can no longer recompute the ideal target. Distinct from the serving rollup gauges above,
+  // which are owned by the PARTIAL phase.
+  private volatile boolean _wagedBaselineComputeFailing = false;
 
   // WAGED per-HardConstraint failure counters. Pre-populated for every HardConstraint.Type so
   // reads return 0 instead of NPE for constraints that have not yet fired.
@@ -889,6 +895,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       _wagedFallbackInUse = false;
       _wagedCustomerActionableFailure = false;
       _wagedInternalFailure = false;
+      _wagedBaselineComputeFailing = false;
     } catch (Exception e) {
       LOG.error("Fail to reset ClusterStatusMonitor, cluster: " + _clusterName, e);
     }
@@ -1320,31 +1327,68 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   /**
-   * Record a WAGED rebalance failure with its classified category. Increments both the
-   * per-category counter and the matching rollup counter (customer-actionable vs internal).
-   * Safe to call from the controller pipeline thread.
+   * Increment the monotonic WAGED failure counters (per-category plus the customer-actionable /
+   * internal rollup counter) for a classified failure. This is the scope-agnostic "how often" tally
+   * -- every failing computation counts, whether baseline, partial, or emergency. It does NOT touch
+   * the reversible rollup gauges; see {@link #setWagedFailureRollupGauge}. Safe to call from any
+   * rebalance thread.
    */
-  public void reportWagedFailureByCategory(HelixRebalanceException.FailureCategory category) {
+  public void incrementWagedFailureCategoryCount(HelixRebalanceException.FailureCategory category) {
     if (category == null) {
       category = HelixRebalanceException.FailureCategory.UNKNOWN;
     }
     _wagedFailureCategoryCounters.get(category).incrementAndGet();
     if (category.isCustomerActionable()) {
       _wagedCustomerActionableFailureCount.incrementAndGet();
-      _wagedCustomerActionableFailure = true;
     } else {
       _wagedInternalFailureCount.incrementAndGet();
+    }
+  }
+
+  /**
+   * Light the reversible rollup failure gauge (customer-actionable vs internal) for a classified
+   * failure. This is the "is serving failing right now" signal and is owned by the SERVING (partial
+   * / emergency) phase only -- baseline failures must not light it, since serving can be healthy
+   * while the baseline is stale. Reset on a clean partial via {@link #resetWagedFailureRollupGauges}.
+   */
+  public void setWagedFailureRollupGauge(HelixRebalanceException.FailureCategory category) {
+    if (category == null) {
+      category = HelixRebalanceException.FailureCategory.UNKNOWN;
+    }
+    if (category.isCustomerActionable()) {
+      _wagedCustomerActionableFailure = true;
+    } else {
       _wagedInternalFailure = true;
     }
   }
 
   /**
-   * Reset the reversible rollup failure gauges to 0. Called on a clean WAGED computation so a prior
-   * "currently failing" reading clears on recovery. The monotonic rollup counters are untouched.
+   * Record a serving-scope WAGED rebalance failure with its classified category: ticks the
+   * monotonic counters and lights the reversible rollup gauge. Convenience for callers on the
+   * serving path (partial failure, synchronous emergency / overwrite). Baseline failures should call
+   * {@link #incrementWagedFailureCategoryCount} only.
+   */
+  public void reportWagedFailureByCategory(HelixRebalanceException.FailureCategory category) {
+    incrementWagedFailureCategoryCount(category);
+    setWagedFailureRollupGauge(category);
+  }
+
+  /**
+   * Reset the reversible rollup failure gauges to 0. Called when the SERVING (partial) computation
+   * succeeds so a prior "currently failing" reading clears on recovery. The monotonic rollup
+   * counters are untouched.
    */
   public void resetWagedFailureRollupGauges() {
     _wagedCustomerActionableFailure = false;
     _wagedInternalFailure = false;
+  }
+
+  /**
+   * Flip the reversible Baseline-compute-failing gauge. Set true when the Baseline (global)
+   * computation fails, false when it next succeeds. Owned exclusively by the GLOBAL_BASELINE phase.
+   */
+  public void updateWagedBaselineComputeFailing(boolean failing) {
+    _wagedBaselineComputeFailing = failing;
   }
 
   /**
@@ -1425,6 +1469,11 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   @Override
   public long getWagedInternalFailureGauge() {
     return _wagedInternalFailure ? 1L : 0L;
+  }
+
+  @Override
+  public long getWagedBaselineComputeFailingGauge() {
+    return _wagedBaselineComputeFailing ? 1L : 0L;
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -210,16 +210,21 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
   // (alert on `== 1 for Xm`), while a transient blip falls back to 0 on the next clean run -- the
   // per-reason transient-vs-persistent discriminator the cumulative counters cannot provide.
   //
-  // SCOPE: these gauges reflect the PARTIAL (serving) phase only. WAGED runs calculate() up to four
-  // times per pipeline -- baseline, emergency, delayed-overwrite, and partial -- and the baseline and
-  // partial phases run concurrently on separate executors. A reversible gauge must have exactly one
-  // writer per pipeline or a clean run of one phase would clobber (mask) a failing run of another, so
-  // a single owner is chosen: partial, because it produces the assignment that is actually served.
-  // The other phases are intentionally NOT wired to these gauges:
-  //   - Baseline (global) failures surface via the binary getWagedBaselineComputeFailingGauge() (no
-  //     per-reason breakdown) plus the monotonic per-HardConstraint counters above.
-  //   - Emergency / delayed-overwrite failures surface via getWagedFallbackInUseGauge() plus
-  //     the monotonic per-HardConstraint counters above.
+  // SCOPE: these gauges reflect the SERVING phases -- PARTIAL and EMERGENCY -- which produce the
+  // assignment that is actually persisted and served. WAGED runs calculate() up to four times per
+  // pipeline (baseline, emergency, delayed-overwrite, partial); a reversible gauge must not be shared
+  // with a phase whose health it does not represent, or a clean run of one phase would clobber (mask)
+  // a failing run of another. Partial and emergency do not race: within a pass emergency runs first
+  // and, when it fails, throws before partial is reached -- so partial does not run, making emergency
+  // the sole serving writer exactly when it is the phase that failed (its per-reason attribution would
+  // otherwise be lost, since node-down-can't-reassign is precisely an emergency failure). The
+  // non-serving phases are intentionally NOT wired to these gauges:
+  //   - Baseline (global) runs concurrently with partial on a separate executor and computes the
+  //     from-scratch ideal, not the served assignment; its failures surface via the binary
+  //     getWagedBaselineComputeFailingGauge() (no per-reason breakdown) plus the per-HardConstraint
+  //     counters above.
+  //   - Delayed-overwrite is a temporary, non-persisted top-up; its failures surface via
+  //     getWagedFallbackInUseGauge() plus the per-HardConstraint counters above.
   // So to attribute a per-reason failure outside the serving path, read the monotonic counters; these
   // reversible gauges answer specifically "which reason is blocking the *served* assignment right now".
 

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -145,6 +145,23 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    */
   long getWagedFallbackInUseGauge();
 
+  /**
+   * Reversible rollup of {@link #getWagedCustomerActionableFailureCounter()}: 1 while WAGED's most
+   * recent computation failed for a customer-controlled reason (capacity / candidate-node / resource
+   * or cluster config), 0 once a later computation succeeds. Unlike the counter, this resets on
+   * recovery -- alert on {@code == 1 for Xm} to page the customer while it is persistently failing.
+   * @return 1 if WAGED is currently failing for a customer-actionable reason; 0 otherwise.
+   */
+  long getWagedCustomerActionableFailureGauge();
+
+  /**
+   * Reversible rollup of {@link #getWagedInternalFailureCounter()}: 1 while WAGED's most recent
+   * computation failed for a Helix-controlled reason (metadata store / algorithm / async / unknown),
+   * 0 once a later computation succeeds. Alert on {@code == 1 for Xm} to page Helix oncall.
+   * @return 1 if WAGED is currently failing for a Helix-internal reason; 0 otherwise.
+   */
+  long getWagedInternalFailureGauge();
+
   // ---- WAGED hard-constraint failure sub-breakdown (subset of WagedFailureNoCandidateNodeCounter) ----
   // When a partition cannot find any eligible node, every hard constraint that rejected at least
   // one candidate gets its counter incremented once for that partition. These sub-dimensions let
@@ -171,6 +188,34 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
 
   /** @return Partitions that failed placement due to a hard constraint with no specific type tag. */
   long getWagedHardConstraintUnknownFailureCounter();
+
+  // ---- WAGED per-HardConstraint "currently blocking" gauges (reversible) ----
+  // Each is 1 while that hard constraint blocked placement in the most recent WAGED computation and
+  // 0 once a later computation places everything. Unlike the monotonic counters above, these reset
+  // on recovery, so a value sustained at 1 means the reason is *currently and persistently* blocking
+  // (alert on `== 1 for Xm`), while a transient blip falls back to 0 on the next clean run -- the
+  // per-reason transient-vs-persistent discriminator the cumulative counters cannot provide.
+
+  /** @return 1 if the fault-zone constraint is currently blocking placement; 0 otherwise. */
+  long getWagedHardConstraintFaultZoneBlockingGauge();
+
+  /** @return 1 if per-node capacity is currently blocking placement; 0 otherwise. */
+  long getWagedHardConstraintNodeCapacityBlockingGauge();
+
+  /** @return 1 if the max-partitions-per-instance limit is currently blocking placement; 0 otherwise. */
+  long getWagedHardConstraintNodeMaxPartitionLimitBlockingGauge();
+
+  /** @return 1 if replica-activation (inactive instances) is currently blocking placement; 0 otherwise. */
+  long getWagedHardConstraintReplicaActivateBlockingGauge();
+
+  /** @return 1 if the same-partition-on-instance rule is currently blocking placement; 0 otherwise. */
+  long getWagedHardConstraintSamePartitionOnInstanceBlockingGauge();
+
+  /** @return 1 if the required-group-tag constraint is currently blocking placement; 0 otherwise. */
+  long getWagedHardConstraintValidGroupTagBlockingGauge();
+
+  /** @return 1 if a hard constraint with no specific type tag is currently blocking placement; 0 otherwise. */
+  long getWagedHardConstraintUnknownBlockingGauge();
 
   /**
    * @return number of all resources in this cluster

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -209,6 +209,19 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
   // on recovery, so a value sustained at 1 means the reason is *currently and persistently* blocking
   // (alert on `== 1 for Xm`), while a transient blip falls back to 0 on the next clean run -- the
   // per-reason transient-vs-persistent discriminator the cumulative counters cannot provide.
+  //
+  // SCOPE: these gauges reflect the PARTIAL (serving) phase only. WAGED runs calculate() up to four
+  // times per pipeline -- baseline, emergency, delayed-overwrite, and partial -- and the baseline and
+  // partial phases run concurrently on separate executors. A reversible gauge must have exactly one
+  // writer per pipeline or a clean run of one phase would clobber (mask) a failing run of another, so
+  // a single owner is chosen: partial, because it produces the assignment that is actually served.
+  // The other phases are intentionally NOT wired to these gauges:
+  //   - Baseline (global) failures surface via the binary getWagedBaselineComputeFailingGauge() (no
+  //     per-reason breakdown) plus the monotonic per-HardConstraint counters above.
+  //   - Emergency / delayed-overwrite failures surface via getWagedFallbackInUseGauge() plus
+  //     the monotonic per-HardConstraint counters above.
+  // So to attribute a per-reason failure outside the serving path, read the monotonic counters; these
+  // reversible gauges answer specifically "which reason is blocking the *served* assignment right now".
 
   /** @return 1 if the fault-zone constraint is currently blocking placement; 0 otherwise. */
   long getWagedHardConstraintFaultZoneBlockingGauge();

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -147,20 +147,34 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
 
   /**
    * Reversible rollup of {@link #getWagedCustomerActionableFailureCounter()}: 1 while WAGED's most
-   * recent computation failed for a customer-controlled reason (capacity / candidate-node / resource
-   * or cluster config), 0 once a later computation succeeds. Unlike the counter, this resets on
-   * recovery -- alert on {@code == 1 for Xm} to page the customer while it is persistently failing.
-   * @return 1 if WAGED is currently failing for a customer-actionable reason; 0 otherwise.
+   * recent SERVING (partial) computation failed for a customer-controlled reason (capacity /
+   * candidate-node / resource or cluster config), 0 once a later partial computation succeeds.
+   * Scoped to the serving phase so a stale-baseline-only failure does not page the customer. Unlike
+   * the counter, this resets on recovery -- alert on {@code == 1 for Xm} to page the customer while
+   * serving is persistently failing.
+   * @return 1 if WAGED serving is currently failing for a customer-actionable reason; 0 otherwise.
    */
   long getWagedCustomerActionableFailureGauge();
 
   /**
    * Reversible rollup of {@link #getWagedInternalFailureCounter()}: 1 while WAGED's most recent
-   * computation failed for a Helix-controlled reason (metadata store / algorithm / async / unknown),
-   * 0 once a later computation succeeds. Alert on {@code == 1 for Xm} to page Helix oncall.
-   * @return 1 if WAGED is currently failing for a Helix-internal reason; 0 otherwise.
+   * SERVING (partial) computation failed for a Helix-controlled reason (metadata store / algorithm /
+   * async / unknown), 0 once a later partial computation succeeds. Alert on {@code == 1 for Xm} to
+   * page Helix oncall.
+   * @return 1 if WAGED serving is currently failing for a Helix-internal reason; 0 otherwise.
    */
   long getWagedInternalFailureGauge();
+
+  /**
+   * Reversible gauge for the Baseline (global) computation: 1 while WAGED's most recent Baseline
+   * computation failed, 0 once a later Baseline computation succeeds. Owned by the GLOBAL_BASELINE
+   * phase. This is the latent signal -- serving can be healthy (partial succeeds off the last-good
+   * baseline) while WAGED can no longer recompute the ideal target, which will bite on the next
+   * disruption. Lower urgency than the serving gauges: alert on {@code == 1 for 1h} as a ticket, not
+   * a page. The specific blocking reason is available from the per-HardConstraint counters.
+   * @return 1 if WAGED Baseline computation is currently failing; 0 otherwise.
+   */
+  long getWagedBaselineComputeFailingGauge();
 
   // ---- WAGED hard-constraint failure sub-breakdown (subset of WagedFailureNoCandidateNodeCounter) ----
   // When a partition cannot find any eligible node, every hard constraint that rejected at least

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -176,6 +176,18 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    */
   long getWagedBaselineComputeFailingGauge();
 
+  /**
+   * Reversible gauge for the delayed-rebalance-overwrite phase: 1 while the most recent overwrite
+   * computation failed, 0 once a later one succeeds or is not needed. Owned by the
+   * DELAYED_REBALANCE_OVERWRITES phase -- its only dedicated reversible signal (it otherwise shares
+   * getWagedFallbackInUseGauge() with emergency). This phase is the temporary, non-persisted
+   * min-active-replica top-up applied during the delayed window, so a sustained 1 means partitions
+   * below minActiveReplicas cannot be topped up while their instances are offline-yet-active. The
+   * specific blocking reason is available from the per-HardConstraint counters.
+   * @return 1 if the WAGED delayed-rebalance-overwrite computation is currently failing; 0 otherwise.
+   */
+  long getWagedRebalanceOverwriteFailingGauge();
+
   // ---- WAGED hard-constraint failure sub-breakdown (subset of WagedFailureNoCandidateNodeCounter) ----
   // When a partition cannot find any eligible node, every hard constraint that rejected at least
   // one candidate gets its counter incremented once for that partition. These sub-dimensions let

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -112,7 +112,7 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
   }
 
   @Test
-  public void testHardConstraintBlockingSnapshotIsPartialScoped()
+  public void testHardConstraintBlockingSnapshotIsServingScoped()
       throws HelixRebalanceException, IOException {
     _metadataStore.reset();
     String testName = "TestBlockingScope";
@@ -130,25 +130,33 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
 
       // A concurrent BASELINE run blocked by a *different* reason must NOT clobber the serving
       // gauges -- this is the cross-phase masking the scope gate exists to prevent. The baseline
-      // snapshot is dropped: NODE_CAPACITY stays 0 and FAULT_ZONE (owned by partial) stays 1.
+      // snapshot is dropped: NODE_CAPACITY stays 0 and FAULT_ZONE (set by partial) stays 1.
       rebalancer.reportHardConstraintBlockingSnapshot(
           ClusterModel.RebalanceScopeType.GLOBAL_BASELINE,
           Collections.singleton(HardConstraint.Type.NODE_CAPACITY));
       Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityBlockingGauge(), 0L);
       Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 1L);
 
-      // EMERGENCY and DELAYED_REBALANCE_OVERWRITES are likewise dropped (no-ops on these gauges).
-      rebalancer.reportHardConstraintBlockingSnapshot(ClusterModel.RebalanceScopeType.EMERGENCY,
-          Collections.singleton(HardConstraint.Type.FAULT_ZONE));
+      // DELAYED_REBALANCE_OVERWRITES is a temporary, non-served computation -- also dropped.
       rebalancer.reportHardConstraintBlockingSnapshot(
           ClusterModel.RebalanceScopeType.DELAYED_REBALANCE_OVERWRITES,
           Collections.singleton(HardConstraint.Type.NODE_CAPACITY));
       Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityBlockingGauge(), 0L);
       Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 1L);
 
-      // The owning PARTIAL phase stays reversible: a clean partial run resets its gauges to 0.
+      // EMERGENCY is also a serving phase (its assignment is persisted), so it DOES publish. When a
+      // node is permanently down and emergency cannot re-place the evacuated replicas, partial never
+      // runs that pass -- so emergency must own the serving gauges or the reason would be lost. Its
+      // snapshot replaces the set: NODE_CAPACITY -> 1, FAULT_ZONE -> 0.
+      rebalancer.reportHardConstraintBlockingSnapshot(ClusterModel.RebalanceScopeType.EMERGENCY,
+          Collections.singleton(HardConstraint.Type.NODE_CAPACITY));
+      Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityBlockingGauge(), 1L);
+      Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 0L);
+
+      // The serving gauges stay reversible: a clean partial run resets them to 0.
       rebalancer.reportHardConstraintBlockingSnapshot(ClusterModel.RebalanceScopeType.PARTIAL,
           Collections.emptySet());
+      Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityBlockingGauge(), 0L);
       Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 0L);
     } finally {
       rebalancer.close();

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/TestWagedRebalancerMetrics.java
@@ -39,8 +39,10 @@ import org.apache.helix.HelixRebalanceException;
 import org.apache.helix.TestHelper;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.pipeline.Pipeline;
+import org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint;
 import org.apache.helix.controller.rebalancer.waged.constraints.MockRebalanceAlgorithm;
 import org.apache.helix.controller.rebalancer.waged.model.AbstractTestClusterModel;
+import org.apache.helix.controller.rebalancer.waged.model.ClusterModel;
 import org.apache.helix.controller.stages.AttributeName;
 import org.apache.helix.controller.stages.ClusterEvent;
 import org.apache.helix.controller.stages.ClusterEventType;
@@ -107,6 +109,50 @@ public class TestWagedRebalancerMetrics extends AbstractTestClusterModel {
     // Check that there exists a non-zero value in the metrics
     Assert.assertTrue(_metricCollector.getMetricMap().values().stream()
         .anyMatch(metric -> ((Number) metric.getLastEmittedMetricValue()).longValue() > 0L));
+  }
+
+  @Test
+  public void testHardConstraintBlockingSnapshotIsPartialScoped()
+      throws HelixRebalanceException, IOException {
+    _metadataStore.reset();
+    String testName = "TestBlockingScope";
+    MetricCollector metricCollector = new WagedRebalancerMetricCollector(testName);
+    WagedRebalancer rebalancer =
+        new WagedRebalancer(_metadataStore, _algorithm, Optional.of(metricCollector));
+    try {
+      ClusterStatusMonitor monitor = new ClusterStatusMonitor(testName);
+      rebalancer.setClusterStatusMonitor(monitor);
+
+      // The PARTIAL (serving) phase owns the per-reason blocking gauges: its snapshot publishes.
+      rebalancer.reportHardConstraintBlockingSnapshot(ClusterModel.RebalanceScopeType.PARTIAL,
+          Collections.singleton(HardConstraint.Type.FAULT_ZONE));
+      Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 1L);
+
+      // A concurrent BASELINE run blocked by a *different* reason must NOT clobber the serving
+      // gauges -- this is the cross-phase masking the scope gate exists to prevent. The baseline
+      // snapshot is dropped: NODE_CAPACITY stays 0 and FAULT_ZONE (owned by partial) stays 1.
+      rebalancer.reportHardConstraintBlockingSnapshot(
+          ClusterModel.RebalanceScopeType.GLOBAL_BASELINE,
+          Collections.singleton(HardConstraint.Type.NODE_CAPACITY));
+      Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityBlockingGauge(), 0L);
+      Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 1L);
+
+      // EMERGENCY and DELAYED_REBALANCE_OVERWRITES are likewise dropped (no-ops on these gauges).
+      rebalancer.reportHardConstraintBlockingSnapshot(ClusterModel.RebalanceScopeType.EMERGENCY,
+          Collections.singleton(HardConstraint.Type.FAULT_ZONE));
+      rebalancer.reportHardConstraintBlockingSnapshot(
+          ClusterModel.RebalanceScopeType.DELAYED_REBALANCE_OVERWRITES,
+          Collections.singleton(HardConstraint.Type.NODE_CAPACITY));
+      Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityBlockingGauge(), 0L);
+      Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 1L);
+
+      // The owning PARTIAL phase stays reversible: a clean partial run resets its gauges to 0.
+      rebalancer.reportHardConstraintBlockingSnapshot(ClusterModel.RebalanceScopeType.PARTIAL,
+          Collections.emptySet());
+      Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 0L);
+    } finally {
+      rebalancer.close();
+    }
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
@@ -22,6 +22,7 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -94,6 +95,48 @@ public class TestConstraintBasedAlgorithm {
     // calling again for recovery (no exception)
     algorithm.calculate(clusterModel);
     verify(mockHardConstraint, atLeastOnce()).setEnableLogging(eq(false));
+  }
+
+  @Test
+  public void testBlockingSnapshotReporterIsReversiblePerRun()
+      throws IOException, HelixRebalanceException {
+    HardConstraint mockHardConstraint = mock(HardConstraint.class);
+    SoftConstraint mockSoftConstraint = mock(SoftConstraint.class);
+    when(mockHardConstraint.isAssignmentValid(any(), any(), any()))
+        .thenReturn(false)  // run 1: blocks placement
+        .thenReturn(true);  // run 2: recovers
+    when(mockHardConstraint.getType()).thenReturn(HardConstraint.Type.FAULT_ZONE);
+    when(mockSoftConstraint.getAssignmentNormalizedScore(any(), any(), any())).thenReturn(1.0);
+    ConstraintBasedAlgorithm algorithm =
+        new ConstraintBasedAlgorithm(ImmutableList.of(mockHardConstraint),
+            ImmutableMap.of(mockSoftConstraint, 1f), TEST_FORK_JOIN_POOL);
+
+    // Capture the per-run blocking snapshot the algorithm publishes (one per calculate run).
+    List<Set<HardConstraint.Type>> snapshots = new ArrayList<>();
+    algorithm.setBlockingSnapshotReporter(snapshot -> snapshots.add(new HashSet<>(snapshot)));
+
+    ClusterModel clusterModel = new ClusterModelTestHelper().getDefaultClusterModel();
+
+    // Run 1: placement fails -> the run's snapshot flags the blocking constraint type.
+    try {
+      algorithm.calculate(clusterModel);
+      Assert.fail("Expected the run to fail with no candidate node");
+    } catch (HelixRebalanceException expected) {
+      Assert.assertEquals(expected.getFailureType(),
+          HelixRebalanceException.Type.FAILED_TO_CALCULATE);
+    }
+    Assert.assertEquals(snapshots.size(), 1);
+    Assert.assertEquals(snapshots.get(0).size(), 1);
+    Assert.assertTrue(snapshots.get(0).contains(HardConstraint.Type.FAULT_ZONE),
+        "Run-1 snapshot should flag the blocking type, got: " + snapshots.get(0));
+
+    // Run 2: placement succeeds -> snapshot resets to empty. This reversibility is the whole point:
+    // a transient blocker drops back to 0 on the next clean run, so it is distinguishable from a
+    // persistent one by value.
+    algorithm.calculate(clusterModel);
+    Assert.assertEquals(snapshots.size(), 2);
+    Assert.assertTrue(snapshots.get(1).isEmpty(),
+        "Blocking snapshot must reset to empty on a clean run, got: " + snapshots.get(1));
   }
 
   @Test

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestConstraintBasedAlgorithm.java
@@ -111,9 +111,14 @@ public class TestConstraintBasedAlgorithm {
         new ConstraintBasedAlgorithm(ImmutableList.of(mockHardConstraint),
             ImmutableMap.of(mockSoftConstraint, 1f), TEST_FORK_JOIN_POOL);
 
-    // Capture the per-run blocking snapshot the algorithm publishes (one per calculate run).
+    // Capture the per-run blocking snapshot the algorithm publishes (one per calculate run). The
+    // reporter also receives the model's rebalance scope -- assert it is plumbed through so a
+    // consumer can route the snapshot to a single owning phase.
     List<Set<HardConstraint.Type>> snapshots = new ArrayList<>();
-    algorithm.setBlockingSnapshotReporter(snapshot -> snapshots.add(new HashSet<>(snapshot)));
+    algorithm.setBlockingSnapshotReporter((scope, snapshot) -> {
+      Assert.assertEquals(scope, ClusterModel.RebalanceScopeType.PARTIAL);
+      snapshots.add(new HashSet<>(snapshot));
+    });
 
     ClusterModel clusterModel = new ClusterModelTestHelper().getDefaultClusterModel();
 

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/ClusterModelTestHelper.java
@@ -44,7 +44,8 @@ public class ClusterModelTestHelper extends AbstractTestClusterModel {
 
     ClusterContext context =
         new ClusterContext(assignableReplicas, assignableNodes, Collections.emptyMap(), Collections.emptyMap());
-    return new ClusterModel(context, assignableReplicas, assignableNodes);
+    return new ClusterModel(context, assignableReplicas, assignableNodes,
+        ClusterModel.RebalanceScopeType.PARTIAL);
   }
 
   public ClusterModel getMultiNodeClusterModel() throws IOException {
@@ -72,6 +73,7 @@ public class ClusterModelTestHelper extends AbstractTestClusterModel {
     ClusterContext context =
         new ClusterContext(assignableReplicas, assignableNodes, Collections.emptyMap(),
             Collections.emptyMap(), clusterConfig);
-    return new ClusterModel(context, assignableReplicas, assignableNodes);
+    return new ClusterModel(context, assignableReplicas, assignableNodes,
+        ClusterModel.RebalanceScopeType.PARTIAL);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModel.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterModel.java
@@ -45,7 +45,8 @@ public class TestClusterModel extends AbstractTestClusterModel {
     ClusterContext context =
         new ClusterContext(assignableReplicas, assignableNodes, Collections.emptyMap(),
             Collections.emptyMap());
-    ClusterModel clusterModel = new ClusterModel(context, assignableReplicas, assignableNodes);
+    ClusterModel clusterModel = new ClusterModel(context, assignableReplicas, assignableNodes,
+        ClusterModel.RebalanceScopeType.PARTIAL);
 
     Assert.assertTrue(clusterModel.getContext().getAssignmentForFaultZoneMap().values().stream()
         .allMatch(resourceMap -> resourceMap.values().isEmpty()));

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.helix.TestHelper;
 import org.apache.helix.common.caches.TaskDataCache;
+import org.apache.helix.controller.rebalancer.waged.constraints.HardConstraint;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.task.AssignableInstanceManager;
@@ -931,5 +932,66 @@ public class TestClusterStatusMonitor {
     ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedHardConstraintNullCluster");
     monitor.reportWagedHardConstraintFailure(null);
     Assert.assertEquals(monitor.getWagedHardConstraintUnknownFailureCounter(), 1L);
+  }
+
+  @Test
+  public void testWagedHardConstraintBlockingGaugesAreReversible() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedBlockingCluster");
+
+    // All blocking gauges start at 0.
+    Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityBlockingGauge(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintValidGroupTagBlockingGauge(), 0L);
+
+    // A failed run flags its blocking reason; unrelated reasons stay 0.
+    monitor.updateWagedHardConstraintBlocking(Collections.singleton(HardConstraint.Type.FAULT_ZONE));
+    Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 1L);
+    Assert.assertEquals(monitor.getWagedHardConstraintNodeCapacityBlockingGauge(), 0L);
+    Assert.assertEquals(monitor.getWagedHardConstraintValidGroupTagBlockingGauge(), 0L);
+
+    // A subsequent clean run resets every gauge to 0 -- the reversibility that distinguishes a
+    // transient blocker from a persistent one (the whole point of this signal).
+    monitor.updateWagedHardConstraintBlocking(Collections.emptySet());
+    Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 0L);
+
+    // The snapshot replaces (not accumulates): a new reason flips on while the prior one flips off.
+    monitor.updateWagedHardConstraintBlocking(
+        Collections.singleton(HardConstraint.Type.VALID_GROUP_TAG));
+    Assert.assertEquals(monitor.getWagedHardConstraintValidGroupTagBlockingGauge(), 1L);
+    Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneBlockingGauge(), 0L);
+
+    // null is treated as a clean run (reset all).
+    monitor.updateWagedHardConstraintBlocking(null);
+    Assert.assertEquals(monitor.getWagedHardConstraintValidGroupTagBlockingGauge(), 0L);
+  }
+
+  @Test
+  public void testWagedFailureRollupGaugesAreReversible() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedRollupGaugeCluster");
+
+    // Both rollup gauges start at 0.
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureGauge(), 0L);
+    Assert.assertEquals(monitor.getWagedInternalFailureGauge(), 0L);
+
+    // A customer-actionable failure flips only the customer gauge to 1.
+    monitor.reportWagedFailureByCategory(
+        org.apache.helix.HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT);
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureGauge(), 1L);
+    Assert.assertEquals(monitor.getWagedInternalFailureGauge(), 0L);
+
+    // A Helix-internal failure flips the internal gauge (both can be "currently failing" at once).
+    monitor.reportWagedFailureByCategory(
+        org.apache.helix.HelixRebalanceException.FailureCategory.METADATA_STORE_IO);
+    Assert.assertEquals(monitor.getWagedInternalFailureGauge(), 1L);
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureGauge(), 1L);
+
+    // A clean computation resets both gauges to 0 -- the reversibility the counters lack.
+    monitor.resetWagedFailureRollupGauges();
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureGauge(), 0L);
+    Assert.assertEquals(monitor.getWagedInternalFailureGauge(), 0L);
+
+    // The monotonic rollup counters are NOT touched by the gauge reset -- they keep the lifetime tally.
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureCounter(), 1L);
+    Assert.assertEquals(monitor.getWagedInternalFailureCounter(), 1L);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -1012,6 +1012,23 @@ public class TestClusterStatusMonitor {
   }
 
   @Test
+  public void testWagedRebalanceOverwriteFailingGaugeIsReversible() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedOverwriteGaugeCluster");
+
+    // Starts at 0 -- gives the delayed-rebalance-overwrite phase its own alertable signal instead of
+    // sharing the fallback gauge with emergency.
+    Assert.assertEquals(monitor.getWagedRebalanceOverwriteFailingGauge(), 0L);
+
+    // A failed overwrite computation flips it to 1.
+    monitor.updateWagedRebalanceOverwriteFailing(true);
+    Assert.assertEquals(monitor.getWagedRebalanceOverwriteFailingGauge(), 1L);
+
+    // A later successful (or not-needed) overwrite computation resets it to 0.
+    monitor.updateWagedRebalanceOverwriteFailing(false);
+    Assert.assertEquals(monitor.getWagedRebalanceOverwriteFailingGauge(), 0L);
+  }
+
+  @Test
   public void testIncrementWagedFailureCategoryCountDoesNotLightRollupGauge() {
     ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedBaselineScopeCluster");
 

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -994,4 +994,39 @@ public class TestClusterStatusMonitor {
     Assert.assertEquals(monitor.getWagedCustomerActionableFailureCounter(), 1L);
     Assert.assertEquals(monitor.getWagedInternalFailureCounter(), 1L);
   }
+
+  @Test
+  public void testWagedBaselineComputeFailingGaugeIsReversible() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedBaselineGaugeCluster");
+
+    // Starts at 0.
+    Assert.assertEquals(monitor.getWagedBaselineComputeFailingGauge(), 0L);
+
+    // A failed Baseline computation flips it to 1.
+    monitor.updateWagedBaselineComputeFailing(true);
+    Assert.assertEquals(monitor.getWagedBaselineComputeFailingGauge(), 1L);
+
+    // A later successful Baseline computation resets it to 0 -- reversible, like the serving gauges.
+    monitor.updateWagedBaselineComputeFailing(false);
+    Assert.assertEquals(monitor.getWagedBaselineComputeFailingGauge(), 0L);
+  }
+
+  @Test
+  public void testIncrementWagedFailureCategoryCountDoesNotLightRollupGauge() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedBaselineScopeCluster");
+
+    // Counter-only path (used by the Baseline phase): ticks the counters but must NOT light the
+    // reversible serving rollup gauge -- a stale baseline must not page the customer while serving
+    // (partial) is healthy.
+    monitor.incrementWagedFailureCategoryCount(
+        org.apache.helix.HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT);
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureCounter(), 1L);
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureGauge(), 0L);
+
+    // The combined serving-scope path (partial / emergency) ticks the counter AND lights the gauge.
+    monitor.reportWagedFailureByCategory(
+        org.apache.helix.HelixRebalanceException.FailureCategory.CAPACITY_DEFICIT);
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureCounter(), 2L);
+    Assert.assertEquals(monitor.getWagedCustomerActionableFailureGauge(), 1L);
+  }
 }


### PR DESCRIPTION
## Summary

Give the WAGED rebalance-failure counters from #188 a **reversible current-state gauge layer, scoped per rebalance phase**, so operators can (a) tell a *transient* failure from a *persistent* one, (b) alert without `rate()` math, and (c) see **each of WAGED's four rebalance phases independently**.

A monotonic counter increments identically whether a failure is a one-off blip or a sustained outage, and under WAGED's sparse rebalance evaluation a `rate()` / `increase()` query cannot distinguish "recovered" from "broken but not retried". This PR adds `0`/`1` gauges that read `1` while a failure is happening and reset to `0` on the next clean computation -- so a value sustained at `1` means "failing now", and a transient blocker self-clears. The monotonic counters are left untouched as the "how often" tally.

All new metrics live on the cluster-level `ClusterStatus` MBean, alongside the existing WAGED counters.

### Design: one owning phase per reversible gauge

WAGED computes assignments in up to four phases per pipeline, each invoking `ConstraintBasedAlgorithm.calculate()`:

| Phase | Produces | Thread (production default) |
|---|---|---|
| **Baseline** (global) | the from-scratch ideal (an input to partial, not served directly) | async executor |
| **Partial** | the best-possible **served** assignment | a *separate* async executor |
| **Emergency** | reassignment off permanently-down nodes (**persisted / served**) | pipeline thread (sync) |
| **Overwrite** | temporary min-active-replica top-up (not persisted) | pipeline thread (sync) |

Because baseline and partial run **concurrently on separate executors**, a single reversible gauge shared across phases would let one phase's clean run clobber another's failing run -- a masking race. So the core design rule is: **every reversible gauge has exactly one owning phase**, while the monotonic counters stay phase-agnostic ("how often, any phase").

### The metric layers (11 new reversible `0`/`1` gauges)

**Per-phase health -- each of the four phases independently alertable:**
- `WagedBaselineComputeFailingGauge` -- baseline failing. This is the *latent* signal: serving can be healthy off the last-good baseline while WAGED can no longer recompute the ideal (which bites on the next disruption).
- `WagedRebalanceOverwriteFailingGauge` -- the delayed-overwrite top-up failing (partitions below `minActiveReplicas` can't be topped up during the delayed window).
- Partial + emergency health is read from the serving gauges below (`== 1` on any of them, or the rollups).

**Per-reason serving detail (PARTIAL + EMERGENCY) -- "which hard constraint is blocking the *served* assignment":**
- `WagedHardConstraintFaultZoneBlockingGauge`
- `WagedHardConstraintNodeCapacityBlockingGauge`
- `WagedHardConstraintNodeMaxPartitionLimitBlockingGauge`
- `WagedHardConstraintReplicaActivateBlockingGauge`
- `WagedHardConstraintSamePartitionOnInstanceBlockingGauge`
- `WagedHardConstraintValidGroupTagBlockingGauge`
- `WagedHardConstraintUnknownBlockingGauge`

**Severity rollup (serving) -- "who to page right now":**
- `WagedCustomerActionableFailureGauge` -- serving failed for a customer-controlled reason (capacity / candidate-node / resource-config / cluster-config).
- `WagedInternalFailureGauge` -- serving failed for a Helix-controlled reason (metadata-store / algorithm / async / unknown).

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

N/A -- this is a follow-up to the WAGED failure-counter work in #188 (it adds reversible, phase-scoped gauge counterparts). No separate tracking issue.

### Description

- [x] Here are some details about my PR (no UI changes):

**What:** 11 new reversible (`0`/`1`) gauges on `ClusterStatus:cluster=<name>`, organized into the three layers above (per-phase health, per-reason serving detail, severity rollup).

**Why:** the #188 counters are monotonic, so (a) a single increment cannot reveal whether the failure persisted, and (b) `rate()` is unreliable for WAGED because global rebalance only re-runs on triggers (sparse) -- a persistently-broken-but-quiescent cluster looks identical to a recovered one. A reversible gauge puts the transient-vs-persistent answer in the *value*. Scoping each gauge to a single phase additionally ensures a baseline retry cannot mask a serving failure, and makes every phase independently alertable.

**How:**
- *Scope tag:* every `ClusterModel` now carries its `RebalanceScopeType` (`PARTIAL` / `GLOBAL_BASELINE` / `EMERGENCY` / `DELAYED_REBALANCE_OVERWRITES`), stamped at construction in `ClusterModelProvider`.
- *Per-reason serving gauges:* `ConstraintBasedAlgorithm.calculate()` publishes a per-run snapshot of the `HardConstraint.Type`s that blocked placement (empty on a clean run) **together with the model's scope**, in a `finally` block so it fires on success and failure. `WagedRebalancer` routes the snapshot to the serving gauges **only for `PARTIAL` and `EMERGENCY`** (both produce the served assignment); `GLOBAL_BASELINE` and `DELAYED_REBALANCE_OVERWRITES` snapshots are dropped. An empty snapshot resets the gauges to `0`. Partial and emergency do not race: emergency runs first and short-circuits partial on failure, so emergency owns the gauges exactly when it is the failing phase.
- *Baseline gauge:* driven from the global-rebalance runner outcome (set on failure, cleared on success), in both async and sync modes.
- *Overwrite gauge:* driven from the delayed-overwrite phase outcome in `handleDelayedRebalanceMinActiveReplica` (reported once in `finally` so both catch paths and the not-needed early return are covered).
- *Rollup gauges:* set on a serving failure (routed by `FailureCategory.isCustomerActionable()`); baseline failures tick the counters but do **not** light the serving rollup. Reset on **partial success** rather than at the synchronous-compute boundary, so the rollup stays reversible under WAGED's async default, where partial failures never reach the synchronous catch.
- The monotonic per-category, rollup, and hard-constraint counters are unchanged.

**Value semantics:** each gauge is `1` while its owning phase's most recent computation is failing (for that reason) and `0` otherwise. It reflects the latest computation and resets on recovery (same staleness characteristics as `WagedFallbackInUseGauge`). All reversible gauges also reset on leadership change.

**Consuming it** (alert on `<gauge> == 1 for Xm` -- no `rate()`, self-clears on recovery):
- `WagedCustomerActionableFailureGauge == 1 for 10m` -> page the customer; route by the lit `WagedHardConstraint<Type>BlockingGauge` for the exact reason.
- `WagedInternalFailureGauge == 1 for 10m` -> page Helix oncall.
- `WagedBaselineComputeFailingGauge == 1 for 1h` -> ticket (not a page): serving is fine but WAGED cannot recompute the ideal; fix before the next disruption.
- `WagedRebalanceOverwriteFailingGauge == 1 for Xm` -> partitions below `minActiveReplicas` cannot be topped up during the delayed window.

(Capacity headroom as a *leading* indicator is covered separately by `EstimatedMaxClusterCapacityUsageGauge`. `CAPACITY_DEFICIT` is an aggregate fail-fast *before* per-replica placement, so it surfaces in the rollup and the capacity gauge -- not in the per-node hard-constraint gauges; the per-node `NODE_CAPACITY` hard constraint does light `WagedHardConstraintNodeCapacityBlockingGauge`.)

<img width="767" height="227" alt="image" src="https://github.com/user-attachments/assets/dc4c042d-17cc-4bd9-ac3e-bdc5419455b2" />

<img width="784" height="424" alt="image" src="https://github.com/user-attachments/assets/0b99cf7a-31b8-4520-a5c9-692a6d2a6bf5" />
<img width="774" height="228" alt="image" src="https://github.com/user-attachments/assets/49a87cf3-cb7e-4d12-baa1-62c6416a51c4" />

### Tests

- [x] The following tests are written for this issue:

- `TestWagedRebalancerMetrics#testHardConstraintBlockingSnapshotIsServingScoped` -- the routing gate: `PARTIAL` and `EMERGENCY` snapshots publish; a concurrent `GLOBAL_BASELINE` snapshot for a different reason does **not** clobber them (the cross-phase masking the scope gate exists to prevent); `DELAYED_REBALANCE_OVERWRITES` is dropped; a clean `PARTIAL` run resets the gauges.
- `TestConstraintBasedAlgorithm#testBlockingSnapshotReporterIsReversiblePerRun` -- a failing run publishes a snapshot flagging the blocking constraint type, the next clean run publishes an empty snapshot (reset-on-success reversibility), and the model's scope is plumbed through to the reporter.
- `TestClusterStatusMonitor#testWagedHardConstraintBlockingGaugesAreReversible` -- per-type blocking gauges set/reset correctly, the snapshot replaces (not accumulates), and null is treated as a clean run.
- `TestClusterStatusMonitor#testWagedFailureRollupGaugesAreReversible` -- the customer/internal rollup gauges flip on the right failure category and reset to `0`, while the monotonic rollup *counters* are untouched by the gauge reset.
- `TestClusterStatusMonitor#testIncrementWagedFailureCategoryCountDoesNotLightRollupGauge` -- the baseline-scoped counter-only path ticks the counters without lighting the serving rollup gauge.
- `TestClusterStatusMonitor#testWagedBaselineComputeFailingGaugeIsReversible` -- the baseline gauge sets on failure and resets on a later success.
- `TestClusterStatusMonitor#testWagedRebalanceOverwriteFailingGaugeIsReversible` -- the overwrite gauge sets on failure and resets on a later success / not-needed.

- The following is the result of the `mvn test` command on the appropriate module:

```
mvn -pl helix-core test -Dtest='TestConstraintBasedAlgorithm,TestClusterModel,TestClusterStatusMonitor,TestWagedRebalancer,TestWagedRebalancerMetrics,TestWagedRebalanceThreadNaming'

Tests run: 51, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Changes that Break Backward Compatibility (Optional)

This PR adds 11 getter methods to the `ClusterStatusMonitorMBean` interface. This is an internal JMX MBean interface whose only implementer is `ClusterStatusMonitor`; it is not intended to be implemented by external code. The change is purely additive (new JMX attributes) -- no existing attribute, method signature, or behavior is changed, and all monotonic counters are untouched -- so monitoring consumers that read attributes over JMX are unaffected. No backward-incompatible behavior is introduced.

The `ClusterModel` constructor gains a `RebalanceScopeType` parameter; `ClusterModel` and its constructor are package-private (`org.apache.helix.controller.rebalancer.waged.model`), so this is internal to the WAGED rebalancer.

### Documentation (Optional)

No wiki page is required. Each gauge is documented inline via Javadoc on `ClusterStatusMonitorMBean`, including the value range, reset semantics, owning phase, and recommended alert form.

### Code Quality

- [x] My diff has been formatted consistent with the surrounding code and `helix-style.xml`.
