### PR TITLE
Reject invalid NUM_PARTITIONS at core ZKHelixAdmin IdealState write paths

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1773,6 +1773,7 @@ public class ZKHelixAdmin implements HelixAdmin {
   @Override
   public void addResource(String clusterName, String resourceName, IdealState idealstate) {
     logger.info("Add resource {} in cluster {}.", resourceName, clusterName);
+    validateNonNegativeNumPartitions(clusterName, idealstate);
     String stateModelRef = idealstate.getStateModelDefRef();
     String stateModelDefPath = PropertyPathBuilder.stateModelDef(clusterName, stateModelRef);
     if (!_zkClient.exists(stateModelDefPath)) {
@@ -1906,10 +1907,29 @@ public class ZKHelixAdmin implements HelixAdmin {
     logger
         .info("Set IdealState for resource {} in cluster {} with new IdealState {}.", resourceName,
             clusterName, idealState == null ? "NULL" : idealState.toString());
+    validateNonNegativeNumPartitions(clusterName, idealState);
     HelixDataAccessor accessor = new ZKHelixDataAccessor(clusterName, _baseDataAccessor);
     PropertyKey.Builder keyBuilder = accessor.keyBuilder();
 
     accessor.setProperty(keyBuilder.idealStates(resourceName), idealState);
+  }
+
+  /**
+   * Validates that the given IdealState has a non-negative NUM_PARTITIONS before it is persisted.
+   * A missing NUM_PARTITIONS field defaults to -1 (see {@link IdealState#getNumPartitions()}). If
+   * such a record reaches ZooKeeper, the rebalancer later cannot place the resource (fails with
+   * NO_CANDIDATE_NODE) and keeps serving a stale assignment. Rejecting the write up front keeps the
+   * invalid record out of ZooKeeper. Mirrors the NUM_PARTITIONS check in
+   * {@link IdealState#isValid()}. A null IdealState is left untouched so existing callers that rely
+   * on that behavior are not affected.
+   */
+  private static void validateNonNegativeNumPartitions(String clusterName, IdealState idealState) {
+    if (idealState != null && idealState.getNumPartitions() < 0) {
+      throw new HelixException(String.format(
+          "Cannot write IdealState for resource %s in cluster %s: NUM_PARTITIONS must be "
+              + "non-negative, but was %d.",
+          idealState.getResourceName(), clusterName, idealState.getNumPartitions()));
+    }
   }
 
   /**
@@ -1929,6 +1949,17 @@ public class ZKHelixAdmin implements HelixAdmin {
       throw new HelixException(String.format(
           "updateIdealState failed. The IdealState for the given resource does not already exist. Resource name: %s",
           resourceName));
+    }
+    // This is a merge update, so a partial input that does not carry NUM_PARTITIONS must still be
+    // allowed (it simply does not touch partitions). Only reject an explicitly negative value so a
+    // caller cannot overwrite a valid NUM_PARTITIONS with -1.
+    if (idealState.getRecord().getSimpleFields()
+            .containsKey(IdealState.IdealStateProperty.NUM_PARTITIONS.name())
+        && idealState.getNumPartitions() < 0) {
+      throw new HelixException(String.format(
+          "updateIdealState failed for resource %s in cluster %s: NUM_PARTITIONS must be "
+              + "non-negative, but was %d.",
+          resourceName, clusterName, idealState.getNumPartitions()));
     }
     // Update by way of merge
     ZKUtil.upsertWithOptionalCreate(_zkClient, zkPath, idealState.getRecord(), true, true, false);

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkHelixAdmin.java
@@ -454,6 +454,114 @@ public class TestZkHelixAdmin extends ZkUnitTestBase {
     System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
   }
 
+  /**
+   * Verifies that every IdealState write path in ZKHelixAdmin rejects a NUM_PARTITIONS that is
+   * missing (defaults to -1) or negative, so an invalid resource can never reach ZooKeeper and
+   * later break the rebalancer with NO_CANDIDATE_NODE. Also verifies that legitimate writes and
+   * partial merge-updates that do not touch NUM_PARTITIONS still succeed.
+   */
+  @Test
+  public void testWriteIdealStateRejectsInvalidNumPartitions() {
+    String className = TestHelper.getTestClassName();
+    String methodName = TestHelper.getTestMethodName();
+    String clusterName = className + "_" + methodName;
+
+    System.out.println("START " + clusterName + " at " + new Date(System.currentTimeMillis()));
+
+    HelixAdmin tool = new ZKHelixAdmin(_gZkClient);
+    tool.addCluster(clusterName, true);
+    Assert.assertTrue(ZKUtil.isClusterSetup(clusterName, _gZkClient), "Cluster should be setup");
+    tool.addStateModelDef(clusterName, "MasterSlave",
+        new StateModelDefinition(StateModelConfigGenerator.generateConfigForMasterSlave()));
+
+    PropertyKey.Builder keyBuilder = new PropertyKey.Builder(clusterName);
+
+    // 1. addResource(IdealState) with no NUM_PARTITIONS (getNumPartitions() defaults to -1) must be
+    // rejected and must not create the ideal-state node. This is the path Ambry's bootstrap tool
+    // uses and the one that caused the incident.
+    String missingPartResource = "resourceMissingNumPartitions";
+    IdealState missingPart = new IdealState(missingPartResource);
+    missingPart.setStateModelDefRef("MasterSlave");
+    Assert.assertEquals(missingPart.getNumPartitions(), -1);
+    try {
+      tool.addResource(clusterName, missingPartResource, missingPart);
+      Assert.fail("addResource should reject an IdealState with NUM_PARTITIONS < 0");
+    } catch (HelixException expected) {
+      // expected
+    }
+    Assert.assertFalse(_gZkClient.exists(keyBuilder.idealStates(missingPartResource).getPath()),
+        "Invalid resource must not be persisted");
+
+    // 2. The int-partitions addResource overload with a negative partition count must also be
+    // rejected (it builds an IdealState and delegates to the IdealState overload).
+    try {
+      tool.addResource(clusterName, "resourceNegativePartitions", -1, "MasterSlave");
+      Assert.fail("addResource should reject a negative partition count");
+    } catch (HelixException expected) {
+      // expected
+    }
+    Assert.assertFalse(
+        _gZkClient.exists(keyBuilder.idealStates("resourceNegativePartitions").getPath()),
+        "Invalid resource must not be persisted");
+
+    // 3. setResourceIdealState (full overwrite) with no NUM_PARTITIONS must be rejected. This is the
+    // path Ambry's full-auto migration and addIdealState(file) use.
+    String overwriteResource = "resourceOverwriteMissingNumPartitions";
+    IdealState overwriteMissing = new IdealState(overwriteResource);
+    overwriteMissing.setStateModelDefRef("MasterSlave");
+    Assert.assertEquals(overwriteMissing.getNumPartitions(), -1);
+    try {
+      tool.setResourceIdealState(clusterName, overwriteResource, overwriteMissing);
+      Assert.fail("setResourceIdealState should reject an IdealState with NUM_PARTITIONS < 0");
+    } catch (HelixException expected) {
+      // expected
+    }
+    Assert.assertFalse(_gZkClient.exists(keyBuilder.idealStates(overwriteResource).getPath()),
+        "Invalid resource must not be persisted");
+
+    // 4. A valid resource must still be created and overwritten successfully (no regression).
+    String validResource = "validResource";
+    tool.addResource(clusterName, validResource, 4, "MasterSlave");
+    Assert.assertTrue(_gZkClient.exists(keyBuilder.idealStates(validResource).getPath()),
+        "Valid resource should be created");
+    IdealState validIdealState = tool.getResourceIdealState(clusterName, validResource);
+    Assert.assertEquals(validIdealState.getNumPartitions(), 4);
+    validIdealState.setNumPartitions(8);
+    tool.setResourceIdealState(clusterName, validResource, validIdealState);
+    Assert.assertEquals(
+        tool.getResourceIdealState(clusterName, validResource).getNumPartitions(), 8);
+
+    // 5. updateIdealState is a merge: a partial update that does NOT carry NUM_PARTITIONS must still
+    // succeed and must not disturb the existing NUM_PARTITIONS.
+    IdealState partialUpdate = new IdealState(validResource);
+    partialUpdate.setInstanceGroupTag("TAG_1");
+    Assert.assertFalse(partialUpdate.getRecord().getSimpleFields()
+        .containsKey(IdealState.IdealStateProperty.NUM_PARTITIONS.name()));
+    tool.updateIdealState(clusterName, validResource, partialUpdate);
+    IdealState afterPartial = tool.getResourceIdealState(clusterName, validResource);
+    Assert.assertEquals(afterPartial.getNumPartitions(), 8, "Merge update must not change partitions");
+    Assert.assertEquals(afterPartial.getInstanceGroupTag(), "TAG_1");
+
+    // 6. updateIdealState with an explicitly negative NUM_PARTITIONS must be rejected so a caller
+    // cannot overwrite a valid value with -1.
+    IdealState badUpdate = new IdealState(validResource);
+    badUpdate.setNumPartitions(-1);
+    Assert.assertTrue(badUpdate.getRecord().getSimpleFields()
+        .containsKey(IdealState.IdealStateProperty.NUM_PARTITIONS.name()));
+    try {
+      tool.updateIdealState(clusterName, validResource, badUpdate);
+      Assert.fail("updateIdealState should reject an explicit NUM_PARTITIONS < 0");
+    } catch (HelixException expected) {
+      // expected
+    }
+    Assert.assertEquals(
+        tool.getResourceIdealState(clusterName, validResource).getNumPartitions(), 8,
+        "Existing NUM_PARTITIONS must be preserved after a rejected update");
+
+    tool.dropCluster(clusterName);
+    System.out.println("END " + clusterName + " at " + new Date(System.currentTimeMillis()));
+  }
+
   // test add/remove message constraint
   @Test
   public void testAddRemoveMsgConstraint() {


### PR DESCRIPTION
## Summary

**What:** Reject creating/updating a Helix resource whose `IdealState` has a missing or negative `NUM_PARTITIONS`, at the core `ZKHelixAdmin` write paths.

**Why:** An `IdealState` written with no `NUM_PARTITIONS` field defaults to `-1` (`IdealState.getNumPartitions()`). The core write methods `addResource(cluster, resource, IdealState)` and `setResourceIdealState(...)` write the record straight to ZooKeeper and never call `IdealState.isValid()`. The bad resource only fails later, at rebalance time, with `HelixRebalanceException category=NO_CANDIDATE_NODE`, which trips the `ContinuousRebalanceFailureCount` alert. Seen in prod on `Ambry-prod` (resource `10129`, `idealState:10129 does not have number of partitions (was -1)`).

Crucially, Ambry does **not** create resources through helix-rest - its `HelixBootstrapUpgradeUtil` calls `HelixAdmin.addResource(IdealState)` / `setResourceIdealState(...)` directly. A helix-rest-only guard would not have prevented this incident. Putting the check at the core `ZKHelixAdmin` choke points covers **every** writer (Ambry's bootstrap tool, `ClusterSetup`, `addIdealState(file)`, and helix-rest).

**How:**
- `addResource(cluster, resource, IdealState)`: reject `NUM_PARTITIONS < 0` before the ZK write (also covers the int-partitions overload, which delegates here).
- `setResourceIdealState(...)`: reject `NUM_PARTITIONS < 0` (covers `addIdealState(file)`, `addResourceWithWeight`, `ClusterSetup`, and Ambry's full-auto migration writes).
- `updateIdealState(...)` is a **merge**, so it only rejects an *explicitly* negative `NUM_PARTITIONS`; a partial update that omits the field still works (no regression).

Threshold is `< 0` (0 is allowed), matching the existing `IdealState.isValid()` semantics.

Internal core callers (`rebalance`, `enableBatchMessageMode`, `rebalance(IdealState)`) operate on an already-valid `IdealState` read from ZK, and the controller/rebalancer pipeline does not call these `HelixAdmin` methods, so there is no control-loop impact.

**Scope note:** helix-rest-layer validation is intentionally **not** in this PR - that is being added through the guardrail validation framework (linkedin/helix#213 and follow-ups by @sjainit). This PR is the core-layer guard only, which is what covers direct `HelixAdmin` callers like Ambry.

Note: this is a preventive guard. It does not repair `IdealState` records already persisted with a missing `NUM_PARTITIONS`; those must be corrected by the resource owner.

## Testing Done

- **New core test `TestZkHelixAdmin#testWriteIdealStateRejectsInvalidNumPartitions`** - runs against a real ZooKeeper and covers every scenario: create with missing `NUM_PARTITIONS` (rejected, not persisted), int-partitions overload with negative count (rejected), `setResourceIdealState` overwrite with missing `NUM_PARTITIONS` (rejected), valid create + overwrite (succeeds), merge-update omitting `NUM_PARTITIONS` (succeeds, partitions preserved), merge-update with explicit `-1` (rejected, existing value preserved). **PASS.**
- **Full `TestZkHelixAdmin`: 23/23 passed, 0 failures.**
- **Integration/rebalancer regression check** (run locally against embedded ZK): `TestClusterVerifier`, `TestDisablePartition`, `TestBatchMessageHandling` (exercises `enableBatchMessageMode -> setResourceIdealState`), `TestWagedNPE`, `TestAutoRebalance`, `TestPreserveAssignmentsOnRebalanceFailure`, `TestWagedRebalance` - all green (~51 tests, 0 failures).


## Interim REST behavior (until the guardrail framework lands)

This PR is intentionally core-only; helix-rest-layer validation is being added through the guardrail framework (linkedin/helix#213 and @sjainit's rule PR). Until that lands, a malformed request that reaches the core guard surfaces as:
- `PUT .../resources/{r}` (addResource): **HTTP 500** (outer `catch(Exception) -> serverError`).
- `POST .../resources/{r}/idealState` (merge with an explicit negative `NUM_PARTITIONS`): **HTTP 404** (`catch(HelixException) -> notFound`).

This is acceptable because ZooKeeper is protected either way (the previous behavior silently wrote the invalid record and only failed later at rebalance time). The clean `400` responses will come from the guardrail framework, which should cover the `addResource`, `addWagedResource`, and `/idealState` update paths.
