### PR TITLE
Fix InstanceOperationDuration gauges to report real elapsed seconds

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -96,7 +96,7 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   private SimpleDynamicMetric<Long> _topStatePartitionCountGauge;
   private SimpleDynamicMetric<Long> _domainInfoValidGauge;
 
-  // Instance Operation Duration Gauges (in milliseconds)
+  // Instance Operation Duration Gauges (in seconds)
   private SimpleDynamicMetric<Long> _instanceOperationDurationEnableGauge;
   private SimpleDynamicMetric<Long> _instanceOperationDurationDisableGauge;
   private SimpleDynamicMetric<Long> _instanceOperationDurationEvacuateGauge;
@@ -106,6 +106,9 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   // Track current operation and start time for duration calculation
   private InstanceConstants.InstanceOperation _currentOperation;
   private long _currentOperationStartTime;
+  // Whether _currentOperationStartTime has been seeded yet. Used only for the legacy
+  // unknown-timestamp (-1) path to latch the first observed time exactly once.
+  private boolean _operationStartTimeInitialized;
 
   // A map of dynamic capacity Gauges. The map's keys could change.
   private final Map<String, SimpleDynamicMetric<Long>> _dynamicCapacityMetricsMap;
@@ -123,9 +126,10 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     _initObjectName = objectName;
     _dynamicCapacityMetricsMap = new ConcurrentHashMap<>();
     _currentOperation = InstanceConstants.InstanceOperation.ENABLE;
-    // Initialize to 0 so that if we haven't received operation info yet, duration will be large
-    // and will be corrected when we receive the actual operation start time from InstanceConfig
+    // Seeded on the first updateInstanceOperation() call. While the operation start time is
+    // uninitialized, the duration gauge stays at 0 instead of measuring from epoch 0.
     _currentOperationStartTime = 0L;
+    _operationStartTimeInitialized = false;
 
     createMetrics();
   }
