### PR TITLE
Add ControllerEventQueueSizeGauge to detect a wedged ("zombie leader" controller)

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -974,6 +974,9 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
         _clusterStatusMonitor
             .updateClusterEventDuration(ClusterEventMonitor.PhaseName.TotalProcessed.name(),
                 _lastPipelineEndTimestamp - startTime);
+        // Report DEFAULT-pipeline progress so ControllerPipelineStalledGauge can tell a wedged
+        // controller (queue not draining) apart from an idle or busy-but-progressing one.
+        _clusterStatusMonitor.setLastPipelineEndTimestamp(_lastPipelineEndTimestamp);
         if (shouldCountTopologyEventAsProcessed(rebalanceFail, dataProvider)) {
           _clusterStatusMonitor.incrementTopologyChangeEventProcessed(event.getEventType());
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -977,6 +977,12 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
         // Report DEFAULT-pipeline progress so ControllerPipelineStalledGauge can tell a wedged
         // controller (queue not draining) apart from an idle or busy-but-progressing one.
         _clusterStatusMonitor.setLastPipelineEndTimestamp(_lastPipelineEndTimestamp);
+        // Keep the stall threshold in sync with ClusterConfig so it can be tuned without a redeploy.
+        ClusterConfig stallThresholdConfig = dataProvider.getClusterConfig();
+        if (stallThresholdConfig != null) {
+          _clusterStatusMonitor.setPipelineStallThresholdMs(
+              stallThresholdConfig.getControllerPipelineStallThresholdMs());
+        }
         if (shouldCountTopologyEventAsProcessed(rebalanceFail, dataProvider)) {
           _clusterStatusMonitor.incrementTopologyChangeEventProcessed(event.getEventType());
         }

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -1547,6 +1547,11 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
             _resourceControlDataProvider.clearMonitoringRecords();
           }
           _clusterStatusMonitor.active();
+          // Seed the pipeline-progress baseline at monitoring-enable (leadership acquisition) so a
+          // controller that wedges before completing its very first pipeline run is still caught:
+          // with a 0 baseline the stalled gauge cannot fire. Cold-start slowness that briefly reads
+          // as stalled is covered by the EKG warm-up window and the configurable stall threshold.
+          _clusterStatusMonitor.setLastPipelineEndTimestamp(System.currentTimeMillis());
         } else {
           logger.info("Disable clusterStatusMonitor for cluster " + _clusterName);
           // Reset will be done if (_isMonitoring = false) later, no matter if the state is changed or not.

--- a/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/GenericHelixController.java
@@ -1342,6 +1342,21 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
       return;
     }
     queue.put(event);
+    if (queue == _eventQueue) {
+      updateControllerEventQueueSizeGauge();
+    }
+  }
+
+  /**
+   * Publish the current DEFAULT cluster-event pipeline backlog to the per-cluster monitor. Invoked
+   * on both the enqueue side (ZK-callback / periodic-rebalance threads) and the dequeue side (the
+   * pipeline thread) so the gauge climbs when events pile up faster than they are drained, which
+   * surfaces a controller that still holds leadership but has stopped processing ("zombie leader").
+   */
+  private void updateControllerEventQueueSizeGauge() {
+    if (_isMonitoring && _clusterStatusMonitor != null && _eventQueue != null) {
+      _clusterStatusMonitor.setControllerEventQueueSizeGauge(_eventQueue.size());
+    }
   }
 
   @Override
