### PR TITLE
Widen flaky poll timeouts in maintenance, STT, and instance-op integration tests

### DIFF
--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
@@ -21,6 +21,7 @@ package org.apache.helix.integration.controller;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -204,7 +205,8 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
     for (int i = 0; i < 3; i++) {
       _participants[i].syncStop();
     }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == 0, 2000L);
+    Assert.assertTrue(TestHelper.verify(
+        () -> _dataAccessor.getProperty(_keyBuilder.maintenance()) != null, TestHelper.WAIT_DURATION));
 
     // Check that the cluster is in maintenance
     MaintenanceSignal maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
@@ -216,7 +218,8 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
       _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
       _participants[i].syncStart();
     }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == 3, 2000L);
+    Assert.assertTrue(TestHelper.verify(
+        () -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, TestHelper.WAIT_DURATION));
 
     // Check that the cluster is no longer in maintenance (auto-recovered)
     maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
@@ -233,7 +236,11 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
     for (int i = 0; i < 2; i++) {
       _participants[i].syncStop();
     }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == 0, 2000L);
+    Assert.assertTrue(TestHelper.verify(() -> {
+      List<String> liveInstances = _dataAccessor.getChildNames(_keyBuilder.liveInstances());
+      return !liveInstances.contains(PARTICIPANT_PREFIX + "_" + _startPort)
+          && !liveInstances.contains(PARTICIPANT_PREFIX + "_" + (_startPort + 1));
+    }, TestHelper.WAIT_DURATION));
 
     // Now bring up all instances
     for (int i = 0; i < 3; i++) {
@@ -241,7 +248,12 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
       _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
       _participants[i].syncStart();
     }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == 3, 2000L);
+    Assert.assertTrue(TestHelper.verify(() -> {
+      List<String> liveInstances = _dataAccessor.getChildNames(_keyBuilder.liveInstances());
+      return liveInstances.contains(PARTICIPANT_PREFIX + "_" + _startPort)
+          && liveInstances.contains(PARTICIPANT_PREFIX + "_" + (_startPort + 1))
+          && liveInstances.contains(PARTICIPANT_PREFIX + "_" + (_startPort + 2));
+    }, TestHelper.WAIT_DURATION));
 
     // The cluster should still be in maintenance because it was enabled manually
     MaintenanceSignal maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
@@ -262,7 +274,8 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
     for (int i = 0; i < 3; i++) {
       _participants[i].syncStop();
     }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == 0, 2000L);
+    Assert.assertTrue(TestHelper.verify(
+        () -> _dataAccessor.getProperty(_keyBuilder.maintenance()) != null, TestHelper.WAIT_DURATION));
 
     // Check that maintenance signal was triggered by Controller
     MaintenanceSignal maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
@@ -275,7 +288,11 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
         "TRIGGERED_BY", "SHOULD NOT BE RECORDED");
     _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true, null,
         customFields);
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) != null, 2000L);
+    Assert.assertTrue(TestHelper.verify(() -> {
+      MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+      return signal != null
+          && signal.getTriggeringEntity() == MaintenanceSignal.TriggeringEntity.USER;
+    }, TestHelper.WAIT_DURATION));
 
     // Check that maintenance mode has successfully overwritten with the right TRIGGERED_BY field
     maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
@@ -301,7 +318,11 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
     // Manually exit maintenance mode
     _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null,
         null);
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) != null, 2000L);
+    Assert.assertTrue(TestHelper.verify(() -> {
+      MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+      return signal != null
+          && signal.getTriggeringEntity() == MaintenanceSignal.TriggeringEntity.CONTROLLER;
+    }, TestHelper.WAIT_DURATION));
 
     // Since 3 instances are missing, the cluster should have gone back under maintenance
     // automatically
@@ -318,7 +339,8 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
       _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
       _participants[i].syncStart();
     }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == 3, 2000L);
+    Assert.assertTrue(TestHelper.verify(
+        () -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, TestHelper.WAIT_DURATION));
 
     // Check that the cluster exited maintenance
     maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
@@ -328,7 +350,8 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
     for (int i = 0; i < 3; i++) {
       _participants[i].syncStop();
     }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == 0, 2000L);
+    Assert.assertTrue(TestHelper.verify(
+        () -> _dataAccessor.getProperty(_keyBuilder.maintenance()) != null, TestHelper.WAIT_DURATION));
 
     // Check that cluster is back under maintenance
     maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
@@ -344,9 +367,9 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
     // automatically because the instances currently have more than 1
     clusterConfig.setMaxPartitionsPerInstance(1);
     _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