@@ -247,40 +251,40 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   }
 
   /**
-   * Get the current duration in ENABLE operation (in milliseconds)
-   * @return duration in milliseconds, or 0 if not in ENABLE state
+   * Get the current duration in ENABLE operation (in seconds)
+   * @return duration in seconds, or 0 if not in ENABLE state
    */
   protected long getInstanceOperationDurationEnable() {
     return _instanceOperationDurationEnableGauge.getValue();
   }
 
   /**
-   * Get the current duration in DISABLE operation (in milliseconds)
-   * @return duration in milliseconds, or 0 if not in DISABLE state
+   * Get the current duration in DISABLE operation (in seconds)
+   * @return duration in seconds, or 0 if not in DISABLE state
    */
   protected long getInstanceOperationDurationDisable() {
     return _instanceOperationDurationDisableGauge.getValue();
   }
 
   /**
-   * Get the current duration in EVACUATE operation (in milliseconds)
-   * @return duration in milliseconds, or 0 if not in EVACUATE state
+   * Get the current duration in EVACUATE operation (in seconds)
+   * @return duration in seconds, or 0 if not in EVACUATE state
    */
   protected long getInstanceOperationDurationEvacuate() {
     return _instanceOperationDurationEvacuateGauge.getValue();
   }
 
   /**
-   * Get the current duration in SWAP_IN operation (in milliseconds)
-   * @return duration in milliseconds, or 0 if not in SWAP_IN state
+   * Get the current duration in SWAP_IN operation (in seconds)
+   * @return duration in seconds, or 0 if not in SWAP_IN state
    */
   protected long getInstanceOperationDurationSwapIn() {
     return _instanceOperationDurationSwapInGauge.getValue();
   }
 
   /**
-   * Get the current duration in UNKNOWN operation (in milliseconds)
-   * @return duration in milliseconds, or 0 if not in UNKNOWN state
+   * Get the current duration in UNKNOWN operation (in seconds)
+   * @return duration in seconds, or 0 if not in UNKNOWN state
    */
   protected long getInstanceOperationDurationUnknown() {
     return _instanceOperationDurationUnknownGauge.getValue();
@@ -386,15 +390,16 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   }
 
   /**
-   * Update the instance operation and recalculate duration metrics.
-   * This method should be called whenever the instance operation changes or periodically
-   * to update the duration of the current operation.
+   * Update the instance operation and recalculate duration metrics. This method should be called
+   * whenever the instance operation changes or periodically to refresh the duration of the current
+   * operation. The duration gauges are reported in seconds.
    *
    * @param newOperation the current instance operation
-   * @param operationStartTime the timestamp (in milliseconds since epoch) when the operation started.
-   *                          This should come from InstanceConfig.InstanceOperation.getTimestamp()
-   *                          to survive controller restarts. Use -1 if timestamp is unknown
-   *                          (for backward compatibility with legacy HELIX_ENABLED field).
+   * @param operationStartTime the timestamp (in milliseconds since epoch) when the operation
+   *                          started. This should come from
+   *                          InstanceConfig.InstanceOperation.getTimestamp() to survive controller
+   *                          restarts. Use -1 if the timestamp is unknown (for backward
+   *                          compatibility with the legacy HELIX_ENABLED field).
    */
   public synchronized void updateInstanceOperation(InstanceConstants.InstanceOperation newOperation,
       long operationStartTime) {
@@ -402,27 +407,36 @@ public class InstanceMonitor extends DynamicMBeanProvider {
       newOperation = InstanceConstants.InstanceOperation.ENABLE;
     }
 
-    // Handle backward compatibility: if timestamp is -1 (unknown), use current time
-    // This happens when InstanceOperation is not set and we're using legacy HELIX_ENABLED field
-    // We capture current time ONCE to ensure consistency across calculations
+    // Capture current time ONCE so all calculations below are consistent.
     long currentTime = System.currentTimeMillis();
-    if (operationStartTime == -1L) {
-      operationStartTime = currentTime;
-    }
 
-    // Check if operation changed
-    if (_currentOperation != newOperation) {
-      // Switch to the new operation
+    boolean operationChanged = _currentOperation != newOperation;
+    if (operationChanged) {
       _currentOperation = newOperation;
-      _currentOperationStartTime = operationStartTime;
-
-      // Reset all gauges except the current (new) operation
+      // Reset all gauges except the current (new) operation.
       resetAllExceptOperations(Collections.singleton(_currentOperation));
     }
 
-    // Update the duration gauge for the current operation (called on every update)
-    long currentDuration = currentTime - _currentOperationStartTime;
-    updateOperationDurationGauge(_currentOperation, currentDuration);
+    if (operationStartTime != -1L) {
+      // InstanceConfig carries the authoritative operation timestamp. Always trust it so the
+      // duration is correct even when the operation has not changed (e.g. an instance that is
+      // already ENABLE). Without this, the start time would never be seeded for an already-ENABLE
+      // instance and the gauge would report wall-clock time instead of an elapsed duration.
+      _currentOperationStartTime = operationStartTime;
+      _operationStartTimeInitialized = true;
+    } else if (operationChanged || !_operationStartTimeInitialized) {
+      // Backward compatibility: the timestamp is unknown (legacy HELIX_ENABLED field). Latch the
+      // current time on the first observation or whenever the operation changes, so the duration
+      // grows from now rather than from epoch 0.
+      _currentOperationStartTime = currentTime;
+      _operationStartTimeInitialized = true;
+    }
+
+    // Report the duration in seconds. Clamp to >= 0 to guard against clock skew between the host
+    // that wrote the timestamp and this controller; a future-dated timestamp would otherwise
+    // surface as a negative duration.
+    long currentDurationSeconds = Math.max(0L, (currentTime - _currentOperationStartTime) / 1000L);
+    updateOperationDurationGauge(_currentOperation, currentDurationSeconds);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
@@ -83,7 +83,7 @@ public class TestInstanceMonitor {
   }
 
   @Test
-  public void testInstanceOperationDurationMetrics() throws JMException, InterruptedException {
+  public void testInstanceOperationDurationMetrics() throws JMException {
     String testCluster = "testCluster";
     String testInstance = "testInstance";
     String testDomain = "testDomain:key=value";
@@ -97,73 +97,41 @@ public class TestInstanceMonitor {
     Assert.assertEquals(monitor.getInstanceOperationDurationSwapIn(), 0L);
     Assert.assertEquals(monitor.getInstanceOperationDurationUnknown(), 0L);
 
-    // Test EVACUATE operation
-    long evacuateStartTime = System.currentTimeMillis();
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE, evacuateStartTime);
+    // Durations are reported in seconds and derived from the authoritative start timestamp, so we
+    // drive the monitor with start times in the past instead of relying on sleeps.
+    long now = System.currentTimeMillis();
 
-    // Wait 100ms to let duration accumulate
-    Thread.sleep(100);
-
-    // Update again to calculate current duration
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE, evacuateStartTime);
-
-    // EVACUATE duration should be > 0 and roughly >= 100ms
+    // EVACUATE started 120s ago.
+    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE, now - 120_000L);
     long evacuateDuration = monitor.getInstanceOperationDurationEvacuate();
-    Assert.assertTrue(evacuateDuration >= 100L,
-        "EVACUATE duration should be >= 100ms, but was " + evacuateDuration);
-
-    // The previous operation (ENABLE) should be reset to 0 immediately
+    Assert.assertTrue(evacuateDuration >= 120L,
+        "EVACUATE duration should be >= 120s, but was " + evacuateDuration);
+    // Switching away from ENABLE resets it immediately, and the other operations stay 0.
     Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
         "ENABLE duration should be reset to 0 when switching to EVACUATE");
-
-    // All other operations should be 0
     Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L);
     Assert.assertEquals(monitor.getInstanceOperationDurationSwapIn(), 0L);
     Assert.assertEquals(monitor.getInstanceOperationDurationUnknown(), 0L);
 