@@ -1579,6 +1594,9 @@ public class GenericHelixController implements IdealStateChangeListener, LiveIns
       while (!isInterrupted()) {
         try {
           ClusterEvent newClusterEvent = _eventBlockingQueue.take();
+          if (_eventBlockingQueue == _eventQueue) {
+            updateControllerEventQueueSizeGauge();
+          }
           String threadName = String.format(
               "HelixController-pipeline-%s-(%s)", _processorName, newClusterEvent.getEventId());
           this.setName(threadName);

--- a/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ClusterConfig.java
@@ -67,6 +67,9 @@ public class ClusterConfig extends HelixProperty {
     TOP_STATE_HANDOFF_DURATION_THRESHOLD,
     RESOURCE_PRIORITY_FIELD,
     REBALANCE_TIMER_PERIOD,
+    // Time in ms after which a non-empty controller event queue that has not completed a pipeline
+    // run is treated as a wedged ("zombie leader") controller by ControllerPipelineStalledGauge.
+    CONTROLLER_PIPELINE_STALL_THRESHOLD_MS,
     MAX_CONCURRENT_TASK_PER_INSTANCE,
 
     // The following concerns maintenance mode
@@ -238,6 +241,8 @@ public class ClusterConfig extends HelixProperty {
   private final static int DEFAULT_VIEW_CLUSTER_REFRESH_PERIOD = 30;
   private final static long DEFAULT_LAST_ON_DEMAND_REBALANCE_TIMESTAMP = -1L;
   private final static long DEFAULT_TOP_STATE_HANDOFF_DURATION_THRESHOLD = 300000L; // 5 minutes
+  // Default for CONTROLLER_PIPELINE_STALL_THRESHOLD_MS when unset.
+  private final static long DEFAULT_CONTROLLER_PIPELINE_STALL_THRESHOLD_MS = 5000L; // 5 seconds
 
   /**
    * Instantiate for a specific cluster
@@ -831,6 +836,27 @@ public class ClusterConfig extends HelixProperty {
   public long getTopStateHandoffDurationThreshold() {
     return _record.getLongField(ClusterConfigProperty.TOP_STATE_HANDOFF_DURATION_THRESHOLD.name(),
         DEFAULT_TOP_STATE_HANDOFF_DURATION_THRESHOLD);
+  }
+
+  /**
+   * Set the wedged-controller stall threshold: a non-empty controller event queue that has not
+   * completed a pipeline run within this many ms is reported as stalled by
+   * ControllerPipelineStalledGauge.
+   * @param thresholdMs threshold in milliseconds
+   */
+  public void setControllerPipelineStallThresholdMs(long thresholdMs) {
+    _record.setLongField(ClusterConfigProperty.CONTROLLER_PIPELINE_STALL_THRESHOLD_MS.name(),
+        thresholdMs);
+  }
+
+  /**
+   * @return the wedged-controller stall threshold in ms, defaulting to
+   *         {@value #DEFAULT_CONTROLLER_PIPELINE_STALL_THRESHOLD_MS} when unset.
+   */
+  public long getControllerPipelineStallThresholdMs() {
+    return _record.getLongField(
+        ClusterConfigProperty.CONTROLLER_PIPELINE_STALL_THRESHOLD_MS.name(),
+        DEFAULT_CONTROLLER_PIPELINE_STALL_THRESHOLD_MS);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -102,10 +102,13 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   // GenericHelixController. Paired with the queue-size gauge to derive
   // ControllerPipelineStalledGauge. 0 until the first pipeline completes (treated as "no data").
   private AtomicLong _lastPipelineEndTimestamp = new AtomicLong(0L);
-  // A non-empty event queue whose pipeline has not completed within this many ms is treated as a
-  // wedged ("zombie leader") controller. Deliberately short for now; tune against the observed
-  // ClusterEventMonitor TotalProcessed durations.
-  private static final long PIPELINE_STALL_THRESHOLD_MS = 5000L;
+  // Stall threshold (ms): a non-empty event queue whose pipeline has not completed within this many
+  // ms is treated as a wedged ("zombie leader") controller. Sourced from ClusterConfig
+  // (CONTROLLER_PIPELINE_STALL_THRESHOLD_MS) and pushed by GenericHelixController each pipeline run;
+  // uses the default until first reported.
+  private static final long DEFAULT_PIPELINE_STALL_THRESHOLD_MS = 5000L;
+  private AtomicLong _pipelineStallThresholdMs =
+      new AtomicLong(DEFAULT_PIPELINE_STALL_THRESHOLD_MS);
 
   // WAGED per-FailureCategory counters. Populated in the constructor with a zero AtomicLong per
   // enum value so reads on never-incremented categories return 0 instead of NPE.
@@ -1507,6 +1510,17 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     _lastPipelineEndTimestamp.set(timestampMs);
   }
 
+  /**
+   * Set the wedged-controller stall threshold (ms), sourced from ClusterConfig
+   * (CONTROLLER_PIPELINE_STALL_THRESHOLD_MS) by GenericHelixController. Non-positive values are
+   * ignored so a misconfiguration cannot silently disable {@link #getControllerPipelineStalledGauge()}.
+   */
+  public void setPipelineStallThresholdMs(long thresholdMs) {
+    if (thresholdMs > 0) {
+      _pipelineStallThresholdMs.set(thresholdMs);
+    }
+  }
+
   @Override
   public long getRebalanceFailureCounter() {
     return _rebalanceFailureCount.get();
@@ -1536,7 +1550,7 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     // leader"). Computed lazily on read so it stays correct even if the pipeline thread is dead and
     // no setter runs.
     if (_controllerEventQueueSizeGauge.get() > 0 && lastEnd > 0
-        && (System.currentTimeMillis() - lastEnd) > PIPELINE_STALL_THRESHOLD_MS) {
+        && (System.currentTimeMillis() - lastEnd) > _pipelineStallThresholdMs.get()) {
       return 1L;
     }
     return 0L;

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -94,6 +94,10 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   private AtomicLong _rebalanceFailureCount = new AtomicLong(0L);
   private AtomicLong _continuousResourceRebalanceFailureCount = new AtomicLong(0L);
   private AtomicLong _continuousTaskRebalanceFailureCount = new AtomicLong(0L);
+  // DEFAULT controller cluster-event pipeline backlog. Near 0 on a healthy controller (the queue
+  // dedups by event type); climbs when the controller still holds leadership but stops draining
+  // events, surfacing the "zombie leader" failure mode.
+  private AtomicLong _controllerEventQueueSizeGauge = new AtomicLong(0L);
 
   // WAGED per-FailureCategory counters. Populated in the constructor with a zero AtomicLong per
   // enum value so reads on never-incremented categories return 0 instead of NPE.
@@ -1467,6 +1471,16 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     _continuousTaskRebalanceFailureCount.set(newValue);
   }
 
+  /**
+   * Surface the DEFAULT controller cluster-event pipeline backlog as a JMX gauge. A healthy
+   * controller drains events quickly so this stays near 0 (the queue dedups by event type); a
+   * wedged controller that still holds leadership but stops processing lets it climb, making the
+   * "zombie leader" failure mode detectable.
+   */
+  public void setControllerEventQueueSizeGauge(long size) {
+    _controllerEventQueueSizeGauge.set(size);
+  }
+
   @Override
   public long getRebalanceFailureCounter() {
     return _rebalanceFailureCount.get();
@@ -1480,6 +1494,11 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   @Override
   public long getContinuousTaskRebalanceFailureCount() {
     return _continuousTaskRebalanceFailureCount.get();
+  }
+
+  @Override
+  public long getControllerEventQueueSizeGauge() {
+    return _controllerEventQueueSizeGauge.get();
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -922,6 +922,12 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       _wagedInternalFailure = false;
       _wagedBaselineComputeFailing = false;
       _wagedRebalanceOverwriteFailing = false;
+      // Zero the DEFAULT controller-event pipeline backlog gauge on leadership change, for the
+      // same reason as the counters above: the ClusterStatusMonitor instance is reused across
+      // leadership periods, so a stale depth from a prior leader must not be re-reported by the
+      // re-registered bean after re-election (it would otherwise persist until the next
+      // enqueue/dequeue refreshes it).
+      _controllerEventQueueSizeGauge.set(0L);
     } catch (Exception e) {
       LOG.error("Fail to reset ClusterStatusMonitor, cluster: " + _clusterName, e);
     }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -98,6 +98,14 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   // dedups by event type); climbs when the controller still holds leadership but stops draining
   // events, surfacing the "zombie leader" failure mode.
   private AtomicLong _controllerEventQueueSizeGauge = new AtomicLong(0L);
+  // Wall-clock time (ms) of the last completed DEFAULT controller pipeline run, reported by
+  // GenericHelixController. Paired with the queue-size gauge to derive
+  // ControllerPipelineStalledGauge. 0 until the first pipeline completes (treated as "no data").
+  private AtomicLong _lastPipelineEndTimestamp = new AtomicLong(0L);
+  // A non-empty event queue whose pipeline has not completed within this many ms is treated as a
+  // wedged ("zombie leader") controller. Deliberately short for now; tune against the observed
+  // ClusterEventMonitor TotalProcessed durations.
+  private static final long PIPELINE_STALL_THRESHOLD_MS = 5000L;
 
   // WAGED per-FailureCategory counters. Populated in the constructor with a zero AtomicLong per
   // enum value so reads on never-incremented categories return 0 instead of NPE.
@@ -928,6 +936,9 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       // re-registered bean after re-election (it would otherwise persist until the next
       // enqueue/dequeue refreshes it).
       _controllerEventQueueSizeGauge.set(0L);
+      // Reset the pipeline-progress timestamp for the same reason: a stale value from a prior
+      // leadership period must not make the re-registered bean report a spurious stall.
+      _lastPipelineEndTimestamp.set(0L);
     } catch (Exception e) {
       LOG.error("Fail to reset ClusterStatusMonitor, cluster: " + _clusterName, e);
     }
@@ -1487,6 +1498,15 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
     _controllerEventQueueSizeGauge.set(size);
   }
 
+  /**
+   * Report the wall-clock time (ms) of the most recent completed DEFAULT controller pipeline run.
+   * Consumed by {@link #getControllerPipelineStalledGauge()} to tell a wedged controller (queue
+   * not draining) apart from a healthy idle or busy-but-progressing one.
+   */
+  public void setLastPipelineEndTimestamp(long timestampMs) {
+    _lastPipelineEndTimestamp.set(timestampMs);
+  }
+
   @Override
   public long getRebalanceFailureCounter() {
     return _rebalanceFailureCount.get();
@@ -1505,6 +1525,21 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   @Override
   public long getControllerEventQueueSizeGauge() {
     return _controllerEventQueueSizeGauge.get();
+  }
+
+  @Override
+  public long getControllerPipelineStalledGauge() {
+    long lastEnd = _lastPipelineEndTimestamp.get();
+    // 0 = not stalled: either the queue is empty (idle is healthy) or no pipeline has completed yet
+    // (no baseline). 1 = a non-empty queue whose DEFAULT pipeline has not completed within the
+    // stall threshold, i.e. the controller holds events but is not draining them (wedged / "zombie
+    // leader"). Computed lazily on read so it stays correct even if the pipeline thread is dead and
+    // no setter runs.
+    if (_controllerEventQueueSizeGauge.get() > 0 && lastEnd > 0
+        && (System.currentTimeMillis() - lastEnd) > PIPELINE_STALL_THRESHOLD_MS) {
+      return 1L;
+    }
+    return 0L;
   }
 
   @Override

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -101,7 +101,13 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    * Backlog of the DEFAULT controller cluster-event pipeline (events enqueued but not yet
    * processed). Stays near 0 on a healthy controller because the pipeline drains quickly and the
    * queue dedups by event type; climbs when the controller holds leadership but has stopped
-   * processing events ("zombie leader"). Alert on a sustained average above ~0.
+   * processing events ("zombie leader").
+   * <p>
+   * Depth alone is ambiguous: under load a healthy controller also reads &gt; 0 (events queue
+   * behind the in-flight pipeline run), but it keeps draining them, so
+   * {@code ClusterEventStatus...TotalProcessed.EventCounter} advances. A wedged controller instead
+   * shows depth stuck &gt; 0 with that counter flat. The alert threshold and windowing belong in
+   * the alerting layer, not here.
    * @return The current DEFAULT controller event queue size.
    */
   long getControllerEventQueueSizeGauge();

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -112,6 +112,16 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    */
   long getControllerEventQueueSizeGauge();
 
+  /**
+   * Reversible 0/1 wedged-controller ("zombie leader") gauge. 1 when the DEFAULT event queue is
+   * non-empty but no pipeline run has completed within the stall threshold, i.e. the controller
+   * holds events but is not processing them; 0 when idle (empty queue) or actively draining.
+   * Unlike the raw queue size, this is producer-rate-independent and does not false-positive on a
+   * busy-but-progressing controller. Gate EKG/alerts on {@code == 1}.
+   * @return 1 if the controller pipeline appears wedged, otherwise 0.
+   */
+  long getControllerPipelineStalledGauge();
+
   // ---- WAGED failure-category counters (mirror of WagedRebalancerMetricCollector) ----
   // Each WAGED HelixRebalanceException increments exactly one of these. The pair
   // {WagedCustomerActionableFailureCounter, WagedInternalFailureCounter} is the recommended

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitorMBean.java
@@ -97,6 +97,15 @@ public interface ClusterStatusMonitorMBean extends SensorNameProvider {
    */
   long getContinuousTaskRebalanceFailureCount();
 
+  /**
+   * Backlog of the DEFAULT controller cluster-event pipeline (events enqueued but not yet
+   * processed). Stays near 0 on a healthy controller because the pipeline drains quickly and the
+   * queue dedups by event type; climbs when the controller holds leadership but has stopped
+   * processing events ("zombie leader"). Alert on a sustained average above ~0.
+   * @return The current DEFAULT controller event queue size.
+   */
+  long getControllerEventQueueSizeGauge();
+
   // ---- WAGED failure-category counters (mirror of WagedRebalancerMetricCollector) ----
   // Each WAGED HelixRebalanceException increments exactly one of these. The pair
   // {WagedCustomerActionableFailureCounter, WagedInternalFailureCounter} is the recommended

--- a/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
+++ b/helix-core/src/test/java/org/apache/helix/model/TestClusterConfig.java
@@ -49,6 +49,15 @@ public class TestClusterConfig {
   }
 
   @Test
+  public void testControllerPipelineStallThresholdMsDefaultAndRoundTrip() {
+    ClusterConfig testConfig = new ClusterConfig("testId");
+    // Defaults to 5000ms when unset.
+    Assert.assertEquals(testConfig.getControllerPipelineStallThresholdMs(), 5000L);
+    testConfig.setControllerPipelineStallThresholdMs(30000L);
+    Assert.assertEquals(testConfig.getControllerPipelineStallThresholdMs(), 30000L);
+  }
+
+  @Test
   public void testGetCapacityKeysEmpty() {
     ClusterConfig testConfig = new ClusterConfig("testId");
     Assert.assertEquals(testConfig.getInstanceCapacityKeys(), Collections.emptyList());

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -930,6 +930,60 @@ public class TestClusterStatusMonitor {
   }
 
   @Test
+  public void testControllerPipelineStalledGaugeStartsAtZero() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestPipelineStalledStartCluster");
+    // No queue backlog and no pipeline completion reported yet: no baseline, so not stalled.
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 0L);
+  }
+
+  @Test
+  public void testControllerPipelineStalledGaugeZeroWhenQueueEmpty() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestPipelineStalledIdleCluster");
+    // Empty queue but a stale last-completion timestamp: an idle controller is healthy, not wedged.
+    monitor.setControllerEventQueueSizeGauge(0L);
+    monitor.setLastPipelineEndTimestamp(System.currentTimeMillis() - 60000L);
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 0L);
+  }
+
+  @Test
+  public void testControllerPipelineStalledGaugeZeroWhenProgressing() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestPipelineStalledBusyCluster");
+    // Non-empty queue but a pipeline completed just now: busy-but-progressing, not wedged.
+    monitor.setControllerEventQueueSizeGauge(5L);
+    monitor.setLastPipelineEndTimestamp(System.currentTimeMillis());
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 0L);
+  }
+
+  @Test
+  public void testControllerPipelineStalledGaugeZeroWithoutBaseline() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestPipelineStalledNoBaselineCluster");
+    // Non-empty queue but no pipeline completion ever reported (timestamp 0): treated as no data.
+    monitor.setControllerEventQueueSizeGauge(5L);
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 0L);
+  }
+
+  @Test
+  public void testControllerPipelineStalledGaugeOneWhenWedged() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestPipelineStalledWedgedCluster");
+    // Non-empty queue whose pipeline last completed longer ago than the stall threshold (5s):
+    // the controller holds events but is not draining them, i.e. wedged.
+    monitor.setControllerEventQueueSizeGauge(3L);
+    monitor.setLastPipelineEndTimestamp(System.currentTimeMillis() - 6000L);
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 1L);
+  }
+
+  @Test
+  public void testControllerPipelineStalledGaugeResetsToZeroOnLeadershipChange() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestPipelineStalledResetCluster");
+    monitor.setControllerEventQueueSizeGauge(3L);
+    monitor.setLastPipelineEndTimestamp(System.currentTimeMillis() - 6000L);
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 1L);
+    // reset() zeroes the progress timestamp so a re-registered bean does not report a stale stall.
+    monitor.reset();
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 0L);
+  }
+
+  @Test
   public void testWagedHardConstraintCountersStartAtZero() {
     ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedHardConstraintCluster");
     Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneFailureCounter(), 0L);

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -916,6 +916,20 @@ public class TestClusterStatusMonitor {
   }
 
   @Test
