### PR TITLE
Cache WAGED partition-movement state maps

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/AbstractPartitionMovementConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/AbstractPartitionMovementConstraint.java
@@ -19,14 +19,11 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
  * under the License.
  */
 
-import java.util.Collections;
 import java.util.Map;
 
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
-import org.apache.helix.model.Partition;
-import org.apache.helix.model.ResourceAssignment;
 
 /**
  * Evaluate the proposed assignment according to the potential partition movements cost.
@@ -53,16 +50,6 @@ abstract class AbstractPartitionMovementConstraint extends SoftConstraint {
   @Override
   protected abstract double getAssignmentScore(AssignableNode node, AssignableReplica replica,
       ClusterContext clusterContext);
-
-  protected Map<String, String> getStateMap(AssignableReplica replica,
-      Map<String, ResourceAssignment> assignment) {
-    String resourceName = replica.getResourceName();
-    String partitionName = replica.getPartitionName();
-    if (assignment == null || !assignment.containsKey(resourceName)) {
-      return Collections.emptyMap();
-    }
-    return assignment.get(resourceName).getReplicaMap(new Partition(partitionName));
-  }
 
   protected double calculateAssignmentScore(String logicalId, String state,
       Map<String, String> instanceToStateMap) {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/BaselineInfluenceConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/BaselineInfluenceConstraint.java
@@ -36,14 +36,14 @@ public class BaselineInfluenceConstraint extends AbstractPartitionMovementConstr
   @Override
   protected double getAssignmentScore(AssignableNode node, AssignableReplica replica,
       ClusterContext clusterContext) {
-    Map<String, String> bestPossibleAssignment =
-        getStateMap(replica, clusterContext.getBestPossibleAssignment());
+    Map<String, String> bestPossibleAssignment = clusterContext
+        .getBestPossibleAssignmentStateMap(replica.getResourceName(), replica.getPartitionName());
     if (bestPossibleAssignment.isEmpty()) {
       return getMinScore();
     }
 
-    Map<String, String> baselineAssignment =
-        getStateMap(replica, clusterContext.getBaselineAssignment());
+    Map<String, String> baselineAssignment = clusterContext
+        .getBaselineAssignmentStateMap(replica.getResourceName(), replica.getPartitionName());
     return calculateAssignmentScore(node.getLogicalId(), replica.getReplicaState(),
         baselineAssignment);
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/PartitionMovementConstraint.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/constraints/PartitionMovementConstraint.java
@@ -36,10 +36,10 @@ public class PartitionMovementConstraint extends AbstractPartitionMovementConstr
   @Override
   protected double getAssignmentScore(AssignableNode node, AssignableReplica replica,
       ClusterContext clusterContext) {
-    Map<String, String> bestPossibleAssignment =
-        getStateMap(replica, clusterContext.getBestPossibleAssignment());
-    Map<String, String> baselineAssignment =
-        getStateMap(replica, clusterContext.getBaselineAssignment());
+    Map<String, String> bestPossibleAssignment = clusterContext
+        .getBestPossibleAssignmentStateMap(replica.getResourceName(), replica.getPartitionName());
+    Map<String, String> baselineAssignment = clusterContext
+        .getBaselineAssignmentStateMap(replica.getResourceName(), replica.getPartitionName());
     String logicalId = node.getLogicalId();
     String state = replica.getReplicaState();
 

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -26,11 +26,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.apache.helix.HelixException;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.Partition;
 import org.apache.helix.model.ResourceAssignment;
 import org.apache.helix.model.ResourceConfig;
 import org.slf4j.Logger;
@@ -60,6 +62,14 @@ public class ClusterContext {
   private final Map<String, ResourceAssignment> _baselineAssignment;
   // <ResourceName, ResourceAssignment contains the best possible assignment>
   private final Map<String, ResourceAssignment> _bestPossibleAssignment;
+  // Memoized per-(resource, partition) instance->state views derived from the immutable baseline
+  // and best possible assignments above. These lookups are invariant for the whole rebalance run,
+  // so caching them avoids recomputing the same map (and allocating a throwaway Partition key) for
+  // every candidate node while scoring a replica. Keyed: resourceName -> partitionName -> map.
+  private final Map<String, Map<String, Map<String, String>>> _baselineAssignmentStateMapCache =
+      new ConcurrentHashMap<>();
+  private final Map<String, Map<String, Map<String, String>>> _bestPossibleAssignmentStateMapCache =
+      new ConcurrentHashMap<>();
   // Estimate remaining capacity after assignment. Used to compute score when sorting replicas.
   private final Map<String, Long> _estimateUtilizationMap;
   // Cluster total capacity. Used to compute score when sorting replicas.
@@ -160,6 +170,46 @@ public class ClusterContext {
   public Map<String, ResourceAssignment> getBestPossibleAssignment() {
     return _bestPossibleAssignment == null || _bestPossibleAssignment.isEmpty() ? Collections.emptyMap()
         : _bestPossibleAssignment;
+  }
+
+  /**
+   * Returns the (instanceName -&gt; state) map for the given partition from the baseline assignment.
+   * The result is memoized for the lifetime of this {@link ClusterContext} because the baseline
+   * assignment does not change during a rebalance run. This lets partition-movement soft
+   * constraints avoid recomputing the same lookup once per candidate node.
+   * @return the instance-to-state map, or {@link Collections#emptyMap()} if the resource or
+   *         partition is absent from the baseline assignment.
+   */
+  public Map<String, String> getBaselineAssignmentStateMap(String resourceName,
+      String partitionName) {
+    return getCachedAssignmentStateMap(_baselineAssignmentStateMapCache, getBaselineAssignment(),
+        resourceName, partitionName);
+  }
+
+  /**
+   * Returns the (instanceName -&gt; state) map for the given partition from the best possible
+   * assignment. The result is memoized for the lifetime of this {@link ClusterContext} because the
+   * best possible assignment does not change during a rebalance run. This lets partition-movement
+   * soft constraints avoid recomputing the same lookup once per candidate node.
+   * @return the instance-to-state map, or {@link Collections#emptyMap()} if the resource or
+   *         partition is absent from the best possible assignment.
+   */
+  public Map<String, String> getBestPossibleAssignmentStateMap(String resourceName,
+      String partitionName) {
+    return getCachedAssignmentStateMap(_bestPossibleAssignmentStateMapCache,
+        getBestPossibleAssignment(), resourceName, partitionName);
+  }
+
+  private static Map<String, String> getCachedAssignmentStateMap(
+      Map<String, Map<String, Map<String, String>>> cache,
+      Map<String, ResourceAssignment> assignment, String resourceName, String partitionName) {
+    ResourceAssignment resourceAssignment = assignment.get(resourceName);
+    if (resourceAssignment == null) {
+      return Collections.emptyMap();
+    }
+    return cache.computeIfAbsent(resourceName, key -> new ConcurrentHashMap<>())
+        .computeIfAbsent(partitionName,
+            key -> resourceAssignment.getReplicaMap(new Partition(key)));
   }
 
   public Map<String, Map<String, Set<String>>> getAssignmentForFaultZoneMap() {

--- a/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/rebalancer/waged/model/ClusterContext.java
@@ -62,10 +62,10 @@ public class ClusterContext {
   private final Map<String, ResourceAssignment> _baselineAssignment;
   // <ResourceName, ResourceAssignment contains the best possible assignment>
   private final Map<String, ResourceAssignment> _bestPossibleAssignment;
-  // Memoized per-(resource, partition) instance->state views derived from the immutable baseline
-  // and best possible assignments above. These lookups are invariant for the whole rebalance run,
-  // so caching them avoids recomputing the same map (and allocating a throwaway Partition key) for
-  // every candidate node while scoring a replica. Keyed: resourceName -> partitionName -> map.
+  // Memoized per-(resource, partition) instance->state views derived from the immutable
+  // _baselineAssignment and _bestPossibleAssignment fields. These lookups are invariant for the
+  // whole rebalance run, so caching them avoids recomputing the same map (and allocating a throwaway
+  // Partition key) for every candidate node while scoring a replica. Keyed: resource -> partition -> map.
   private final Map<String, Map<String, Map<String, String>>> _baselineAssignmentStateMapCache =
       new ConcurrentHashMap<>();
   private final Map<String, Map<String, Map<String, String>>> _bestPossibleAssignmentStateMapCache =
@@ -173,12 +173,12 @@ public class ClusterContext {
   }
 
   /**
-   * Returns the (instanceName -&gt; state) map for the given partition from the baseline assignment.
+   * Returns the (instanceName -> state) map for the given partition from the baseline assignment.
    * The result is memoized for the lifetime of this {@link ClusterContext} because the baseline
    * assignment does not change during a rebalance run. This lets partition-movement soft
    * constraints avoid recomputing the same lookup once per candidate node.
-   * @return the instance-to-state map, or {@link Collections#emptyMap()} if the resource or
-   *         partition is absent from the baseline assignment.
+   * @return an unmodifiable instance-to-state map, or {@link Collections#emptyMap()} if the resource
+   *         or partition is absent from the baseline assignment.
    */
   public Map<String, String> getBaselineAssignmentStateMap(String resourceName,
       String partitionName) {
@@ -187,12 +187,12 @@ public class ClusterContext {
   }
 
   /**
-   * Returns the (instanceName -&gt; state) map for the given partition from the best possible
+   * Returns the (instanceName -> state) map for the given partition from the best possible
    * assignment. The result is memoized for the lifetime of this {@link ClusterContext} because the
    * best possible assignment does not change during a rebalance run. This lets partition-movement
    * soft constraints avoid recomputing the same lookup once per candidate node.
-   * @return the instance-to-state map, or {@link Collections#emptyMap()} if the resource or
-   *         partition is absent from the best possible assignment.
+   * @return an unmodifiable instance-to-state map, or {@link Collections#emptyMap()} if the resource
+   *         or partition is absent from the best possible assignment.
    */
   public Map<String, String> getBestPossibleAssignmentStateMap(String resourceName,
       String partitionName) {
@@ -207,9 +207,10 @@ public class ClusterContext {
     if (resourceAssignment == null) {
       return Collections.emptyMap();
     }
-    return cache.computeIfAbsent(resourceName, key -> new ConcurrentHashMap<>())
-        .computeIfAbsent(partitionName,
-            key -> resourceAssignment.getReplicaMap(new Partition(key)));
+    return Collections.unmodifiableMap(
+        cache.computeIfAbsent(resourceName, key -> new ConcurrentHashMap<>())
+            .computeIfAbsent(partitionName,
+                key -> resourceAssignment.getReplicaMap(new Partition(key))));
   }
 
   public Map<String, Map<String, Set<String>>> getAssignmentForFaultZoneMap() {

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestPartitionMovementConstraint.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/constraints/TestPartitionMovementConstraint.java
@@ -20,14 +20,11 @@ package org.apache.helix.controller.rebalancer.waged.constraints;
  */
 
 import java.util.Collections;
-import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableNode;
 import org.apache.helix.controller.rebalancer.waged.model.AssignableReplica;
 import org.apache.helix.controller.rebalancer.waged.model.ClusterContext;
-import org.apache.helix.model.Partition;
-import org.apache.helix.model.ResourceAssignment;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -58,8 +55,10 @@ public class TestPartitionMovementConstraint {
 
   @Test
   public void testGetAssignmentScoreWhenBestPossibleBaselineMissing() {
-    when(_clusterContext.getBaselineAssignment()).thenReturn(Collections.emptyMap());
-    when(_clusterContext.getBestPossibleAssignment()).thenReturn(Collections.emptyMap());
+    when(_clusterContext.getBaselineAssignmentStateMap(RESOURCE, PARTITION))
+        .thenReturn(Collections.emptyMap());
+    when(_clusterContext.getBestPossibleAssignmentStateMap(RESOURCE, PARTITION))
+        .thenReturn(Collections.emptyMap());
 
     verifyScore(_baselineInfluenceConstraint, _testNode, _testReplica, _clusterContext, 0.0, 0.0);
     verifyScore(_partitionMovementConstraint, _testNode, _testReplica, _clusterContext, 0.0, 0.0);
@@ -67,13 +66,10 @@ public class TestPartitionMovementConstraint {
 
   @Test
   public void testGetAssignmentScoreWhenBestPossibleMissing() {
-    ResourceAssignment mockResourceAssignment = mock(ResourceAssignment.class);
-    when(mockResourceAssignment.getReplicaMap(new Partition(PARTITION)))
+    when(_clusterContext.getBaselineAssignmentStateMap(RESOURCE, PARTITION))
         .thenReturn(ImmutableMap.of(INSTANCE, "Master"));
-    Map<String, ResourceAssignment> assignmentMap =
-        ImmutableMap.of(RESOURCE, mockResourceAssignment);
-    when(_clusterContext.getBaselineAssignment()).thenReturn(assignmentMap);
-    when(_clusterContext.getBestPossibleAssignment()).thenReturn(Collections.emptyMap());
+    when(_clusterContext.getBestPossibleAssignmentStateMap(RESOURCE, PARTITION))
+        .thenReturn(Collections.emptyMap());
     // when the calculated states are both equal to the replica's current state
     when(_testReplica.getReplicaState()).thenReturn("Master");
     verifyScore(_baselineInfluenceConstraint, _testNode, _testReplica, _clusterContext, 0.0, 0.0);
@@ -92,16 +88,10 @@ public class TestPartitionMovementConstraint {
     String instanceNameC = INSTANCE + "C";
     AssignableNode testAssignableNode = mock(AssignableNode.class);
 
-    ResourceAssignment bestPossibleResourceAssignment = mock(ResourceAssignment.class);
-    when(bestPossibleResourceAssignment.getReplicaMap(new Partition(PARTITION)))
+    when(_clusterContext.getBestPossibleAssignmentStateMap(RESOURCE, PARTITION))
         .thenReturn(ImmutableMap.of(instanceNameA, "Master", instanceNameB, "Slave"));
-    when(_clusterContext.getBestPossibleAssignment())
-        .thenReturn(ImmutableMap.of(RESOURCE, bestPossibleResourceAssignment));
-    ResourceAssignment baselineResourceAssignment = mock(ResourceAssignment.class);
-    when(baselineResourceAssignment.getReplicaMap(new Partition(PARTITION)))
+    when(_clusterContext.getBaselineAssignmentStateMap(RESOURCE, PARTITION))
         .thenReturn(ImmutableMap.of(instanceNameA, "Slave", instanceNameC, "Master"));
-    when(_clusterContext.getBaselineAssignment())
-        .thenReturn(ImmutableMap.of(RESOURCE, baselineResourceAssignment));
 
     // when the replica's state matches with best possible, allocation matches with baseline
     when(testAssignableNode.getInstanceName()).thenReturn(instanceNameA);

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterContext.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterContext.java
@@ -31,10 +31,17 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.helix.HelixException;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.model.ClusterConfig;
+import org.apache.helix.model.Partition;
+import org.apache.helix.model.ResourceAssignment;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestClusterContext extends AbstractTestClusterModel {
   @BeforeClass
@@ -84,6 +91,68 @@ public class TestClusterContext extends AbstractTestClusterModel {
         _partitionNames.get(0)));
 
     Assert.assertEquals(context.getAssignmentForFaultZoneMap(), expectedFaultZoneMap);
+  }
+
+  @Test
+  public void testAssignmentStateMapLookup() throws IOException {
+    ResourceControllerDataProvider testCache = setupClusterDataCache();
+    Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
+
+    String resourceName = _resourceNames.get(0);
+    String partitionName = _partitionNames.get(0);
+    Map<String, String> bestPossibleStateMap = ImmutableMap.of("instance0", "MASTER");
+    Map<String, String> baselineStateMap = ImmutableMap.of("instance1", "SLAVE");
+
+    ResourceAssignment bestPossibleAssignment = new ResourceAssignment(resourceName);
+    bestPossibleAssignment.addReplicaMap(new Partition(partitionName), bestPossibleStateMap);
+    ResourceAssignment baselineAssignment = new ResourceAssignment(resourceName);
+    baselineAssignment.addReplicaMap(new Partition(partitionName), baselineStateMap);
+
+    // Constructor arg order is (replicas, nodes, baseline, bestPossible).
+    ClusterContext context = new ClusterContext(assignmentSet, generateNodes(testCache),
+        ImmutableMap.of(resourceName, baselineAssignment),
+        ImmutableMap.of(resourceName, bestPossibleAssignment));
+
+    // A present partition returns the stored instance->state map for each assignment.
+    Assert.assertEquals(context.getBestPossibleAssignmentStateMap(resourceName, partitionName),
+        bestPossibleStateMap);
+    Assert.assertEquals(context.getBaselineAssignmentStateMap(resourceName, partitionName),
+        baselineStateMap);
+
+    // A missing resource or missing partition returns an empty map (never null).
+    Assert.assertEquals(
+        context.getBestPossibleAssignmentStateMap("NonExistentResource", partitionName),
+        Collections.emptyMap());
+    Assert.assertEquals(
+        context.getBestPossibleAssignmentStateMap(resourceName, "NonExistentPartition"),
+        Collections.emptyMap());
+    // An empty baseline assignment also returns an empty map.
+    Assert.assertEquals(context.getBaselineAssignmentStateMap("NonExistentResource", partitionName),
+        Collections.emptyMap());
+  }
+
+  @Test
+  public void testAssignmentStateMapMemoization() throws IOException {
+    ResourceControllerDataProvider testCache = setupClusterDataCache();
+    Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
+
+    String resourceName = _resourceNames.get(0);
+    String partitionName = _partitionNames.get(0);
+    Map<String, String> stateMap = ImmutableMap.of("instance0", "MASTER");
+
+    // Mock ResourceAssignment so we can count how many times the underlying lookup is performed.
+    ResourceAssignment bestPossibleAssignment = mock(ResourceAssignment.class);
+    when(bestPossibleAssignment.getReplicaMap(new Partition(partitionName))).thenReturn(stateMap);
+
+    ClusterContext context = new ClusterContext(assignmentSet, generateNodes(testCache),
+        new HashMap<>(), ImmutableMap.of(resourceName, bestPossibleAssignment));
+
+    // Repeated lookups for the same partition must resolve the underlying map only once.
+    for (int i = 0; i < 5; i++) {
+      Assert.assertEquals(context.getBestPossibleAssignmentStateMap(resourceName, partitionName),
+          stateMap);
+    }
+    verify(bestPossibleAssignment, times(1)).getReplicaMap(new Partition(partitionName));
   }
 
   @Test(expectedExceptions = HelixException.class, expectedExceptionsMessageRegExp = "Resource Resource1 already has a replica from partition Partition1 in fault zone testZone")

--- a/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterContext.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/rebalancer/waged/model/TestClusterContext.java
@@ -20,11 +20,19 @@ package org.apache.helix.controller.rebalancer.waged.model;
  */
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
@@ -152,6 +160,54 @@ public class TestClusterContext extends AbstractTestClusterModel {
       Assert.assertEquals(context.getBestPossibleAssignmentStateMap(resourceName, partitionName),
           stateMap);
     }
+    verify(bestPossibleAssignment, times(1)).getReplicaMap(new Partition(partitionName));
+  }
+
+  @Test
+  public void testAssignmentStateMapConcurrentMemoization()
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    ResourceControllerDataProvider testCache = setupClusterDataCache();
+    Set<AssignableReplica> assignmentSet = generateReplicas(testCache);
+
+    String resourceName = _resourceNames.get(0);
+    String partitionName = _partitionNames.get(0);
+    Map<String, String> stateMap = ImmutableMap.of("instance0", "MASTER");
+
+    // Mock ResourceAssignment so we can count how many times the underlying lookup is performed.
+    ResourceAssignment bestPossibleAssignment = mock(ResourceAssignment.class);
+    when(bestPossibleAssignment.getReplicaMap(new Partition(partitionName))).thenReturn(stateMap);
+
+    ClusterContext context = new ClusterContext(assignmentSet, generateNodes(testCache),
+        new HashMap<>(), ImmutableMap.of(resourceName, bestPossibleAssignment));
+
+    // Many threads race to resolve the SAME (resource, partition) key at once, mirroring how
+    // ConstraintBasedAlgorithm scores a single replica across all candidate nodes via parallelStream.
+    // The ConcurrentHashMap-backed cache must still resolve the underlying map exactly once; a plain
+    // HashMap here would be unsafe and could invoke the lookup more than once. The single-threaded
+    // loop in testAssignmentStateMapMemoization would pass even without thread safety, so this test
+    // specifically guards the concurrent-access invariant.
+    int threadCount = 16;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    List<Future<Map<String, String>>> results = new ArrayList<>();
+    try {
+      for (int i = 0; i < threadCount; i++) {
+        results.add(executor.submit(() -> {
+          // Block until released so all threads hit the cache key simultaneously.
+          startLatch.await();
+          return context.getBestPossibleAssignmentStateMap(resourceName, partitionName);
+        }));
+      }
+      // Release all threads at once to maximize contention on the same cache key.
+      startLatch.countDown();
+      for (Future<Map<String, String>> result : results) {
+        Assert.assertEquals(result.get(30, TimeUnit.SECONDS), stateMap);
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+
+    // Despite concurrent access to the same key, the underlying lookup must run exactly once.
     verify(bestPossibleAssignment, times(1)).getReplicaMap(new Partition(partitionName));
   }
 


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

No dedicated GitHub issue was filed; this is a self-contained performance optimization in the WAGED rebalancer's scoring hot path. Happy to open a tracking issue if maintainers prefer.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Memoize the per-(resource, partition) instance-to-state map lookups used by the WAGED partition-movement soft constraints, caching them on `ClusterContext`.

**Why:** While scoring a replica, `ConstraintBasedAlgorithm` evaluates every candidate node in a `parallelStream`. For each node, `PartitionMovementConstraint` and `BaselineInfluenceConstraint` called `getStateMap(replica, ...)`, which looked up the baseline and best-possible `ResourceAssignment` for the replica's (resource, partition). That result is independent of the candidate node, so the identical map was recomputed once per node — and each call allocated a throwaway `new Partition(partitionName)` key. For a cluster with N assignable nodes this repeated the same work N times per replica per constraint.

**How:** `ClusterContext` already owns the immutable baseline and best-possible assignments for the whole rebalance run. It now exposes `getBaselineAssignmentStateMap(resource, partition)` and `getBestPossibleAssignmentStateMap(resource, partition)`, backed by `ConcurrentHashMap` caches (safe under the parallel scoring stream), so each map is resolved exactly once and reused across all nodes. The two movement constraints read these accessors, and the now-unused `getStateMap` helper is removed from `AbstractPartitionMovementConstraint`. Behavior is unchanged: absent resources/partitions still return `Collections.emptyMap()`.

### Tests

- [x] The following tests are written for this issue:

  - `TestClusterContext#testAssignmentStateMapLookup` — verifies the new accessors return the correct instance-to-state map, and an empty map for a missing resource / missing partition / empty assignment.
  - `TestClusterContext#testAssignmentStateMapMemoization` — verifies a partition's underlying `getReplicaMap` is resolved only once across repeated lookups (proving memoization).
  - `TestPartitionMovementConstraint` — updated to stub the new cached accessors; existing assertions and expected scores are unchanged.

- [x] Local code review completed

- The following is the result of the "mvn test" command on the appropriate module:

  Maven is not available in my local environment, so `mvn test` was not run locally; relying on the project CI to execute the `helix-core` test suite. The change is confined to `helix-core` and is covered by the unit tests listed above.

### Changes that Break Backward Compatibility (Optional)

None. `getStateMap` was a package-private helper on the package-private abstract class `AbstractPartitionMovementConstraint` with no external callers; the new `ClusterContext` accessors are purely additive. No public API or behavior changes.

### Documentation (Optional)

Not applicable — internal performance optimization with no new user-facing functionality.

### Commits

- [x] My commit uses an imperative subject separated from the body by a blank line, wrapped at 72 columns, and explains what and why rather than how.

### Code Quality

- [x] The diff follows the existing Helix formatting conventions in the touched files.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
