### PR TITLE
[helix-rest] Surface validation reason in addVirtualTopologyGroup 400 response

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -279,7 +279,13 @@ public class ClusterAccessor extends AbstractHelixResource {
           return badRequest("Invalid payload json body: " + content);
         } catch (IllegalArgumentException ex) {
           LOG.error("Illegal input {} for command {}.", content, command, ex);
-          return badRequest(String.format("Illegal input %s for command %s", content, command));
+          // Surface the validation reason (for example "Number of virtual groups cannot be greater
+          // than the number of zones.") in the response body, not just the echoed payload, so
+          // callers like ACM can report the actual cause instead of an opaque "Illegal input"
+          // message that only lives in this server's log.
+          String reason = (ex.getMessage() == null) ? "" : (": " + ex.getMessage());
+          return badRequest(
+              String.format("Illegal input %s for command %s%s", content, command, reason));
         } catch (Exception ex) {
           LOG.error("Failed to add virtual topology group to cluster {}", clusterId, ex);
           return serverError(ex);

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestClusterAccessor.java
@@ -516,6 +516,32 @@ public class TestClusterAccessor extends AbstractTestClass {
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 
+  @Test
+  public void testAddVirtualTopologyGroupSurfacesValidationReason() {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String clusterName = "VgErrorReasonCluster";
+    setupClusterForVirtualTopology(clusterName);
+
+    // The cluster has 5 fault zones; requesting 6 ZONE_BASED virtual groups must fail the
+    // "numGroups <= zones" validation and return a 400.
+    String requestParam = "{\"virtualTopologyGroupNumber\":\"6\",\"virtualTopologyGroupName\":\"vgTest\","
+        + "\"assignmentAlgorithmType\":\"ZONE_BASED\"}";
+
+    Response response = post("clusters/" + clusterName,
+        ImmutableMap.of("command", "addVirtualTopologyGroup"),
+        Entity.entity(requestParam, MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.BAD_REQUEST.getStatusCode(), true);
+
+    // The validation reason must be surfaced in the response body, not only in the server log, so
+    // callers (for example ACM) can report the actual cause instead of an opaque "Illegal input"
+    // message.
+    String body = response.readEntity(String.class);
+    Assert.assertTrue(
+        body.contains("Number of virtual groups cannot be greater than the number of zones"),
+        "Expected the validation reason in the response body but got: " + body);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
   @Test(dependsOnMethods = "testGetClusterTopologyAndFaultZoneMap")
   public void testAddConfigFields() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());


### PR DESCRIPTION
The addVirtualTopologyGroup IllegalArgumentException handler in ClusterAccessor returned only the echoed payload and command name, so the actual precondition failure (for example "Number of virtual groups cannot be greater than the number of zones.") was visible only in the helix-rest server log. Callers such as ACM received an opaque "Illegal input ... for command addVirtualTopologyGroup" with no cause.

Append ex.getMessage() to the badRequest body so the reason travels on the wire, and add a test asserting the reason is present in the 400 body.

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
