### PR TITLE
Add REST accessor for cluster message/state constraints

### DIFF
--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ConstraintAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ConstraintAccessor.java
@@ -1,0 +1,259 @@
+package org.apache.helix.rest.server.resources.helix;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.manager.zk.ZKUtil;
+import org.apache.helix.model.ClusterConstraints;
+import org.apache.helix.model.ClusterConstraints.ConstraintType;
+import org.apache.helix.model.ConstraintItem;
+import org.apache.helix.model.builder.ConstraintItemBuilder;
+import org.apache.helix.rest.common.HttpConstants;
+import org.apache.helix.rest.server.filters.ClusterAuth;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+/**
+ * REST accessor for cluster-level {@link ClusterConstraints} (e.g. MESSAGE_CONSTRAINT,
+ * STATE_CONSTRAINT). These constraints live at
+ * {@code /{clusterName}/CONFIGS/CONSTRAINT/{constraintType}} in ZooKeeper. This accessor lets
+ * operators create, read, and delete individual constraint items through the REST API instead of
+ * editing ZNodes by hand.
+ */
+@Path("/clusters/{clusterId}/constraints")
+@Api(value = "", description = "Helix REST Cluster Constraints APIs")
+public class ConstraintAccessor extends AbstractHelixResource {
+  private static final Logger LOG = LoggerFactory.getLogger(ConstraintAccessor.class.getName());
+
+  /**
+   * Return all constraint items for the given constraint type.
+   * @param clusterId cluster name
+   * @param constraintTypeStr one of {@link ConstraintType} (e.g. MESSAGE_CONSTRAINT)
+   * @return the {@link ClusterConstraints} record for the type
+   */
+  @ClusterAuth
+  @ResponseMetered(name = HttpConstants.READ_REQUEST)
+  @Timed(name = HttpConstants.READ_REQUEST)
+  @GET
+  @Path("{constraintType}")
+  @ApiOperation(value = "Get all constraints of a type", notes = "Helix REST Constraints Get API")
+  public Response getConstraints(@PathParam("clusterId") String clusterId,
+      @PathParam("constraintType") String constraintTypeStr) {
+    if (!doesClusterExist(clusterId)) {
+      return notFound("Cluster " + clusterId + " does not exist");
+    }
+    ConstraintType constraintType = parseConstraintType(constraintTypeStr);
+    if (constraintType == null) {
+      return badRequest(invalidConstraintTypeMessage(constraintTypeStr));
+    }
+
+    ClusterConstraints constraints = getHelixAdmin().getConstraints(clusterId, constraintType);
+    if (constraints == null) {
+      return notFound(
+          "No " + constraintType.name() + " constraints found for cluster " + clusterId);
+    }
+    return JSONRepresentation(constraints.getRecord());
+  }
+
+  /**
+   * Return a single constraint item.
+   * @param clusterId cluster name
+   * @param constraintTypeStr one of {@link ConstraintType}
+   * @param constraintId the constraint item id (an arbitrary, caller-chosen unique label)
+   * @return the constraint item's attribute map
+   */
+  @ClusterAuth
+  @ResponseMetered(name = HttpConstants.READ_REQUEST)
+  @Timed(name = HttpConstants.READ_REQUEST)
+  @GET
+  @Path("{constraintType}/{constraintId}")
+  @ApiOperation(value = "Get a single constraint item", notes = "Helix REST Constraints Get API")
+  public Response getConstraintItem(@PathParam("clusterId") String clusterId,
+      @PathParam("constraintType") String constraintTypeStr,
+      @PathParam("constraintId") String constraintId) {
+    if (!doesClusterExist(clusterId)) {
+      return notFound("Cluster " + clusterId + " does not exist");
+    }
+    ConstraintType constraintType = parseConstraintType(constraintTypeStr);
+    if (constraintType == null) {
+      return badRequest(invalidConstraintTypeMessage(constraintTypeStr));
+    }
+
+    ClusterConstraints constraints = getHelixAdmin().getConstraints(clusterId, constraintType);
+    Map<String, String> item =
+        constraints == null ? null : constraints.getRecord().getMapField(constraintId);
+    if (item == null) {
+      return notFound("Constraint " + constraintId + " of type " + constraintType.name()
+          + " does not exist for cluster " + clusterId);
+    }
+    return JSONRepresentation(item);
+  }
+
+  /**
+   * Create or overwrite a constraint item. The request body is a flat JSON object of constraint
+   * attributes, for example:
+   *
+   * <pre>
+   * {
+   *   "MESSAGE_TYPE": "STATE_TRANSITION",
+   *   "TRANSITION": "OFFLINE-BOOTSTRAP",
+   *   "INSTANCE": "localhost_12918",
+   *   "CONSTRAINT_VALUE": "0"
+   * }
+   * </pre>
+   *
+   * Attribute keys must be members of {@link ClusterConstraints.ConstraintAttribute}. A valid
+   * {@code CONSTRAINT_VALUE} (an integer or {@code ANY}) is required. If a constraint
+   * with the same {@code constraintId} already exists it is overwritten.
+   *
+   * @param clusterId cluster name
+   * @param constraintTypeStr one of {@link ConstraintType}
+   * @param constraintId the constraint item id (an arbitrary, caller-chosen unique label)
+   * @param content JSON object mapping constraint attribute to value
+   * @return 200 OK on success
+   */
+  @ClusterAuth
+  @ResponseMetered(name = HttpConstants.WRITE_REQUEST)
+  @Timed(name = HttpConstants.WRITE_REQUEST)
+  @PUT
+  @Path("{constraintType}/{constraintId}")
+  @ApiOperation(value = "Create or overwrite a constraint item",
+      notes = "Helix REST Constraints Put API")
+  public Response setConstraint(@PathParam("clusterId") String clusterId,
+      @PathParam("constraintType") String constraintTypeStr,
+      @PathParam("constraintId") String constraintId, String content) {
+    if (!doesClusterExist(clusterId)) {
+      return notFound("Cluster " + clusterId + " does not exist");
+    }
+    ConstraintType constraintType = parseConstraintType(constraintTypeStr);
+    if (constraintType == null) {
+      return badRequest(invalidConstraintTypeMessage(constraintTypeStr));
+    }
+    if (StringUtils.isBlank(constraintId)) {
+      return badRequest("constraintId cannot be empty");
+    }
+
+    Map<String, String> attributes;
+    try {
+      attributes = OBJECT_MAPPER.readValue(content, new TypeReference<Map<String, String>>() {
+      });
+    } catch (IOException e) {
+      String errMsg = "Failed to parse constraint attributes from request body: " + content;
+      LOG.warn(errMsg, e);
+      return badRequest(errMsg + " Exception: " + e.getMessage());
+    }
+    if (attributes == null || attributes.isEmpty()) {
+      return badRequest("Constraint attributes cannot be empty");
+    }
+
+    ConstraintItemBuilder builder = new ConstraintItemBuilder();
+    builder.addConstraintAttributes(attributes);
+    ConstraintItem item = builder.build();
+    // Mirror the validation ClusterConstraints applies when loading from ZK: an item must carry at
+    // least one recognized attribute and a valid constraint value. Unrecognized attribute keys or
+    // an invalid CONSTRAINT_VALUE are dropped by the builder, so an empty result means bad input.
+    if (item.getAttributes().isEmpty() || item.getConstraintValue() == null) {
+      return badRequest("Invalid constraint. Requires at least one valid constraint attribute from "
+          + Arrays.toString(ClusterConstraints.ConstraintAttribute.values())
+          + " and a valid CONSTRAINT_VALUE (an integer or ANY). Parsed input: "
+          + attributes);
+    }
+
+    try {
+      getHelixAdmin().setConstraint(clusterId, constraintType, constraintId, item);
+    } catch (Exception e) {
+      LOG.error("Failed to set constraint {} of type {} for cluster {}.", constraintId,
+          constraintType, clusterId, e);
+      return serverError(e);
+    }
+    return OK();
+  }
+
+  /**
+   * Remove a constraint item.
+   * @param clusterId cluster name
+   * @param constraintTypeStr one of {@link ConstraintType}
+   * @param constraintId the constraint item id to remove
+   * @return 200 OK on success
+   */
+  @ClusterAuth
+  @ResponseMetered(name = HttpConstants.WRITE_REQUEST)
+  @Timed(name = HttpConstants.WRITE_REQUEST)
+  @DELETE
+  @Path("{constraintType}/{constraintId}")
+  @ApiOperation(value = "Remove a constraint item", notes = "Helix REST Constraints Delete API")
+  public Response removeConstraint(@PathParam("clusterId") String clusterId,
+      @PathParam("constraintType") String constraintTypeStr,
+      @PathParam("constraintId") String constraintId) {
+    if (!doesClusterExist(clusterId)) {
+      return notFound("Cluster " + clusterId + " does not exist");
+    }
+    ConstraintType constraintType = parseConstraintType(constraintTypeStr);
+    if (constraintType == null) {
+      return badRequest(invalidConstraintTypeMessage(constraintTypeStr));
+    }
+
+    try {
+      getHelixAdmin().removeConstraint(clusterId, constraintType, constraintId);
+    } catch (Exception e) {
+      LOG.error("Failed to remove constraint {} of type {} for cluster {}.", constraintId,
+          constraintType, clusterId, e);
+      return serverError(e);
+    }
+    return OK();
+  }
+
+  private static ConstraintType parseConstraintType(String constraintTypeStr) {
+    if (constraintTypeStr == null) {
+      return null;
+    }
+    try {
+      return ConstraintType.valueOf(constraintTypeStr);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private static String invalidConstraintTypeMessage(String constraintTypeStr) {
+    return "Invalid constraint type: " + constraintTypeStr + ". Valid types are "
+        + Arrays.toString(ConstraintType.values());
+  }
+
+  private boolean doesClusterExist(String cluster) {
+    RealmAwareZkClient zkClient = getRealmAwareZkClient();
+    return ZKUtil.isClusterSetup(cluster, zkClient);
+  }
+}

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestConstraintAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestConstraintAccessor.java
@@ -1,0 +1,177 @@
+package org.apache.helix.rest.server;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.util.Map;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import org.apache.helix.TestHelper;
+import org.apache.helix.model.ClusterConstraints;
+import org.apache.helix.model.ClusterConstraints.ConstraintAttribute;
+import org.apache.helix.model.ClusterConstraints.ConstraintType;
+import org.apache.helix.model.ConstraintItem;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestConstraintAccessor extends AbstractTestClass {
+  private static final String CLUSTER = "TestConstraintCluster";
+  private static final String MESSAGE_CONSTRAINT = ConstraintType.MESSAGE_CONSTRAINT.name();
+  private static final String CONSTRAINTS_URI = "clusters/" + CLUSTER + "/constraints";
+  private static final String INSTANCE = "localhost_12918";
+
+  @BeforeClass
+  public void beforeClass() {
+    _gSetupTool.addCluster(CLUSTER, true);
+  }
+
+  private static String messageConstraintUri(String constraintId) {
+    return CONSTRAINTS_URI + "/" + MESSAGE_CONSTRAINT + "/" + constraintId;
+  }
+
+  private static Entity<String> constraintEntity(Map<String, String> attributes)
+      throws IOException {
+    return Entity.entity(OBJECT_MAPPER.writeValueAsString(attributes),
+        MediaType.APPLICATION_JSON_TYPE);
+  }
+
+  @Test
+  public void testCreateGetAndDeleteMessageConstraint() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String constraintId = "bootstrapConstraint";
+    Map<String, String> attributes = ImmutableMap.of(
+        "MESSAGE_TYPE", "STATE_TRANSITION",
+        "TRANSITION", "OFFLINE-BOOTSTRAP",
+        "INSTANCE", INSTANCE,
+        "CONSTRAINT_VALUE", "0");
+
+    // Create the constraint through REST.
+    put(messageConstraintUri(constraintId), null, constraintEntity(attributes),
+        Response.Status.OK.getStatusCode());
+
+    // Verify it landed in ZK with the expected attributes.
+    ClusterConstraints constraints = _gSetupTool.getClusterManagementTool()
+        .getConstraints(CLUSTER, ConstraintType.MESSAGE_CONSTRAINT);
+    Assert.assertNotNull(constraints);
+    ConstraintItem item = constraints.getConstraintItem(constraintId);
+    Assert.assertNotNull(item);
+    Assert.assertEquals(item.getConstraintValue(), "0");
+    Assert.assertEquals(item.getAttributeValue(ConstraintAttribute.MESSAGE_TYPE),
+        "STATE_TRANSITION");
+    Assert.assertEquals(item.getAttributeValue(ConstraintAttribute.TRANSITION), "OFFLINE-BOOTSTRAP");
+    Assert.assertEquals(item.getAttributeValue(ConstraintAttribute.INSTANCE), INSTANCE);
+
+    // GET all constraints of the type.
+    String body = get(CONSTRAINTS_URI + "/" + MESSAGE_CONSTRAINT, null,
+        Response.Status.OK.getStatusCode(), true);
+    JsonNode node = OBJECT_MAPPER.readTree(body);
+    Assert.assertTrue(node.get("mapFields").has(constraintId));
+
+    // GET the single constraint item.
+    body = get(messageConstraintUri(constraintId), null, Response.Status.OK.getStatusCode(), true);
+    node = OBJECT_MAPPER.readTree(body);
+    Assert.assertEquals(node.get("CONSTRAINT_VALUE").asText(), "0");
+    Assert.assertEquals(node.get("INSTANCE").asText(), INSTANCE);
+
+    // DELETE it.
+    delete(messageConstraintUri(constraintId), Response.Status.OK.getStatusCode());
+    constraints = _gSetupTool.getClusterManagementTool()
+        .getConstraints(CLUSTER, ConstraintType.MESSAGE_CONSTRAINT);
+    Assert.assertTrue(
+        constraints == null || constraints.getConstraintItem(constraintId) == null);
+
+    // GET the deleted item now 404s.
+    get(messageConstraintUri(constraintId), null, Response.Status.NOT_FOUND.getStatusCode(), false);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test
+  public void testCreateMultipleConstraintsSameType() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    String[] ids = {"bootstrapConstraint0", "bootstrapConstraint1", "bootstrapConstraint2"};
+    for (int i = 0; i < ids.length; i++) {
+      String id = ids[i];
+      Map<String, String> attributes = ImmutableMap.of(
+          "MESSAGE_TYPE", "STATE_TRANSITION",
+          "TRANSITION", "OFFLINE-BOOTSTRAP",
+          "INSTANCE", "localhost_1291" + i,
+          "CONSTRAINT_VALUE", "0");
+      put(messageConstraintUri(id), null, constraintEntity(attributes),
+          Response.Status.OK.getStatusCode());
+    }
+
+    ClusterConstraints constraints = _gSetupTool.getClusterManagementTool()
+        .getConstraints(CLUSTER, ConstraintType.MESSAGE_CONSTRAINT);
+    Assert.assertNotNull(constraints);
+    for (String id : ids) {
+      Assert.assertNotNull(constraints.getConstraintItem(id),
+          "Expected constraint " + id + " to exist");
+      delete(messageConstraintUri(id), Response.Status.OK.getStatusCode());
+    }
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test
+  public void testInvalidConstraintType() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    Map<String, String> attributes =
+        ImmutableMap.of("MESSAGE_TYPE", "STATE_TRANSITION", "CONSTRAINT_VALUE", "0");
+    put(CONSTRAINTS_URI + "/NOT_A_TYPE/someId", null, constraintEntity(attributes),
+        Response.Status.BAD_REQUEST.getStatusCode());
+    get(CONSTRAINTS_URI + "/NOT_A_TYPE", null, Response.Status.BAD_REQUEST.getStatusCode(), false);
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test
+  public void testMissingCluster() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    Map<String, String> attributes =
+        ImmutableMap.of("MESSAGE_TYPE", "STATE_TRANSITION", "CONSTRAINT_VALUE", "0");
+    put("clusters/NonExistentCluster/constraints/" + MESSAGE_CONSTRAINT + "/someId", null,
+        constraintEntity(attributes), Response.Status.NOT_FOUND.getStatusCode());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test
+  public void testInvalidConstraintBody() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+    // Missing CONSTRAINT_VALUE -> rejected.
+    Map<String, String> noValue =
+        ImmutableMap.of("MESSAGE_TYPE", "STATE_TRANSITION", "TRANSITION", "OFFLINE-BOOTSTRAP");
+    put(messageConstraintUri("noValue"), null, constraintEntity(noValue),
+        Response.Status.BAD_REQUEST.getStatusCode());
+
+    // Only unrecognized attribute keys -> nothing valid parsed -> rejected.
+    Map<String, String> onlyBogus = ImmutableMap.of("BOGUS_ATTR", "x", "CONSTRAINT_VALUE", "0");
+    put(messageConstraintUri("onlyBogus"), null, constraintEntity(onlyBogus),
+        Response.Status.BAD_REQUEST.getStatusCode());
+
+    // Empty body -> rejected.
+    put(messageConstraintUri("empty"), null,
+        Entity.entity("{}", MediaType.APPLICATION_JSON_TYPE),
+        Response.Status.BAD_REQUEST.getStatusCode());
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+}


### PR DESCRIPTION
Operators previously had to hand-edit the CONSTRAINT ZNodes `(/{cluster}/CONFIGS/CONSTRAINT/{type})` to add a message constraint, which is error prone during an incident. This adds a ConstraintAccessor exposing CRUD over individual constraint items:

```
  GET    /clusters/{clusterId}/constraints/{constraintType}
  GET    /clusters/{clusterId}/constraints/{constraintType}/{constraintId}
  PUT    /clusters/{clusterId}/constraints/{constraintType}/{constraintId}
  DELETE /clusters/{clusterId}/constraints/{constraintType}/{constraintId}
```

PUT accepts a flat JSON map of constraint attributes and delegates to HelixAdmin.setConstraint, validating the constraint type, attribute keys, and CONSTRAINT_VALUE the same way the core loader does. The accessor is auto-registered via the existing package scan. Adds TestConstraintAccessor covering create/get/delete, multiple items of the same type, and the invalid-type, missing-cluster, and invalid-body error paths.

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
