### PR TITLE
Batch instance-config reads in helix-rest stoppable/instances paths

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/clusterMaintenanceService/StoppableInstancesSelector.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.helix.PropertyKey;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.InstanceConfig;
@@ -300,10 +299,15 @@ public class StoppableInstancesSelector {
   private Set<String> findToBeStoppedInstances(List<String> toBeStoppedInstances) {
     Set<String> toBeStoppedInstancesSet = new HashSet<>(toBeStoppedInstances);
     Set<String> allInstances = _clusterTopology.getAllInstances();
+    // Batch-read all instance configs in a single ZK call instead of one getProperty per instance.
+    Map<String, InstanceConfig> instanceConfigMap =
+        _dataAccessor.getChildValuesMap(_dataAccessor.keyBuilder().instanceConfigs(), true);
     for (String instance : allInstances) {
-      PropertyKey.Builder propertyKeyBuilder = _dataAccessor.keyBuilder();
-      InstanceConfig instanceConfig =
-          _dataAccessor.getProperty(propertyKeyBuilder.instanceConfig(instance));
+      InstanceConfig instanceConfig = instanceConfigMap.get(instance);
+      if (instanceConfig == null) {
+        // Instance is in the topology but has no config (e.g. removed concurrently); skip it.
+        continue;
+      }
       InstanceConstants.InstanceOperation operation = instanceConfig.getInstanceOperation().getOperation();
       if (operation == InstanceConstants.InstanceOperation.EVACUATE
           || operation == InstanceConstants.InstanceOperation.SWAP_IN

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -133,11 +133,14 @@ public class InstancesAccessor extends AbstractHelixResource {
       ArrayNode unknownNode = root.putArray(InstancesAccessor.InstancesProperties.unknown.name());
 
       List<String> liveInstances = accessor.getChildNames(accessor.keyBuilder().liveInstances());
+      // Batch-read all instance configs in a single ZK call, keyed by instance name, instead of
+      // issuing one getProperty per instance below.
+      Map<String, InstanceConfig> instanceConfigMap =
+          accessor.getChildValuesMap(accessor.keyBuilder().instanceConfigs(), true);
 
       // Categorize each instance by its operation state
       for (String instanceName : instances) {
-        InstanceConfig instanceConfig =
-            accessor.getProperty(accessor.keyBuilder().instanceConfig(instanceName));
+        InstanceConfig instanceConfig = instanceConfigMap.get(instanceName);
         if (instanceConfig != null) {
           // Get the instance operation
           InstanceConfig.InstanceOperation instanceOperation = instanceConfig.getInstanceOperation();

--- a/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestStoppableInstancesSelector.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/clusterMaintenanceService/TestStoppableInstancesSelector.java
@@ -1,0 +1,118 @@
+package org.apache.helix.rest.clusterMaintenanceService;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.PropertyKey;
+import org.apache.helix.constants.InstanceConstants;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.rest.server.json.cluster.ClusterTopology;
+import org.mockito.ArgumentCaptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestStoppableInstancesSelector {
+  private static final String TEST_CLUSTER = "TestCluster";
+
+  /**
+   * findToBeStoppedInstances should read every instance config in a single batched
+   * getChildValuesMap call (not one getProperty per instance), flag instances whose operation is
+   * EVACUATE/SWAP_IN/UNKNOWN, and skip an instance that is present in the topology but missing an
+   * InstanceConfig without throwing (previously an unguarded getInstanceOperation() would NPE).
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testFindToBeStoppedInstancesBatchesReadsAndSkipsMissingConfig() throws IOException {
+    // Topology contains an instance ("instance_no_config") that has no InstanceConfig on purpose.
+    Set<String> allInstances = new HashSet<>(Arrays.asList("instance_evacuate", "instance_swap_in",
+        "instance_unknown", "instance_enable", "instance_no_config"));
+    ClusterTopology clusterTopology = mock(ClusterTopology.class);
+    when(clusterTopology.getAllInstances()).thenReturn(allInstances);
+
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+    instanceConfigMap.put("instance_evacuate",
+        instanceConfig("instance_evacuate", InstanceConstants.InstanceOperation.EVACUATE));
+    instanceConfigMap.put("instance_swap_in",
+        instanceConfig("instance_swap_in", InstanceConstants.InstanceOperation.SWAP_IN));
+    instanceConfigMap.put("instance_unknown",
+        instanceConfig("instance_unknown", InstanceConstants.InstanceOperation.UNKNOWN));
+    instanceConfigMap.put("instance_enable",
+        instanceConfig("instance_enable", InstanceConstants.InstanceOperation.ENABLE));
+    // "instance_no_config" deliberately absent from the config map.
+
+    ZKHelixDataAccessor dataAccessor = mock(ZKHelixDataAccessor.class);
+    when(dataAccessor.keyBuilder()).thenReturn(new PropertyKey.Builder(TEST_CLUSTER));
+    when(dataAccessor.<InstanceConfig>getChildValuesMap(any(PropertyKey.class), anyBoolean()))
+        .thenReturn(instanceConfigMap);
+
+    // Capture the toBeStoppedInstances set that findToBeStoppedInstances produces and forwards to
+    // the stoppable-check call. An empty instance list keeps the check itself a no-op.
+    MaintenanceManagementService maintenanceService = mock(MaintenanceManagementService.class);
+    ArgumentCaptor<Set<String>> toBeStoppedCaptor = ArgumentCaptor.forClass(Set.class);
+    when(maintenanceService.batchGetInstancesStoppableChecks(anyString(), anyList(),
+        nullable(String.class), toBeStoppedCaptor.capture(), anyBoolean()))
+        .thenReturn(Collections.emptyMap());
+
+    StoppableInstancesSelector selector =
+        new StoppableInstancesSelector.StoppableInstancesSelectorBuilder().setClusterId(TEST_CLUSTER)
+            .setClusterTopology(clusterTopology).setDataAccessor(dataAccessor)
+            .setMaintenanceService(maintenanceService).setIncludeDetails(false).build();
+
+    // A pre-existing presumed-stopped instance is passed through and must be retained.
+    selector.getStoppableInstancesNonZoneBased(Collections.emptyList(),
+        Collections.singletonList("instance_preexisting"));
+
+    Set<String> capturedToBeStopped = toBeStoppedCaptor.getValue();
+    Assert.assertEquals(capturedToBeStopped, new HashSet<>(Arrays.asList("instance_preexisting",
+        "instance_evacuate", "instance_swap_in", "instance_unknown")));
+    // ENABLE instance is not flagged; the config-less instance is skipped without throwing.
+    Assert.assertFalse(capturedToBeStopped.contains("instance_enable"));
+    Assert.assertFalse(capturedToBeStopped.contains("instance_no_config"));
+
+    // Configs are read via a single batched call rather than one getProperty per instance.
+    verify(dataAccessor).getChildValuesMap(any(PropertyKey.class), anyBoolean());
+    verify(dataAccessor, never()).getProperty(any(PropertyKey.class));
+  }
+
+  private static InstanceConfig instanceConfig(String instanceName,
+      InstanceConstants.InstanceOperation operation) {
+    InstanceConfig instanceConfig = new InstanceConfig(instanceName);
+    instanceConfig.setInstanceOperation(operation);
+    return instanceConfig;
+  }
+}


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

No dedicated GitHub issue was filed; this is a self-contained performance/robustness improvement in helix-rest. Happy to open a tracking issue if maintainers prefer.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Batch the per-instance `InstanceConfig` reads on two helix-rest read paths into a single accessor call, and guard a latent NPE.

**Why:** `InstancesAccessor.getAllInstances` (backing `GET /clusters/{cluster}/instances`) and `StoppableInstancesSelector.findToBeStoppedInstances` (part of the stoppable-instances check) each looped over every instance and issued `accessor.getProperty(keyBuilder().instanceConfig(name))` — one **serial, synchronous** ZooKeeper read per instance, so wall-clock latency grows linearly with cluster size (~N × RTT).

**How:** Both sites now read all instance configs up front with a single `accessor.getChildValuesMap(keyBuilder().instanceConfigs(), true)` and look each instance up in the returned `Map<String, InstanceConfig>`.

Under the hood ZooKeeper has no "children-with-data" primitive, so `getChildValuesMap` still reads every child — but as **1 synchronous `getChildren` (names) + N asynchronous, pipelined `getData` joined once** (`ZkBaseDataAccessor.get(paths, …)` dispatches all reads via `asyncGetData` and then waits). The number of ZK operations is therefore unchanged; the win is that N serial blocking reads become N in-flight-at-once reads, collapsing wall-clock latency from ~N × RTT to ~1 RTT, plus a single accessor call instead of N+1. This mirrors the existing pattern in `ResourceAssignmentOptimizerAccessor`.

The batched map is a request-scoped local, GC-eligible as soon as the loop ends. Instance (node) counts are modest and each `InstanceConfig` is small, so the transient O(N) footprint is negligible; the reads are also the same non-atomic snapshot as before (N independent `getData`, not a `multi`), so there is no consistency change.

**Latent NPE fix:** `findToBeStoppedInstances` previously called `instanceConfig.getInstanceOperation()` with no null check. An instance present in `ClusterTopology` but missing an `InstanceConfig` znode (e.g. removed concurrently) would NPE; it is now skipped. (`InstancesAccessor` already had this null guard, so its behavior is unchanged.)

### Tests

- [x] The following tests are written for this issue:

  - `TestStoppableInstancesSelector#testFindToBeStoppedInstancesBatchesReadsAndSkipsMissingConfig` — asserts configs are read via a single batched `getChildValuesMap` (and `getProperty` is never called), that EVACUATE/SWAP_IN/UNKNOWN instances are flagged while ENABLE is not, and that an instance present in the topology but missing an `InstanceConfig` is skipped without throwing.

  Existing integration tests already cover the happy path on both sites and act as regression coverage: `TestInstancesAccessor#testGetAllInstancesWithOperationStates` (site 1) and `TestInstancesAccessor#testInstanceStoppableCrossZoneBasedWithEvacuatingInstances` (site 2).

- The following is the result of the "mvn test" command on the appropriate module:

  Maven is not available in my local environment, so `mvn test` was not run locally; relying on project CI to execute the `helix-rest` test suite. The change is confined to `helix-rest`.

### Changes that Break Backward Compatibility (Optional)

None. Both paths process the same instances and make the same operation-based decisions as before. The only behavioral delta is that a config-less instance in `findToBeStoppedInstances` is now skipped instead of throwing an NPE. No public API changes.

### Documentation (Optional)

Not applicable — internal performance/robustness improvement with no new user-facing functionality.

### Commits

- [x] My commit uses an imperative subject separated from the body by a blank line, wraps the body at 72 columns, and explains what and why rather than how.

### Code Quality

- [x] The diff follows the existing Helix formatting conventions in the touched files.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
