### PR TITLE
Update CODEOWNERS: remove @proud-parselmouth, add @sjainit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default reviewers for all PRs.
 # At least one approval from a code owner is required before merging.
 # GitHub will automatically exclude the PR author from the reviewer list.
-* @kabragaurav @thestreak101 @ngngwr @proud-parselmouth @laxman-ch @LZD-PratyushBhatt @PranaviAncha @arkmish
+* @kabragaurav @thestreak101 @ngngwr @laxman-ch @LZD-PratyushBhatt @PranaviAncha @arkmish @sjainit


### PR DESCRIPTION
Removes @proud-parselmouth and adds @sjainit as a default code owner/reviewer in `.github/CODEOWNERS`.