-    // Wait another 100ms
-    Thread.sleep(100);
-
-    // Update again - duration should have increased
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE, evacuateStartTime);
+    // The authoritative timestamp is honored on every poll: an earlier start time yields a larger
+    // duration even though the operation itself did not change.
+    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.EVACUATE, now - 240_000L);
     long evacuateDuration2 = monitor.getInstanceOperationDurationEvacuate();
-    Assert.assertTrue(evacuateDuration2 > evacuateDuration,
-        "EVACUATE duration should increase over time");
-    Assert.assertTrue(evacuateDuration2 >= 200L,
-        "EVACUATE duration should be >= 200ms, but was " + evacuateDuration2);
+    Assert.assertTrue(evacuateDuration2 >= 240L,
+        "EVACUATE duration should track the configured start time, but was " + evacuateDuration2);
 
-    // Change to DISABLE operation
-    long disableStartTime = System.currentTimeMillis();
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.DISABLE, disableStartTime);
-
-    // All gauges except DISABLE should be reset to 0
+    // Change to DISABLE, started 60s ago. All gauges except DISABLE reset to 0.
+    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.DISABLE, now - 60_000L);
+    Assert.assertTrue(monitor.getInstanceOperationDurationDisable() >= 60L,
+        "DISABLE duration should be >= 60s");
     Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
         "EVACUATE duration should be reset to 0 when switching to DISABLE");
-    Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L,
-        "DISABLE duration should start at 0");
-    Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
-        "ENABLE duration should be reset to 0");
+    Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L);
 
-    // Wait and verify DISABLE duration increases
-    Thread.sleep(100);
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.DISABLE, disableStartTime);
-    long disableDuration = monitor.getInstanceOperationDurationDisable();
-    Assert.assertTrue(disableDuration >= 100L,
-        "DISABLE duration should be >= 100ms, but was " + disableDuration);
-    // EVACUATE should remain reset at 0
-    Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
-        "EVACUATE should remain at 0");
-
-    // Test SWAP_IN operation
-    long swapInStartTime = System.currentTimeMillis();
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.SWAP_IN, swapInStartTime);
-    Thread.sleep(50);
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.SWAP_IN, swapInStartTime);
-
-    long swapInDuration = monitor.getInstanceOperationDurationSwapIn();
-    Assert.assertTrue(swapInDuration >= 50L,
-        "SWAP_IN duration should be >= 50ms, but was " + swapInDuration);
-    // All others (DISABLE, EVACUATE, ENABLE) should be reset to 0
+    // Change to SWAP_IN, started 30s ago.
+    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.SWAP_IN, now - 30_000L);
+    Assert.assertTrue(monitor.getInstanceOperationDurationSwapIn() >= 30L,
+        "SWAP_IN duration should be >= 30s");
     Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L,
         "DISABLE should be reset to 0");
     Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