-    TestHelper.verify(
+    Assert.assertTrue(TestHelper.verify(
         () -> ((ClusterConfig) _dataAccessor.getProperty(_keyBuilder.clusterConfig())).getMaxPartitionsPerInstance() == 1,
-        2000L);
+        TestHelper.WAIT_DURATION));
 
 
     // Now bring up all instances
@@ -355,7 +378,12 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
       _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
       _participants[i].syncStart();
     }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).size() == 3, 2000L);
+    Assert.assertTrue(TestHelper.verify(() -> {
+      List<String> liveInstances = _dataAccessor.getChildNames(_keyBuilder.liveInstances());
+      return liveInstances.contains(PARTICIPANT_PREFIX + "_" + _startPort)
+          && liveInstances.contains(PARTICIPANT_PREFIX + "_" + (_startPort + 1))
+          && liveInstances.contains(PARTICIPANT_PREFIX + "_" + (_startPort + 2));
+    }, TestHelper.WAIT_DURATION));
 
     // Check that the cluster is still in maintenance (should not have auto-exited because it would
     // fail the MaxPartitionsPerInstance check)
@@ -432,7 +460,12 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
     clusterConfig.setMaxPartitionsPerInstance(-1);
     _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
 
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ControllerHistory h = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+      return "EXIT".equals(convertStringToMap(
+          h.getMaintenanceHistoryList().get(h.getMaintenanceHistoryList().size() - 1))
+          .get("OPERATION_TYPE"));
+    }, TestHelper.WAIT_DURATION));
 
     // Now check that the cluster exited maintenance
     // EXIT, CONTROLLER, for MAX_PARTITION_PER_INSTANCE_EXCEEDED
@@ -448,7 +481,12 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
     Map<String, String> customFieldMap = ImmutableMap.of("k1", "v1", "k2", "v2");
     _gSetupTool.getClusterManagementTool()
         .manuallyEnableMaintenanceMode(CLUSTER_NAME, true, TestHelper.getTestMethodName(), customFieldMap);
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) != null, 2000L);
+    Assert.assertTrue(TestHelper.verify(() -> {
+      ControllerHistory h = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+      Map<String, String> last = convertStringToMap(
+          h.getMaintenanceHistoryList().get(h.getMaintenanceHistoryList().size() - 1));
+      return "ENTER".equals(last.get("OPERATION_TYPE")) && "USER".equals(last.get("TRIGGERED_BY"));
+    }, TestHelper.WAIT_DURATION));
 
     // ENTER, USER, for reason TEST, no internalReason
     history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());

--- a/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestStateTransitionTimeout.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/paticipant/TestStateTransitionTimeout.java
@@ -162,12 +162,13 @@ public class TestStateTransitionTimeout extends ZkStandAloneCMTestBase {
 
     boolean result =
         ClusterStateVerifier
-            .verifyByPolling(new MasterNbInExtViewVerifier(ZK_ADDR, CLUSTER_NAME));
+            .verifyByPolling(new MasterNbInExtViewVerifier(ZK_ADDR, CLUSTER_NAME),
+                TestHelper.WAIT_DURATION);
     Assert.assertTrue(result);
     HelixDataAccessor accessor = _participants[0].getHelixDataAccessor();
 
-    TestHelper.verify(() -> verify(accessor, idealState, factories), 5000);
-    Assert.assertTrue(verify(accessor, idealState, factories));
+    Assert.assertTrue(TestHelper.verify(
+        () -> verify(accessor, idealState, factories), TestHelper.WAIT_DURATION));
   }
 
   private boolean verify(HelixDataAccessor accessor, IdealState idealState,

--- a/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/rebalancer/TestInstanceOperation.java
@@ -1381,7 +1381,7 @@ public class TestInstanceOperation extends ZkTestBase {
     _gSetupTool.getClusterManagementTool().setInstanceConfig(CLUSTER_NAME, instanceToSwapInName, swapInInstanceConfig);
 
     // Assert successfully complete swap
-    verifier(() -> _gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, instanceToSwapOutName), 30000);
+    verifier(() -> _gSetupTool.getClusterManagementTool().canCompleteSwap(CLUSTER_NAME, instanceToSwapOutName), TestHelper.WAIT_DURATION);
     Assert.assertTrue(_gSetupTool.getClusterManagementTool()
         .completeSwapIfPossible(CLUSTER_NAME, instanceToSwapOutName, false));
     Assert.assertTrue(_clusterVerifier.verifyByPolling());
@@ -1492,7 +1492,7 @@ public class TestInstanceOperation extends ZkTestBase {
         continue;
       }
       verifier(() -> ((_dataAccessor.getChildNames(
-          _dataAccessor.keyBuilder().messages(participant))).isEmpty()), 30000);
+          _dataAccessor.keyBuilder().messages(participant))).isEmpty()), TestHelper.WAIT_DURATION);
     }
     Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
     Assert.assertFalse(_admin.isReadyForPreparingJoiningCluster(CLUSTER_NAME, instanceToEvacuate));