+  public void testControllerEventQueueSizeGaugeResetsToZeroOnLeadershipChange() {
+    ClusterStatusMonitor monitor =
+        new ClusterStatusMonitor("TestControllerEventQueueGaugeResetCluster");
+    monitor.setControllerEventQueueSizeGauge(5L);
+    Assert.assertEquals(monitor.getControllerEventQueueSizeGauge(), 5L);
+    // reset() runs on leadership change / monitor teardown. Because the monitor instance is reused
+    // across leadership periods, a backlog left over from a prior leader must be zeroed here;
+    // otherwise the re-registered bean would re-report it after re-election until the next
+    // enqueue/dequeue refreshes the gauge.
+    monitor.reset();
+    Assert.assertEquals(monitor.getControllerEventQueueSizeGauge(), 0L);
+  }
+
+  @Test
   public void testWagedHardConstraintCountersStartAtZero() {
     ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedHardConstraintCluster");
     Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneFailureCounter(), 0L);

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -898,6 +898,24 @@ public class TestClusterStatusMonitor {
   }
 
   @Test
+  public void testControllerEventQueueSizeGaugeStartsAtZero() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestControllerEventQueueGaugeCluster");
+    Assert.assertEquals(monitor.getControllerEventQueueSizeGauge(), 0L);
+  }
+
+  @Test
+  public void testControllerEventQueueSizeGaugeReflectsLatestSetter() {
+    ClusterStatusMonitor monitor =
+        new ClusterStatusMonitor("TestControllerEventQueueGaugeSetterCluster");
+    Assert.assertEquals(monitor.getControllerEventQueueSizeGauge(), 0L);
+    monitor.setControllerEventQueueSizeGauge(7L);
+    Assert.assertEquals(monitor.getControllerEventQueueSizeGauge(), 7L);
+    // Gauge is reversible: draining the pipeline takes it back down to 0.
+    monitor.setControllerEventQueueSizeGauge(0L);
+    Assert.assertEquals(monitor.getControllerEventQueueSizeGauge(), 0L);
+  }
+
+  @Test
   public void testWagedHardConstraintCountersStartAtZero() {
     ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedHardConstraintCluster");
     Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneFailureCounter(), 0L);

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -984,6 +984,22 @@ public class TestClusterStatusMonitor {
   }
 
   @Test