@@ -171,32 +139,15 @@ public class TestInstanceMonitor {
     Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
         "ENABLE should be reset to 0");
 
-    // Test UNKNOWN operation
-    long unknownStartTime = System.currentTimeMillis();
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN, unknownStartTime);
-    Thread.sleep(50);
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN, unknownStartTime);
-
-    long unknownDuration = monitor.getInstanceOperationDurationUnknown();
-    Assert.assertTrue(unknownDuration >= 50L,
-        "UNKNOWN duration should be >= 50ms, but was " + unknownDuration);
-    // All others (SWAP_IN, DISABLE, EVACUATE, ENABLE) should be reset to 0
+    // Change to UNKNOWN, started 10s ago.
+    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.UNKNOWN, now - 10_000L);
+    Assert.assertTrue(monitor.getInstanceOperationDurationUnknown() >= 10L,
+        "UNKNOWN duration should be >= 10s");
     Assert.assertEquals(monitor.getInstanceOperationDurationSwapIn(), 0L,
         "SWAP_IN should be reset to 0");
-    Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L,
-        "DISABLE should be reset to 0");
-    Assert.assertEquals(monitor.getInstanceOperationDurationEvacuate(), 0L,
-        "EVACUATE should be reset to 0");
-    Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
-        "ENABLE should be reset to 0");
 
-    // Test going back to ENABLE - all others reset to 0
-    long enableStartTime = System.currentTimeMillis();
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.ENABLE, enableStartTime);
-    Thread.sleep(50);
-    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.ENABLE, enableStartTime);
-
-    // All gauges except ENABLE should be reset to 0
+    // Back to ENABLE, started 50s ago. All others reset to 0.
+    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.ENABLE, now - 50_000L);
     Assert.assertEquals(monitor.getInstanceOperationDurationUnknown(), 0L,
         "UNKNOWN should be reset to 0");
     Assert.assertEquals(monitor.getInstanceOperationDurationDisable(), 0L,
@@ -205,26 +156,20 @@ public class TestInstanceMonitor {
         "EVACUATE should be reset to 0");
     Assert.assertEquals(monitor.getInstanceOperationDurationSwapIn(), 0L,
         "SWAP_IN should be reset to 0");
-
-    // ENABLE duration should be > 0
     long enableDuration = monitor.getInstanceOperationDurationEnable();
     Assert.assertTrue(enableDuration >= 50L,
-        "ENABLE duration should be >= 50ms, but was " + enableDuration);
+        "ENABLE duration should be >= 50s, but was " + enableDuration);
 
-    // Test null operation defaults to ENABLE
-    monitor.updateInstanceOperation(null, enableStartTime);
-    Thread.sleep(50);
-    monitor.updateInstanceOperation(null, enableStartTime);
-    long enableDuration2 = monitor.getInstanceOperationDurationEnable();
-    Assert.assertTrue(enableDuration2 > enableDuration,
-        "ENABLE duration should continue increasing");
+    // A null operation defaults to ENABLE and keeps tracking the same operation/timestamp.
+    monitor.updateInstanceOperation(null, now - 50_000L);
+    Assert.assertTrue(monitor.getInstanceOperationDurationEnable() >= 50L,
+        "ENABLE duration should keep tracking after a null (defaulted) operation");
 
     monitor.unregister();
   }
 
   @Test