@@ -1545,7 +1545,7 @@ public class TestInstanceOperation extends ZkTestBase {
 
     // message should be pending at the to evacuate participant
     verifier(() -> ((_dataAccessor.getChildNames(
-        _dataAccessor.keyBuilder().messages(instanceToEvacuate))).isEmpty()), 30000);
+        _dataAccessor.keyBuilder().messages(instanceToEvacuate))).isEmpty()), TestHelper.WAIT_DURATION);
     Assert.assertFalse(_admin.isEvacuateFinished(CLUSTER_NAME, instanceToEvacuate));
 
     // cancel evacuation
@@ -1708,7 +1708,7 @@ public class TestInstanceOperation extends ZkTestBase {
         }
       }
       return true;
-    }, 30000);
+    }, TestHelper.WAIT_DURATION);
 
     removeOfflineOrInactiveInstances();
     addParticipant(PARTICIPANT_PREFIX + "_" + _nextStartPort);
@@ -1767,7 +1767,7 @@ public class TestInstanceOperation extends ZkTestBase {
     _gSetupTool.getClusterManagementTool().setInstanceOperation(CLUSTER_NAME,
         toDisableThenEvacuateInstanceName, InstanceConstants.InstanceOperation.EVACUATE);
 
-    verifier(() -> _admin.isEvacuateFinished(CLUSTER_NAME, toDisableThenEvacuateInstanceName), 30000);
+    verifier(() -> _admin.isEvacuateFinished(CLUSTER_NAME, toDisableThenEvacuateInstanceName), TestHelper.WAIT_DURATION);
     int downwardSTCountAfterEvacuateComplete = stateTransitionCountStateModelFactory.getDownwardStateTransitionCounter();
 
     // Assert node received no upward state transitions after evacuation was called on already disabled node


### PR DESCRIPTION
### Issues

- [x] My PR addresses the following Helix issues and references them in the PR description:

Fixes several **pre-existing flaky integration tests** that intermittently fail in CI with `expected:<true> but was:<false>`, unrelated to the change under test. Most recently `testEvacuateWithDisabledPartition` failed this way on a PR CI run (`Tests run: 1846, Failures: 1`). No tracking issue is currently filed — happy to open one if preferred.

### Description

- [x] Here are some details about my PR:

**What.** Test-only change that stabilizes three flaky integration-test classes by making their convergence polls wait long enough and assert the right condition.

**Why.** Each test polls for cluster convergence and then asserts on the outcome, but the polls use tight/default timeouts (30s) or — in the maintenance test — wait on a *different* condition than the one asserted. Under CI scheduling contention a poll can return before the cluster converges, yielding an intermittent `AssertionError: expected:<true> but was:<false>` that has nothing to do with the change under test. For example `testEvacuateWithDisabledPartition` polled `_admin.isEvacuateFinished(...)` for only 30s; under load evacuation took longer (elapsed 36.8s) and the assert flaked.

**How.**
- **`TestClusterMaintenanceMode`** — re-point 13 polls at the *exact* asserted condition (maintenance-signal presence/absence, specific live-instance names, or the history entry's `OPERATION_TYPE`), assert the poll result instead of ignoring it, and wait `TestHelper.WAIT_DURATION`. Some polls previously waited on stale/wrong live-instance counts; these are corrected to count-independent or name-based predicates.
- **`TestStateTransitionTimeout`** — assert the `verifyByPolling` result and use the 60s overload instead of the default 30s.
- **`TestInstanceOperation`** — widen five 30s `verifier(...)` polls to `TestHelper.WAIT_DURATION`.

Widening these budgets is safe: each poll returns as soon as its predicate becomes true, so a passing run is unaffected; only slow-but-correct runs get the extra time they need.

### Tests

- [x] Test-only PR (no product code touched). Changed classes:

`TestClusterMaintenanceMode`, `TestStateTransitionTimeout`, `TestInstanceOperation`.

- `mvn test` result: `TestClusterMaintenanceMode` and `TestStateTransitionTimeout` were validated locally under a CPU-throttle reproduction harness — both pass 3/3 iterations at the load that previously reproduced the flake, and pass at normal speed with no regression. `TestInstanceOperation` compiles cleanly but is not locally reproducible in isolation (deep `dependsOnMethods` chain); relying on CI for that class.

### Changes that Break Backward Compatibility (Optional)

None. Test-only change; no production code, public API, config, or serialization-format changes.

### Documentation (Optional)

None.

### Commits

- [x] Commit subject uses the imperative mood; the body explains what and why (not how) and is wrapped.

### Code Quality

- [x] Diff follows the `helix-style` formatting conventions.