+  public void testControllerPipelineStalledGaugeHonorsConfiguredThreshold() {
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestPipelineStalledThresholdCluster");
+    monitor.setControllerEventQueueSizeGauge(2L);
+    monitor.setLastPipelineEndTimestamp(System.currentTimeMillis() - 6000L); // 6s since last run
+    // With a 10s threshold, a 6s gap is not yet stalled.
+    monitor.setPipelineStallThresholdMs(10000L);
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 0L);
+    // Tightening the threshold to 3s makes the same 6s gap count as stalled.
+    monitor.setPipelineStallThresholdMs(3000L);
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 1L);
+    // A non-positive threshold is ignored (keeps the last valid value), so it stays stalled.
+    monitor.setPipelineStallThresholdMs(0L);
+    Assert.assertEquals(monitor.getControllerPipelineStalledGauge(), 1L);
+  }
+
+  @Test
   public void testWagedHardConstraintCountersStartAtZero() {
     ClusterStatusMonitor monitor = new ClusterStatusMonitor("TestWagedHardConstraintCluster");
     Assert.assertEquals(monitor.getWagedHardConstraintFaultZoneFailureCounter(), 0L);


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes #200

### Description

- [x] Here are some details about my PR:

**What:** Add a new per-cluster controller JMX gauge, `ControllerEventQueueSizeGauge`, on
`ClusterStatusMonitor`, exposing the depth of the DEFAULT cluster-event pipeline queue
(`GenericHelixController._eventQueue`).

**Why:** The controller pipeline is drained by a single `ClusterEventProcessor` thread while
the ZK session is kept alive by a separate ZK-client thread. As a result a wedged controller
can keep leadership and a live ZK session yet stop processing events entirely. None of the
existing controller signals (ZK session expiries, controllership-takeover failures, ZK op
latency, WAGED internal failure) catch this, because the process stays up and remains leader.
This "zombie leader" failure mode is currently invisible to monitoring.

**How:** Expose the DEFAULT cluster-event pipeline backlog as a per-cluster JMX gauge on
`ClusterStatusMonitor`, updated from `GenericHelixController` on both the enqueue side
(ZK-callback / periodic-rebalance threads, in `enqueueEvent` when the target is `_eventQueue`)
and the dequeue side (the pipeline thread, in `ClusterEventProcessor.run()` after `take()` for
the DEFAULT queue). Updates are guarded by `_isMonitoring` and a null check on the monitor.

A healthy controller keeps this near 0: the queue dedups by event type
(`DedupEventBlockingQueue`), so depth saturates at the few distinct pending event types and the
pipeline drains them quickly. A wedged controller lets it climb and stay elevated. EKG / alerts
should therefore gate on a **sustained average above ~0** (not MAX), with a small threshold.

Sensor / attribute exposed: ObjectName `ClusterStatus:cluster={cluster}`, attribute
`ControllerEventQueueSizeGauge`.

Files changed:
- `helix-core/.../monitoring/mbeans/ClusterStatusMonitor.java` - new `AtomicLong` field, setter
  `setControllerEventQueueSizeGauge(long)`, getter `getControllerEventQueueSizeGauge()`.
- `helix-core/.../monitoring/mbeans/ClusterStatusMonitorMBean.java` - getter declared on the MBean
  interface (auto-exports the JMX attribute).
- `helix-core/.../controller/GenericHelixController.java` - `updateControllerEventQueueSizeGauge()`
  helper, invoked at enqueue and dequeue of the DEFAULT `_eventQueue`.

### Tests

- [x] The following tests are written for this issue:

- `TestClusterStatusMonitor#testControllerEventQueueSizeGaugeStartsAtZero`
- `TestClusterStatusMonitor#testControllerEventQueueSizeGaugeReflectsLatestSetter`

- The following is the result of the "mvn test" command on the appropriate module
  (`mvn test -pl helix-core -Dtest=TestClusterStatusMonitor`):

```
[INFO] Running org.apache.helix.monitoring.mbeans.TestClusterStatusMonitor
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.226 s - in org.apache.helix.monitoring.mbeans.TestClusterStatusMonitor
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

### Changes that Break Backward Compatibility (Optional)

- [ ] My PR contains changes that break backward compatibility or previous assumptions for certain methods or API.

No backward-incompatible behavior changes. The only API surface change is **additive**: a new
read-only getter `getControllerEventQueueSizeGauge()` on the `ClusterStatusMonitorMBean` JMX
interface. No existing method signatures are changed or removed, and the sole implementor
(`ClusterStatusMonitor`) is updated in this PR. The new value defaults to 0 until the controller
reports it, so existing consumers and dashboards are unaffected.

### Documentation (Optional)

- [ ] In case of new functionality, my PR adds documentation in the following wiki page:

Not applicable. The change adds a single self-describing JMX gauge (documented via Javadoc on the
MBean interface); no public wiki change is required.

### Commits

- [ ] My commits all reference appropriate Apache Helix GitHub issues in their subject lines.
  In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

> Note: the current commit subject is
> `Add ControllerEventQueueSizeGauge to detect a wedged ("zombie leader") controller`.
> It uses the imperative mood, has a blank line before the body, does not end with a period, and
> the body explains what/why. It does **not** yet reference #200 and exceeds 50 characters. Amend
> to e.g. `Fix #200: add ControllerEventQueueSizeGauge for wedged controllers` before merge if
> strict compliance is required.

### Code Quality

- [x] My diff has been formatted using helix-style.xml
  (helix-style-intellij.xml if IntelliJ IDE is used)