-  public void testInstanceOperationDurationWithInstanceConfigAPI()
-      throws JMException, InterruptedException {
+  public void testInstanceOperationDurationWithInstanceConfigAPI() throws JMException {
     String testCluster = "testCluster";
     String testInstance = "localhost_12345";
     String testDomain = "testDomain:key=value";
@@ -262,21 +207,18 @@ public class TestInstanceMonitor {
     Assert.assertTrue(operationTimestamp > 0,
         "Operation timestamp should be set");
 
-    // Update monitor with the new operation (simulating what ClusterStatusMonitor does)
+    // Update monitor with the new operation (simulating what ClusterStatusMonitor does).
     monitor.updateInstanceOperation(instanceConfig.getInstanceOperation().getOperation(),
-        instanceConfig.getInstanceOperation().getTimestamp());
+        operationTimestamp);
 
-    // Wait for duration to accumulate
-    Thread.sleep(150);
-
-    // Update monitor again to get current duration
-    monitor.updateInstanceOperation(instanceConfig.getInstanceOperation().getOperation(),
-        instanceConfig.getInstanceOperation().getTimestamp());
-
-    // Verify EVACUATE duration is tracking
+    // The API stamps the operation with the current time, so the gauge must reflect
+    // (now - timestamp) in seconds - a small, non-negative number. It must NOT be the
+    // wall-clock-derived value (~1.7e9 s) that the previous implementation produced for an
+    // operation that was already in progress.
     long evacuateDuration = monitor.getInstanceOperationDurationEvacuate();
-    Assert.assertTrue(evacuateDuration >= 150L,
-        "EVACUATE duration should be >= 150ms, but was " + evacuateDuration);
+    long evacuateUpperBound = (System.currentTimeMillis() - operationTimestamp) / 1000L + 2L;
+    Assert.assertTrue(evacuateDuration >= 0L && evacuateDuration <= evacuateUpperBound,
+        "EVACUATE duration should reflect (now - timestamp) in seconds, but was " + evacuateDuration);
     // ENABLE should be reset to 0 when switching to EVACUATE
     Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
         "ENABLE should be reset to 0 when switching to EVACUATE");
@@ -303,22 +245,67 @@ public class TestInstanceMonitor {
         InstanceConstants.InstanceOperationSource.ADMIN);
 
     // Update monitor
+    long disableTimestamp = instanceConfig2.getInstanceOperation().getTimestamp();
     monitor2.updateInstanceOperation(instanceConfig2.getInstanceOperation().getOperation(),
-        instanceConfig2.getInstanceOperation().getTimestamp());
-
-    Thread.sleep(100);
-    monitor2.updateInstanceOperation(instanceConfig2.getInstanceOperation().getOperation(),
-        instanceConfig2.getInstanceOperation().getTimestamp());
+        disableTimestamp);
 
     long disableDuration = monitor2.getInstanceOperationDurationDisable();
-    Assert.assertTrue(disableDuration >= 100L,
-        "DISABLE duration should be >= 100ms, but was " + disableDuration);
+    long disableUpperBound = (System.currentTimeMillis() - disableTimestamp) / 1000L + 2L;
+    Assert.assertTrue(disableDuration >= 0L && disableDuration <= disableUpperBound,
+        "DISABLE duration should reflect (now - timestamp) in seconds, but was " + disableDuration);
     Assert.assertEquals(monitor2.getInstanceOperationDurationEvacuate(), 0L,
         "EVACUATE should be 0 for this instance");
 
     // Clean up
     monitor.unregister();
     monitor2.unregister();
