### PR TITLE
Emit StoppedWorkflowGauge metric for stopped workflows

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/WorkflowMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/WorkflowMonitor.java
@@ -44,6 +44,7 @@ public class WorkflowMonitor extends DynamicMBeanProvider {
   private SimpleDynamicMetric<Long> _successfulWorkflowCount;
   private SimpleDynamicMetric<Long> _failedWorkflowCount;
   private SimpleDynamicMetric<Long> _failedWorkflowGauge;
+  private SimpleDynamicMetric<Long> _stoppedWorkflowGauge;
   private SimpleDynamicMetric<Long> _existingWorkflowGauge;
   private SimpleDynamicMetric<Long> _queuedWorkflowGauge;
   private SimpleDynamicMetric<Long> _runningWorkflowGauge;
@@ -57,6 +58,7 @@ public class WorkflowMonitor extends DynamicMBeanProvider {
     _successfulWorkflowCount = new SimpleDynamicMetric("SuccessfulWorkflowCount", 0L);
     _failedWorkflowCount = new SimpleDynamicMetric("FailedWorkflowCount", 0L);
     _failedWorkflowGauge = new SimpleDynamicMetric("FailedWorkflowGauge", 0L);
+    _stoppedWorkflowGauge = new SimpleDynamicMetric("StoppedWorkflowGauge", 0L);
     _existingWorkflowGauge = new SimpleDynamicMetric("ExistingWorkflowGauge", 0L);
     _queuedWorkflowGauge = new SimpleDynamicMetric("QueuedWorkflowGauge", 0L);
     _runningWorkflowGauge = new SimpleDynamicMetric("RunningWorkflowGauge", 0L);
@@ -98,6 +100,7 @@ public class WorkflowMonitor extends DynamicMBeanProvider {
    */
   public void resetGauges() {
     _failedWorkflowGauge.updateValue(0L);
+    _stoppedWorkflowGauge.updateValue(0L);
     _existingWorkflowGauge.updateValue(0L);
     _runningWorkflowGauge.updateValue(0L);
     _queuedWorkflowGauge.updateValue(0L);
@@ -118,6 +121,8 @@ public class WorkflowMonitor extends DynamicMBeanProvider {
       incrementSimpleDynamicMetric(_runningWorkflowGauge);
     } else if (current.equals(TaskState.FAILED)) {
       incrementSimpleDynamicMetric(_failedWorkflowGauge);
+    } else if (current.equals(TaskState.STOPPED)) {
+      incrementSimpleDynamicMetric(_stoppedWorkflowGauge);
     }
     incrementSimpleDynamicMetric(_existingWorkflowGauge);
   }
@@ -133,6 +138,10 @@ public class WorkflowMonitor extends DynamicMBeanProvider {
 
   public long getFailedWorkflowGauge() {
     return _failedWorkflowGauge.getValue();
+  }
+
+  public long getStoppedWorkflowGauge() {
+    return _stoppedWorkflowGauge.getValue();
   }
 
   public long getExistingWorkflowGauge() {
@@ -153,6 +162,7 @@ public class WorkflowMonitor extends DynamicMBeanProvider {
     attributeList.add(_successfulWorkflowCount);
     attributeList.add(_failedWorkflowCount);
     attributeList.add(_failedWorkflowGauge);
+    attributeList.add(_stoppedWorkflowGauge);
     attributeList.add(_existingWorkflowGauge);
     attributeList.add(_queuedWorkflowGauge);
     attributeList.add(_runningWorkflowGauge);

--- a/helix-core/src/test/java/org/apache/helix/monitoring/TestWorkflowMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/TestWorkflowMonitor.java
@@ -51,7 +51,8 @@ public class TestWorkflowMonitor {
         null);
     HashSet<String> expectedAttr = new HashSet<>(Arrays
         .asList("SuccessfulWorkflowCount", "FailedWorkflowCount", "FailedWorkflowGauge",
-            "ExistingWorkflowGauge", "QueuedWorkflowGauge", "RunningWorkflowGauge"));
+            "StoppedWorkflowGauge", "ExistingWorkflowGauge", "QueuedWorkflowGauge",
+            "RunningWorkflowGauge"));
     for (ObjectInstance i : existingInstances) {
       for (MBeanAttributeInfo info : beanServer.getMBeanInfo(i.getObjectName()).getAttributes()) {
         expectedAttr.remove(info.getName());
@@ -63,6 +64,7 @@ public class TestWorkflowMonitor {
     int failedWfCnt = 10;
     int queuedWfCnt = 10;
     int runningWfCnt = 10;
+    int stoppedWfCnt = 10;
 
     for (int i = 0; i < successfulWfCnt; i++) {
       wm.updateWorkflowCounters(TaskState.COMPLETED);
@@ -82,12 +84,17 @@ public class TestWorkflowMonitor {
       wm.updateWorkflowGauges(TaskState.IN_PROGRESS);
     }
 
+    for (int i = 0; i < stoppedWfCnt; i++) {
+      wm.updateWorkflowGauges(TaskState.STOPPED);
+    }
+
     // Test gauges
     Assert.assertEquals(wm.getExistingWorkflowGauge(),
-        successfulWfCnt + failedWfCnt + queuedWfCnt + runningWfCnt);
+        successfulWfCnt + failedWfCnt + queuedWfCnt + runningWfCnt + stoppedWfCnt);
     Assert.assertEquals(wm.getFailedWorkflowGauge(), failedWfCnt);
     Assert.assertEquals(wm.getQueuedWorkflowGauge(), queuedWfCnt);
     Assert.assertEquals(wm.getRunningWorkflowGauge(), runningWfCnt);
+    Assert.assertEquals(wm.getStoppedWorkflowGauge(), stoppedWfCnt);
 
     // Test counts
     Assert.assertEquals(wm.getFailedWorkflowCount(), failedWfCnt);
@@ -113,12 +120,17 @@ public class TestWorkflowMonitor {
       wm.updateWorkflowGauges(TaskState.IN_PROGRESS);
     }
 
+    for (int i = 0; i < stoppedWfCnt; i++) {
+      wm.updateWorkflowGauges(TaskState.STOPPED);
+    }
+
     // After reset, counters should be accumulative, but gauges should be reset
     Assert.assertEquals(wm.getExistingWorkflowGauge(),
-        successfulWfCnt + failedWfCnt + queuedWfCnt + runningWfCnt);
+        successfulWfCnt + failedWfCnt + queuedWfCnt + runningWfCnt + stoppedWfCnt);
     Assert.assertEquals(wm.getFailedWorkflowGauge(), failedWfCnt);
     Assert.assertEquals(wm.getQueuedWorkflowGauge(), queuedWfCnt);
     Assert.assertEquals(wm.getRunningWorkflowGauge(), runningWfCnt);
+    Assert.assertEquals(wm.getStoppedWorkflowGauge(), stoppedWfCnt);
     Assert.assertEquals(wm.getFailedWorkflowCount(), failedWfCnt * 2);
     Assert.assertEquals(wm.getSuccessfulWorkflowCount(), successfulWfCnt * 2);
 


### PR DESCRIPTION
WorkflowMonitor exposed queued, running, and failed workflow gauges but had no metric for workflows sitting in the STOPPED state. A workflow (for example a stopped job queue) could remain STOPPED indefinitely without any observable signal, so operators had no way to alert on it and only noticed after downstream detection windows elapsed and logs had already rotated.

Add a per-workflow-type StoppedWorkflowGauge that is refreshed each pipeline cycle alongside the existing gauges, cleared in resetGauges, and registered as an MBean attribute. Operators can now alert when any workflow of a given type is stopped. Extend TestWorkflowMonitor to cover the new gauge on both the accumulate and post-reset paths.

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