+  }
+
+  @Test
+  public void testEnableDurationUsesConfiguredTimestampNotWallClock() throws JMException {
+    String testCluster = "testCluster";
+    String testInstance = "testInstance";
+    String testDomain = "testDomain:key=value";
+    InstanceMonitor monitor =
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+
+    // Regression test: an instance that is already ENABLE (the monitor's default operation) never
+    // triggers an operation "change". The duration must still be measured from the configured
+    // enable timestamp, not from epoch 0 - the latter previously made the gauge report wall-clock
+    // time, which after 32-bit truncation downstream surfaced as a negative value.
+    long enabledTenMinutesAgo = System.currentTimeMillis() - 600_000L;
+    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.ENABLE,
+        enabledTenMinutesAgo);
+
+    long enableDuration = monitor.getInstanceOperationDurationEnable();
+    Assert.assertTrue(enableDuration >= 600L,
+        "ENABLE duration should be >= 600s (time since enable), but was " + enableDuration);
+    // Guard against the old wall-clock bug: an elapsed duration of a freshly-enabled instance must
+    // not be anywhere near epoch-seconds (~1.7e9).
+    Assert.assertTrue(enableDuration < 86_400L,
+        "ENABLE duration should be an elapsed duration, not wall-clock time, but was "
+            + enableDuration);
+
+    monitor.unregister();
+  }
+
+  @Test
+  public void testFutureOperationTimestampClampedToZero() throws JMException {
+    String testCluster = "testCluster";
+    String testInstance = "testInstance";
+    String testDomain = "testDomain:key=value";
+    InstanceMonitor monitor =
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+
+    // A timestamp in the future (e.g. clock skew between the host that wrote it and this
+    // controller) must be clamped to 0 rather than producing a negative duration.
+    long oneHourInFuture = System.currentTimeMillis() + 3_600_000L;
+    monitor.updateInstanceOperation(InstanceConstants.InstanceOperation.ENABLE, oneHourInFuture);
+
+    Assert.assertEquals(monitor.getInstanceOperationDurationEnable(), 0L,
+        "A future-dated operation timestamp should be clamped to 0");
+
+    monitor.unregister();
   }
 
   @Test


### PR DESCRIPTION
  ### Issues
  - [ ] My PR addresses the following Helix issues and references them in the PR description:
  N/A - no separate GitHub issue; this is an internal metric-correctness fix for the `InstanceOperationDuration_*` gauges.
  ### Description
  - [x] Here are some details about my PR, including screenshots of any UI changes:
  The instance operation duration gauges in `InstanceMonitor` were emitting wall-clock time instead of an elapsed duration for any instance whose operation was already ENABLE (the constructor
  default). The start time was only seeded inside the "operation changed" branch, so an already-ENABLE instance never seeded it and the gauge computed `currentTime - 0`, i.e. epoch millis.
  Downstream 32-bit truncation then wrapped that ~1.78e12 value into a large negative number, which is what showed up on the dashboards.
  Fixes:
  - Seed `_currentOperationStartTime` from the authoritative `InstanceConfig` timestamp on every poll (not just on operation change), so an already-ENABLE instance reports the true time since
  enable.
  - Report durations in seconds instead of milliseconds. A "time since operation" gauge in ms overflows signed 32-bit after ~24.86 days; seconds pushes that ceiling to ~68 years.
  - Clamp the duration to >= 0 to guard against a future-dated timestamp from clock skew between the writer and the controller.
  ### Tests
  - [x] The following tests are written for this issue:
  - `testEnableDurationUsesConfiguredTimestampNotWallClock` - new regression: an already-ENABLE instance reports elapsed time, not wall-clock.
  - `testFutureOperationTimestampClampedToZero` - new regression: a future-dated timestamp clamps to 0 instead of going negative.
  - `testInstanceOperationDurationMetrics` - reworked to be deterministic (past-dated start times, no sleeps) and assert in seconds.
  - `testInstanceOperationDurationWithInstanceConfigAPI` - reworked to assert the gauge reflects `(now - timestamp)` in seconds.
  - The following is the result of the "mvn test" command on the appropriate module:

  $ mvn test -pl helix-core -Dtest=TestInstanceMonitor
  Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS

  ### Changes that Break Backward Compatibility (Optional)
  - The `InstanceOperationDuration_*` gauges now report **seconds** instead of milliseconds, and now report a correct elapsed duration (previously they emitted epoch-scale values that wrapped
  negative downstream). These metrics are not yet consumed by any dashboard/alert, so this is treated as a fresh metric rather than a breaking change to an established contract.
  ### Documentation (Optional)
  - N/A - no new functionality; behavior of an existing metric is corrected.
  ### Commits
  - [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit
  message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"
  ### Code Quality
  - [x] My diff has been formatted using helix-style.xml
  (helix-style-intellij.xml if IntelliJ IDE is used)