### PR TITLE
Add per-instance actual-state partition gauges from CurrentState

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -42,6 +42,7 @@ import org.apache.helix.model.CurrentState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
+import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.monitoring.mbeans.ClusterStatusMonitor;
 import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
@@ -86,6 +87,8 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             Map<String, Set<Message>> instanceMessageMap = Maps.newHashMap();
             Map<String, InstanceConfig> instanceConfigMap = dataProvider.getInstanceConfigMap();
             Map<String, Long> instanceErrorPartitionCounts = Maps.newHashMap();
+            Map<String, Long> instanceActualPartitionCounts = Maps.newHashMap();
+            Map<String, Long> instanceActualTopStatePartitionCounts = Maps.newHashMap();
             
             for (Map.Entry<String, InstanceConfig> e : instanceConfigMap.entrySet()) {
               String instanceName = e.getKey();
@@ -96,9 +99,13 @@ public class ReadClusterDataStage extends AbstractBaseStage {
                 instanceMessageMap.put(instanceName,
                     Sets.newHashSet(dataProvider.getMessages(instanceName).values()));
                 
-                // Count ERROR partitions for this live instance
-                long errorCount = countErrorPartitions(dataProvider, instanceName);
-                instanceErrorPartitionCounts.put(instanceName, errorCount);
+                // Count partitions this live instance actually hosts, from its CurrentState
+                InstancePartitionCounts partitionCounts =
+                    computeInstancePartitionCounts(dataProvider, instanceName);
+                instanceErrorPartitionCounts.put(instanceName, partitionCounts.errorCount);
+                instanceActualPartitionCounts.put(instanceName, partitionCounts.actualPartitionCount);
+                instanceActualTopStatePartitionCounts.put(instanceName,
+                    partitionCounts.actualTopStatePartitionCount);
               }
               if (!config.getInstanceEnabled()) {
                 disabledInstanceSet.add(instanceName);
@@ -115,6 +122,8 @@ public class ReadClusterDataStage extends AbstractBaseStage {
                 .setClusterInstanceStatus(liveInstanceSet, instanceSet, disabledInstanceSet,
                     disabledPartitions, oldDisabledPartitions, tags, instanceMessageMap,
                     instanceConfigMap, instanceErrorPartitionCounts);
+            clusterStatusMonitor.setInstanceActualPartitionStatus(instanceActualPartitionCounts,
+                instanceActualTopStatePartitionCounts);
             LogUtil.logDebug(logger, _eventId, "Complete cluster status monitors update.");
           }
           return null;
@@ -181,51 +190,84 @@ public class ReadClusterDataStage extends AbstractBaseStage {
   }
 
   /**
-   * Count the number of partitions in ERROR state for a given instance
+   * Holder for per-instance partition counts derived from an instance's CurrentState.
+   */
+  private static class InstancePartitionCounts {
+    long errorCount = 0L;
+    long actualPartitionCount = 0L;
+    long actualTopStatePartitionCount = 0L;
+  }
+
+  /**
+   * Compute per-instance partition counts from the instance's CurrentState in a single pass:
+   * the number of partitions in ERROR state, the number of partitions actually hosted (any
+   * non-DROPPED state), and the number of partitions in the resource top state.
    * @param dataProvider the data provider containing current state information
    * @param instanceName the name of the instance to check
-   * @return the count of partitions in ERROR state
+   * @return the counts; all zero if the instance is not live or on any read failure
    */
-  private long countErrorPartitions(BaseControllerDataProvider dataProvider, String instanceName) {
-    long errorCount = 0L;
-    
+  private InstancePartitionCounts computeInstancePartitionCounts(
+      BaseControllerDataProvider dataProvider, String instanceName) {
+    InstancePartitionCounts counts = new InstancePartitionCounts();
+
     try {
       Map<String, LiveInstance> liveInstances = dataProvider.getLiveInstances();
       LiveInstance liveInstance = liveInstances.get(instanceName);
-      
+
       if (liveInstance == null) {
-        return errorCount;
+        return counts;
       }
-      
+
       String sessionId = liveInstance.getEphemeralOwner();
-      Map<String, CurrentState> currentStateMap = 
+      Map<String, CurrentState> currentStateMap =
           dataProvider.getCurrentState(instanceName, sessionId, false);
-      
+
       if (currentStateMap == null) {
-        return errorCount;
+        return counts;
       }
-      
+
       for (CurrentState currentState : currentStateMap.values()) {
         if (currentState == null) {
           continue;
         }
-        
+
         Map<String, String> partitionStateMap = currentState.getPartitionStateMap();
         if (partitionStateMap == null) {
           continue;
         }
-        
+
+        // Resolve the top state for this resource's state model, if available.
+        String topState = null;
+        String stateModelDefRef = currentState.getStateModelDefRef();
+        if (stateModelDefRef != null) {
+          StateModelDefinition stateModelDef = dataProvider.getStateModelDef(stateModelDefRef);
+          if (stateModelDef != null) {
+            topState = stateModelDef.getTopState();
+          }
+        }
+
         for (String state : partitionStateMap.values()) {
+          if (state == null) {
+            continue;
+          }
           if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
-            errorCount++;
+            counts.errorCount++;
+          }
+          // DROPPED partitions are no longer hosted, so they are excluded from actual counts.
+          if (HelixDefinedState.DROPPED.name().equalsIgnoreCase(state)) {
+            continue;
+          }
+          counts.actualPartitionCount++;
+          if (topState != null && topState.equalsIgnoreCase(state)) {
+            counts.actualTopStatePartitionCount++;
           }
         }
       }
     } catch (Exception e) {
-      LogUtil.logWarn(logger, _eventId, 
-          "Failed to count error partitions for instance: " + instanceName, e);
+      LogUtil.logWarn(logger, _eventId,
+          "Failed to compute partition counts for instance: " + instanceName, e);
     }
-    
-    return errorCount;
+
+    return counts;
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -204,10 +204,12 @@ public class ReadClusterDataStage extends AbstractBaseStage {
    * the number of partitions in ERROR state, the number of partitions actually hosted, and the
    * number of those partitions in the resource top state.
    * <p>
-   * A partition counts as "actually hosted" when its current state is neither DROPPED nor the
-   * state model's initial state (typically OFFLINE), matching the convention already used by
-   * {@link org.apache.helix.monitoring.mbeans.PerInstanceResourceMonitor}. A resource whose state
-   * model definition cannot be resolved is skipped, since its states cannot be interpreted.
+   * A partition counts as "actually hosted" when its current state is not the state model's
+   * initial state (typically OFFLINE), matching the convention already used by
+   * {@link org.apache.helix.monitoring.mbeans.PerInstanceResourceMonitor}. DROPPED is also
+   * excluded defensively; participants delete the partition entry rather than persisting DROPPED,
+   * so it is not expected to appear here. A resource whose state model definition cannot be
+   * resolved is skipped, since its states cannot be interpreted.
    * @param dataProvider the data provider containing current state information
    * @param instanceName the name of the instance to check
    * @return the counts; all zero if the instance is not live. Resources that fail to be read are
@@ -291,8 +293,10 @@ public class ReadClusterDataStage extends AbstractBaseStage {
       if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
         counts.errorCount++;
       }
-      // DROPPED partitions are no longer hosted, and initial-state (e.g. OFFLINE) partitions are
-      // not yet being served, so neither counts towards what the instance actually hosts.
+      // Initial-state (e.g. OFFLINE) partitions are not being served, so they do not count towards
+      // what the instance actually hosts. DROPPED is excluded defensively only: on a successful
+      // drop the participant subtracts the partition entry from CurrentState instead of persisting
+      // DROPPED, so it should never be observed here.
       if (HelixDefinedState.DROPPED.name().equalsIgnoreCase(state)
           || state.equalsIgnoreCase(initialState)) {
         continue;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -121,9 +121,8 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             clusterStatusMonitor
                 .setClusterInstanceStatus(liveInstanceSet, instanceSet, disabledInstanceSet,
                     disabledPartitions, oldDisabledPartitions, tags, instanceMessageMap,
-                    instanceConfigMap, instanceErrorPartitionCounts);
-            clusterStatusMonitor.setInstanceActualPartitionStatus(instanceActualPartitionCounts,
-                instanceActualTopStatePartitionCounts);
+                    instanceConfigMap, instanceErrorPartitionCounts, instanceActualPartitionCounts,
+                    instanceActualTopStatePartitionCounts);
             LogUtil.logDebug(logger, _eventId, "Complete cluster status monitors update.");
           }
           return null;

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -87,8 +87,8 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             Map<String, Set<Message>> instanceMessageMap = Maps.newHashMap();
             Map<String, InstanceConfig> instanceConfigMap = dataProvider.getInstanceConfigMap();
             Map<String, Long> instanceErrorPartitionCounts = Maps.newHashMap();
-            Map<String, Long> instanceActualPartitionCounts = Maps.newHashMap();
-            Map<String, Long> instanceActualTopStatePartitionCounts = Maps.newHashMap();
+            Map<String, Long> instanceActiveStatePartitionCounts = Maps.newHashMap();
+            Map<String, Long> instanceActiveStateTopStatePartitionCounts = Maps.newHashMap();
             
             for (Map.Entry<String, InstanceConfig> e : instanceConfigMap.entrySet()) {
               String instanceName = e.getKey();
@@ -99,13 +99,13 @@ public class ReadClusterDataStage extends AbstractBaseStage {
                 instanceMessageMap.put(instanceName,
                     Sets.newHashSet(dataProvider.getMessages(instanceName).values()));
                 
-                // Count partitions this live instance actually hosts, from its CurrentState
+                // Count partitions this live instance holds in an active state, from CurrentState
                 InstancePartitionCounts partitionCounts =
                     computeInstancePartitionCounts(dataProvider, instanceName);
                 instanceErrorPartitionCounts.put(instanceName, partitionCounts.errorCount);
-                instanceActualPartitionCounts.put(instanceName, partitionCounts.actualPartitionCount);
-                instanceActualTopStatePartitionCounts.put(instanceName,
-                    partitionCounts.actualTopStatePartitionCount);
+                instanceActiveStatePartitionCounts.put(instanceName, partitionCounts.activeStatePartitionCount);
+                instanceActiveStateTopStatePartitionCounts.put(instanceName,
+                    partitionCounts.activeStateTopStatePartitionCount);
               }
               if (!config.getInstanceEnabled()) {
                 disabledInstanceSet.add(instanceName);
@@ -121,8 +121,8 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             clusterStatusMonitor
                 .setClusterInstanceStatus(liveInstanceSet, instanceSet, disabledInstanceSet,
                     disabledPartitions, oldDisabledPartitions, tags, instanceMessageMap,
-                    instanceConfigMap, instanceErrorPartitionCounts, instanceActualPartitionCounts,
-                    instanceActualTopStatePartitionCounts);
+                    instanceConfigMap, instanceErrorPartitionCounts, instanceActiveStatePartitionCounts,
+                    instanceActiveStateTopStatePartitionCounts);
             LogUtil.logDebug(logger, _eventId, "Complete cluster status monitors update.");
           }
           return null;
@@ -194,21 +194,23 @@ public class ReadClusterDataStage extends AbstractBaseStage {
    */
   static class InstancePartitionCounts {
     long errorCount = 0L;
-    long actualPartitionCount = 0L;
-    long actualTopStatePartitionCount = 0L;
+    long activeStatePartitionCount = 0L;
+    long activeStateTopStatePartitionCount = 0L;
   }
 
   /**
    * Compute per-instance partition counts from the instance's CurrentState in a single pass:
-   * the number of partitions in ERROR state, the number of partitions actually hosted, and the
+   * the number of partitions in ERROR state, the number of partitions in an active state, and the
    * number of those partitions in the resource top state.
    * <p>
-   * A partition counts as "actually hosted" when its current state is not the state model's
-   * initial state (typically OFFLINE), matching the convention already used by
-   * {@link org.apache.helix.monitoring.mbeans.PerInstanceResourceMonitor}. DROPPED is also
-   * excluded defensively; participants delete the partition entry rather than persisting DROPPED,
-   * so it is not expected to appear here. A resource whose state model definition cannot be
-   * resolved is skipped, since its states cannot be interpreted.
+   * A partition counts as being in an "active state" when its current state is not the state
+   * model's initial state (typically OFFLINE), matching the convention already used by
+   * {@link org.apache.helix.monitoring.mbeans.PerInstanceResourceMonitor}. This tracks state
+   * machine progress rather than disk residency, so a partition that occupies disk while sitting
+   * in the initial state is not counted. DROPPED is also excluded defensively; participants delete
+   * the partition entry rather than persisting DROPPED, so it is not expected to appear here. A
+   * resource whose state model definition cannot be resolved is skipped, since its states cannot
+   * be interpreted.
    * @param dataProvider the data provider containing current state information
    * @param instanceName the name of the instance to check
    * @return the counts; all zero if the instance is not live. Resources that fail to be read are
@@ -269,10 +271,11 @@ public class ReadClusterDataStage extends AbstractBaseStage {
     StateModelDefinition stateModelDef =
         stateModelDefRef == null ? null : dataProvider.getStateModelDef(stateModelDefRef);
     if (stateModelDef == null) {
-      // Without the state model we cannot tell hosted partitions from initial/dropped ones, so
-      // counting them would report a misleading value. Still count ERROR, which is model agnostic.
+      // Without the state model we cannot tell active-state partitions from initial/dropped ones,
+      // so counting them would report a misleading value. Still count ERROR, which is model
+      // agnostic.
       LogUtil.logWarn(logger, _eventId,
-          "Skipping actual partition counts for resource: " + currentState.getResourceName()
+          "Skipping active-state partition counts for resource: " + currentState.getResourceName()
               + ", unresolved state model definition: " + stateModelDefRef);
       for (String state : partitionStateMap.values()) {
         if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
@@ -292,17 +295,17 @@ public class ReadClusterDataStage extends AbstractBaseStage {
       if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
         counts.errorCount++;
       }
-      // Initial-state (e.g. OFFLINE) partitions are not being served, so they do not count towards
-      // what the instance actually hosts. DROPPED is excluded defensively only: on a successful
-      // drop the participant subtracts the partition entry from CurrentState instead of persisting
-      // DROPPED, so it should never be observed here.
+      // Initial-state (e.g. OFFLINE) partitions are not being served, so they do not count as
+      // active. This tracks state machine progress, not disk residency. DROPPED is excluded
+      // defensively only: on a successful drop the participant subtracts the partition entry from
+      // CurrentState instead of persisting DROPPED, so it should never be observed here.
       if (HelixDefinedState.DROPPED.name().equalsIgnoreCase(state)
           || state.equalsIgnoreCase(initialState)) {
         continue;
       }
-      counts.actualPartitionCount++;
+      counts.activeStatePartitionCount++;
       if (topState != null && topState.equalsIgnoreCase(state)) {
-        counts.actualTopStatePartitionCount++;
+        counts.activeStateTopStatePartitionCount++;
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -19,6 +19,7 @@ package org.apache.helix.controller.stages;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import com.google.common.collect.Sets;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixDefinedState;
 import org.apache.helix.HelixManager;
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.LogUtil;
 import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
@@ -39,6 +41,7 @@ import org.apache.helix.controller.pipeline.StageException;
 import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.Message;
@@ -87,8 +90,8 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             Map<String, Set<Message>> instanceMessageMap = Maps.newHashMap();
             Map<String, InstanceConfig> instanceConfigMap = dataProvider.getInstanceConfigMap();
             Map<String, Long> instanceErrorPartitionCounts = Maps.newHashMap();
-            Map<String, Long> instanceActiveStatePartitionCounts = Maps.newHashMap();
-            Map<String, Long> instanceActiveStateTopStatePartitionCounts = Maps.newHashMap();
+            Map<String, Long> instanceActualPartitionCounts = Maps.newHashMap();
+            Map<String, Long> instanceActualTopStatePartitionCounts = Maps.newHashMap();
             
             for (Map.Entry<String, InstanceConfig> e : instanceConfigMap.entrySet()) {
               String instanceName = e.getKey();
@@ -99,13 +102,13 @@ public class ReadClusterDataStage extends AbstractBaseStage {
                 instanceMessageMap.put(instanceName,
                     Sets.newHashSet(dataProvider.getMessages(instanceName).values()));
                 
-                // Count partitions this live instance holds in an active state, from CurrentState
+                // Count the partitions this live instance actually holds, from its CurrentState
                 InstancePartitionCounts partitionCounts =
                     computeInstancePartitionCounts(dataProvider, instanceName);
                 instanceErrorPartitionCounts.put(instanceName, partitionCounts.errorCount);
-                instanceActiveStatePartitionCounts.put(instanceName, partitionCounts.activeStatePartitionCount);
-                instanceActiveStateTopStatePartitionCounts.put(instanceName,
-                    partitionCounts.activeStateTopStatePartitionCount);
+                instanceActualPartitionCounts.put(instanceName, partitionCounts.actualPartitionCount);
+                instanceActualTopStatePartitionCounts.put(instanceName,
+                    partitionCounts.actualTopStatePartitionCount);
               }
               if (!config.getInstanceEnabled()) {
                 disabledInstanceSet.add(instanceName);
@@ -121,8 +124,8 @@ public class ReadClusterDataStage extends AbstractBaseStage {
             clusterStatusMonitor
                 .setClusterInstanceStatus(liveInstanceSet, instanceSet, disabledInstanceSet,
                     disabledPartitions, oldDisabledPartitions, tags, instanceMessageMap,
-                    instanceConfigMap, instanceErrorPartitionCounts, instanceActiveStatePartitionCounts,
-                    instanceActiveStateTopStatePartitionCounts);
+                    instanceConfigMap, instanceErrorPartitionCounts, instanceActualPartitionCounts,
+                    instanceActualTopStatePartitionCounts);
             LogUtil.logDebug(logger, _eventId, "Complete cluster status monitors update.");
           }
           return null;
@@ -194,23 +197,25 @@ public class ReadClusterDataStage extends AbstractBaseStage {
    */
   static class InstancePartitionCounts {
     long errorCount = 0L;
-    long activeStatePartitionCount = 0L;
-    long activeStateTopStatePartitionCount = 0L;
+    long actualPartitionCount = 0L;
+    long actualTopStatePartitionCount = 0L;
   }
 
   /**
    * Compute per-instance partition counts from the instance's CurrentState in a single pass:
-   * the number of partitions in ERROR state, the number of partitions in an active state, and the
-   * number of those partitions in the resource top state.
+   * the number of partitions in ERROR state, the number of partitions the instance actually holds,
+   * and the number of those partitions in the resource top state.
    * <p>
-   * A partition counts as being in an "active state" when its current state is not the state
-   * model's initial state (typically OFFLINE), matching the convention already used by
-   * {@link org.apache.helix.monitoring.mbeans.PerInstanceResourceMonitor}. This tracks state
-   * machine progress rather than disk residency, so a partition that occupies disk while sitting
-   * in the initial state is not counted. DROPPED is also excluded defensively; participants delete
-   * the partition entry rather than persisting DROPPED, so it is not expected to appear here. A
-   * resource whose state model definition cannot be resolved is skipped, since its states cannot
-   * be interpreted.
+   * A partition counts as held when its current state is not the state model's initial state
+   * (typically OFFLINE), or when the initial state is the state the controller intends it to be in.
+   * The rebalancer deliberately parks a partition in the initial state when the instance is
+   * disabled, when that partition is disabled on the instance, or when the whole resource is
+   * disabled, so those partitions are counted: they are exactly where they are supposed to be. A
+   * partition left in the initial state with no such reason is not counted, because it means the
+   * transition has not finished or has failed. DROPPED is excluded defensively; participants
+   * delete the partition entry rather than persisting DROPPED, so it is not expected to appear
+   * here. A resource whose state model definition cannot be resolved is skipped, since its states
+   * cannot be interpreted.
    * @param dataProvider the data provider containing current state information
    * @param instanceName the name of the instance to check
    * @return the counts; all zero if the instance is not live. Resources that fail to be read are
@@ -235,13 +240,15 @@ public class ReadClusterDataStage extends AbstractBaseStage {
       return counts;
     }
 
-    if (currentStateMap == null) {
+    if (currentStateMap == null || currentStateMap.isEmpty()) {
       return counts;
     }
 
+    DisabledPartitionInfo disabledInfo = readDisabledPartitionInfo(dataProvider, instanceName);
+
     for (Map.Entry<String, CurrentState> entry : currentStateMap.entrySet()) {
       try {
-        accumulatePartitionCounts(dataProvider, entry.getValue(), counts);
+        accumulatePartitionCounts(dataProvider, entry.getValue(), disabledInfo, counts);
       } catch (Exception e) {
         // Skip only the offending resource so one bad resource cannot zero out the whole instance.
         LogUtil.logWarn(logger, _eventId, "Failed to compute partition counts for instance: "
@@ -253,11 +260,75 @@ public class ReadClusterDataStage extends AbstractBaseStage {
   }
 
   /**
+   * Snapshot of the disablement that applies to a single instance, read once per instance so the
+   * per-partition loop stays a map lookup.
+   */
+  private static class DisabledPartitionInfo {
+    static final DisabledPartitionInfo NONE =
+        new DisabledPartitionInfo(false, Collections.emptyMap());
+
+    /** True when every partition on the instance is disabled, so all of them are held OFFLINE. */
+    final boolean instanceDisabled;
+    /** Partitions disabled on this instance, keyed by resource name. */
+    final Map<String, List<String>> disabledPartitionsByResource;
+
+    DisabledPartitionInfo(boolean instanceDisabled,
+        Map<String, List<String>> disabledPartitionsByResource) {
+      this.instanceDisabled = instanceDisabled;
+      this.disabledPartitionsByResource = disabledPartitionsByResource;
+    }
+  }
+
+  /**
+   * Read the disablement that applies to {@code instanceName}. The two instance-wide conditions
+   * mirror what {@link BaseControllerDataProvider} itself treats as "disabled for every partition":
+   * the DISABLE instance operation, and the ALL_RESOURCES disabled-partition key.
+   * @return the disablement snapshot, or {@link DisabledPartitionInfo#NONE} if it cannot be read
+   */
+  private DisabledPartitionInfo readDisabledPartitionInfo(BaseControllerDataProvider dataProvider,
+      String instanceName) {
+    try {
+      Map<String, InstanceConfig> instanceConfigMap = dataProvider.getInstanceConfigMap();
+      InstanceConfig instanceConfig =
+          instanceConfigMap == null ? null : instanceConfigMap.get(instanceName);
+      Map<String, List<String>> disabledPartitionsByResource = instanceConfig == null
+          ? Collections.emptyMap() : instanceConfig.getDisabledPartitionsMap();
+      Set<String> disabledInstances = dataProvider.getDisabledInstances();
+      boolean instanceDisabled =
+          (disabledInstances != null && disabledInstances.contains(instanceName))
+              || disabledPartitionsByResource
+                  .containsKey(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY);
+      return new DisabledPartitionInfo(instanceDisabled, disabledPartitionsByResource);
+    } catch (Exception e) {
+      // Degrade to "nothing is disabled" rather than losing the instance's counts entirely. The
+      // gauge then simply stops crediting intentionally OFFLINE partitions for this run.
+      LogUtil.logWarn(logger, _eventId,
+          "Failed to read disabled partition info for instance: " + instanceName, e);
+      return DisabledPartitionInfo.NONE;
+    }
+  }
+
+  /**
+   * Report whether the resource itself is disabled, in which case the rebalancer holds every one of
+   * its partitions in the initial state. A missing IdealState is not a disabled resource: it means
+   * the resource is being removed, so its partitions are on their way to DROPPED.
+   */
+  private static boolean isResourceDisabled(BaseControllerDataProvider dataProvider,
+      String resourceName) {
+    if (resourceName == null) {
+      return false;
+    }
+    IdealState idealState = dataProvider.getIdealState(resourceName);
+    return idealState != null && !idealState.isEnabled();
+  }
+
+  /**
    * Accumulate the partition counts contributed by a single resource's CurrentState into
    * {@code counts}.
    */
   private void accumulatePartitionCounts(BaseControllerDataProvider dataProvider,
-      CurrentState currentState, InstancePartitionCounts counts) {
+      CurrentState currentState, DisabledPartitionInfo disabledInfo,
+      InstancePartitionCounts counts) {
     if (currentState == null) {
       return;
     }
@@ -271,11 +342,10 @@ public class ReadClusterDataStage extends AbstractBaseStage {
     StateModelDefinition stateModelDef =
         stateModelDefRef == null ? null : dataProvider.getStateModelDef(stateModelDefRef);
     if (stateModelDef == null) {
-      // Without the state model we cannot tell active-state partitions from initial/dropped ones,
-      // so counting them would report a misleading value. Still count ERROR, which is model
-      // agnostic.
+      // Without the state model we cannot tell held partitions from initial/dropped ones, so
+      // counting them would report a misleading value. Still count ERROR, which is model agnostic.
       LogUtil.logWarn(logger, _eventId,
-          "Skipping active-state partition counts for resource: " + currentState.getResourceName()
+          "Skipping actual partition counts for resource: " + currentState.getResourceName()
               + ", unresolved state model definition: " + stateModelDefRef);
       for (String state : partitionStateMap.values()) {
         if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
@@ -285,28 +355,46 @@ public class ReadClusterDataStage extends AbstractBaseStage {
       return;
     }
 
+    String resourceName = currentState.getResourceName();
     String topState = stateModelDef.getTopState();
     String initialState = stateModelDef.getInitialState();
 
-    for (String state : partitionStateMap.values()) {
+    // Resolved once per resource rather than per partition. When the instance or the whole resource
+    // is disabled, every partition here is meant to sit in the initial state.
+    boolean allPartitionsHeldInitial =
+        disabledInfo.instanceDisabled || isResourceDisabled(dataProvider, resourceName);
+    Set<String> disabledPartitions = allPartitionsHeldInitial ? Collections.emptySet()
+        : toPartitionSet(disabledInfo.disabledPartitionsByResource.get(resourceName));
+
+    for (Map.Entry<String, String> partitionEntry : partitionStateMap.entrySet()) {
+      String state = partitionEntry.getValue();
       if (state == null) {
         continue;
       }
       if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
         counts.errorCount++;
       }
-      // Initial-state (e.g. OFFLINE) partitions are not being served, so they do not count as
-      // active. This tracks state machine progress, not disk residency. DROPPED is excluded
-      // defensively only: on a successful drop the participant subtracts the partition entry from
-      // CurrentState instead of persisting DROPPED, so it should never be observed here.
-      if (HelixDefinedState.DROPPED.name().equalsIgnoreCase(state)
-          || state.equalsIgnoreCase(initialState)) {
+      // DROPPED is excluded defensively only: on a successful drop the participant subtracts the
+      // partition entry from CurrentState instead of persisting DROPPED, so it should never be
+      // observed here.
+      if (HelixDefinedState.DROPPED.name().equalsIgnoreCase(state)) {
         continue;
       }
-      counts.activeStatePartitionCount++;
+      if (state.equalsIgnoreCase(initialState) && !allPartitionsHeldInitial
+          && !disabledPartitions.contains(partitionEntry.getKey())) {
+        // Sitting in the initial state (e.g. OFFLINE) with nothing disabled means the partition is
+        // not held: the transition has either not finished yet or has failed.
+        continue;
+      }
+      counts.actualPartitionCount++;
       if (topState != null && topState.equalsIgnoreCase(state)) {
-        counts.activeStateTopStatePartitionCount++;
+        counts.actualTopStatePartitionCount++;
       }
     }
+  }
+
+  private static Set<String> toPartitionSet(List<String> partitions) {
+    return partitions == null || partitions.isEmpty() ? Collections.emptySet()
+        : new HashSet<>(partitions);
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -191,8 +191,9 @@ public class ReadClusterDataStage extends AbstractBaseStage {
 
   /**
    * Holder for per-instance partition counts derived from an instance's CurrentState.
+   * Package-private for testing.
    */
-  private static class InstancePartitionCounts {
+  static class InstancePartitionCounts {
     long errorCount = 0L;
     long actualPartitionCount = 0L;
     long actualTopStatePartitionCount = 0L;
@@ -212,20 +213,19 @@ public class ReadClusterDataStage extends AbstractBaseStage {
    * @return the counts; all zero if the instance is not live. Resources that fail to be read are
    *         skipped, so the counts reflect every resource that could be processed.
    */
-  private InstancePartitionCounts computeInstancePartitionCounts(
+  InstancePartitionCounts computeInstancePartitionCounts(
       BaseControllerDataProvider dataProvider, String instanceName) {
     InstancePartitionCounts counts = new InstancePartitionCounts();
 
-    Map<String, LiveInstance> liveInstances = dataProvider.getLiveInstances();
-    LiveInstance liveInstance = liveInstances == null ? null : liveInstances.get(instanceName);
-    if (liveInstance == null) {
-      return counts;
-    }
-
     Map<String, CurrentState> currentStateMap;
     try {
-      currentStateMap = dataProvider.getCurrentState(instanceName, liveInstance.getEphemeralOwner(),
-          false);
+      Map<String, LiveInstance> liveInstances = dataProvider.getLiveInstances();
+      LiveInstance liveInstance = liveInstances == null ? null : liveInstances.get(instanceName);
+      if (liveInstance == null) {
+        return counts;
+      }
+      currentStateMap =
+          dataProvider.getCurrentState(instanceName, liveInstance.getEphemeralOwner(), false);
     } catch (Exception e) {
       LogUtil.logWarn(logger, _eventId,
           "Failed to read current states for instance: " + instanceName, e);

--- a/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/stages/ReadClusterDataStage.java
@@ -200,74 +200,107 @@ public class ReadClusterDataStage extends AbstractBaseStage {
 
   /**
    * Compute per-instance partition counts from the instance's CurrentState in a single pass:
-   * the number of partitions in ERROR state, the number of partitions actually hosted (any
-   * non-DROPPED state), and the number of partitions in the resource top state.
+   * the number of partitions in ERROR state, the number of partitions actually hosted, and the
+   * number of those partitions in the resource top state.
+   * <p>
+   * A partition counts as "actually hosted" when its current state is neither DROPPED nor the
+   * state model's initial state (typically OFFLINE), matching the convention already used by
+   * {@link org.apache.helix.monitoring.mbeans.PerInstanceResourceMonitor}. A resource whose state
+   * model definition cannot be resolved is skipped, since its states cannot be interpreted.
    * @param dataProvider the data provider containing current state information
    * @param instanceName the name of the instance to check
-   * @return the counts; all zero if the instance is not live or on any read failure
+   * @return the counts; all zero if the instance is not live. Resources that fail to be read are
+   *         skipped, so the counts reflect every resource that could be processed.
    */
   private InstancePartitionCounts computeInstancePartitionCounts(
       BaseControllerDataProvider dataProvider, String instanceName) {
     InstancePartitionCounts counts = new InstancePartitionCounts();
 
+    Map<String, LiveInstance> liveInstances = dataProvider.getLiveInstances();
+    LiveInstance liveInstance = liveInstances == null ? null : liveInstances.get(instanceName);
+    if (liveInstance == null) {
+      return counts;
+    }
+
+    Map<String, CurrentState> currentStateMap;
     try {
-      Map<String, LiveInstance> liveInstances = dataProvider.getLiveInstances();
-      LiveInstance liveInstance = liveInstances.get(instanceName);
-
-      if (liveInstance == null) {
-        return counts;
-      }
-
-      String sessionId = liveInstance.getEphemeralOwner();
-      Map<String, CurrentState> currentStateMap =
-          dataProvider.getCurrentState(instanceName, sessionId, false);
-
-      if (currentStateMap == null) {
-        return counts;
-      }
-
-      for (CurrentState currentState : currentStateMap.values()) {
-        if (currentState == null) {
-          continue;
-        }
-
-        Map<String, String> partitionStateMap = currentState.getPartitionStateMap();
-        if (partitionStateMap == null) {
-          continue;
-        }
-
-        // Resolve the top state for this resource's state model, if available.
-        String topState = null;
-        String stateModelDefRef = currentState.getStateModelDefRef();
-        if (stateModelDefRef != null) {
-          StateModelDefinition stateModelDef = dataProvider.getStateModelDef(stateModelDefRef);
-          if (stateModelDef != null) {
-            topState = stateModelDef.getTopState();
-          }
-        }
-
-        for (String state : partitionStateMap.values()) {
-          if (state == null) {
-            continue;
-          }
-          if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
-            counts.errorCount++;
-          }
-          // DROPPED partitions are no longer hosted, so they are excluded from actual counts.
-          if (HelixDefinedState.DROPPED.name().equalsIgnoreCase(state)) {
-            continue;
-          }
-          counts.actualPartitionCount++;
-          if (topState != null && topState.equalsIgnoreCase(state)) {
-            counts.actualTopStatePartitionCount++;
-          }
-        }
-      }
+      currentStateMap = dataProvider.getCurrentState(instanceName, liveInstance.getEphemeralOwner(),
+          false);
     } catch (Exception e) {
       LogUtil.logWarn(logger, _eventId,
-          "Failed to compute partition counts for instance: " + instanceName, e);
+          "Failed to read current states for instance: " + instanceName, e);
+      return counts;
+    }
+
+    if (currentStateMap == null) {
+      return counts;
+    }
+
+    for (Map.Entry<String, CurrentState> entry : currentStateMap.entrySet()) {
+      try {
+        accumulatePartitionCounts(dataProvider, entry.getValue(), counts);
+      } catch (Exception e) {
+        // Skip only the offending resource so one bad resource cannot zero out the whole instance.
+        LogUtil.logWarn(logger, _eventId, "Failed to compute partition counts for instance: "
+            + instanceName + ", resource: " + entry.getKey(), e);
+      }
     }
 
     return counts;
+  }
+
+  /**
+   * Accumulate the partition counts contributed by a single resource's CurrentState into
+   * {@code counts}.
+   */
+  private void accumulatePartitionCounts(BaseControllerDataProvider dataProvider,
+      CurrentState currentState, InstancePartitionCounts counts) {
+    if (currentState == null) {
+      return;
+    }
+
+    Map<String, String> partitionStateMap = currentState.getPartitionStateMap();
+    if (partitionStateMap == null || partitionStateMap.isEmpty()) {
+      return;
+    }
+
+    String stateModelDefRef = currentState.getStateModelDefRef();
+    StateModelDefinition stateModelDef =
+        stateModelDefRef == null ? null : dataProvider.getStateModelDef(stateModelDefRef);
+    if (stateModelDef == null) {
+      // Without the state model we cannot tell hosted partitions from initial/dropped ones, so
+      // counting them would report a misleading value. Still count ERROR, which is model agnostic.
+      LogUtil.logWarn(logger, _eventId,
+          "Skipping actual partition counts for resource: " + currentState.getResourceName()
+              + ", unresolved state model definition: " + stateModelDefRef);
+      for (String state : partitionStateMap.values()) {
+        if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
+          counts.errorCount++;
+        }
+      }
+      return;
+    }
+
+    String topState = stateModelDef.getTopState();
+    String initialState = stateModelDef.getInitialState();
+
+    for (String state : partitionStateMap.values()) {
+      if (state == null) {
+        continue;
+      }
+      if (HelixDefinedState.ERROR.name().equalsIgnoreCase(state)) {
+        counts.errorCount++;
+      }
+      // DROPPED partitions are no longer hosted, and initial-state (e.g. OFFLINE) partitions are
+      // not yet being served, so neither counts towards what the instance actually hosts.
+      if (HelixDefinedState.DROPPED.name().equalsIgnoreCase(state)
+          || state.equalsIgnoreCase(initialState)) {
+        continue;
+      }
+      counts.actualPartitionCount++;
+      if (topState != null && topState.equalsIgnoreCase(state)) {
+        counts.actualTopStatePartitionCount++;
+      }
+    }
   }
 }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -348,24 +348,25 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
 
   /**
    * Update the gauges for all instances in the cluster, including the CurrentState-derived
-   * active-state partition gauges.
+   * actual partition gauges.
    * <p>
-   * The active-state partition counts are applied in the same {@code _instanceMonitorMap} critical
+   * The actual partition counts are applied in the same {@code _instanceMonitorMap} critical
    * section that registers and unregisters the instance beans. Updating them separately would leave
-   * a window in which a bean is registered but its active-state gauges have not been populated yet,
-   * so a live instance could briefly publish 0 for partitions it really holds.
+   * a window in which a bean is registered but its actual partition gauges have not been populated
+   * yet, so a live instance could briefly publish 0 for partitions it really holds.
    * @param errorPartitionCounts a map of instance name to the count of partitions in ERROR state
-   * @param activeStatePartitionCounts instance name to number of partitions in a non-initial state,
-   *          or null to leave the active-state partition gauges untouched
-   * @param activeStateTopStatePartitionCounts instance name to number of top-state partitions, or
-   *          null to leave the active-state top-state partition gauges untouched
+   * @param actualPartitionCounts instance name to the number of partitions the instance actually
+   *          holds according to CurrentState, or null to leave the actual partition gauges
+   *          untouched
+   * @param actualTopStatePartitionCounts instance name to number of top-state partitions, or
+   *          null to leave the actual top-state partition gauges untouched
    */
   public void setClusterInstanceStatus(Set<String> liveInstanceSet, Set<String> instanceSet,
       Set<String> disabledInstanceSet, Map<String, Map<String, List<String>>> disabledPartitions,
       Map<String, List<String>> oldDisabledPartitions, Map<String, Set<String>> tags,
       Map<String, Set<Message>> instanceMessageMap, Map<String, InstanceConfig> instanceConfigMap,
-      Map<String, Long> errorPartitionCounts, Map<String, Long> activeStatePartitionCounts,
-      Map<String, Long> activeStateTopStatePartitionCounts) {
+      Map<String, Long> errorPartitionCounts, Map<String, Long> actualPartitionCounts,
+      Map<String, Long> actualTopStatePartitionCounts) {
     synchronized (_instanceMonitorMap) {
       // Unregister beans for instances that are no longer configured
       Set<String> toUnregister = Sets.newHashSet(_instanceMonitorMap.keySet());
@@ -492,20 +493,20 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
         }
       }
 
-      // Apply the CurrentState-derived active-state partition gauges while still holding the lock,
+      // Apply the CurrentState-derived actual partition gauges while still holding the lock,
       // so that bean registration and gauge population are observed together. Registered instances
       // absent from the supplied maps (for example, instances that are no longer live) are reset
       // to 0 rather than left holding a stale value.
-      if (activeStatePartitionCounts != null || activeStateTopStatePartitionCounts != null) {
+      if (actualPartitionCounts != null || actualTopStatePartitionCounts != null) {
         for (Map.Entry<String, InstanceMonitor> entry : _instanceMonitorMap.entrySet()) {
           String instanceName = entry.getKey();
           InstanceMonitor bean = entry.getValue();
-          if (activeStatePartitionCounts != null) {
-            bean.updateActiveStatePartitionCount(activeStatePartitionCounts.getOrDefault(instanceName, 0L));
+          if (actualPartitionCounts != null) {
+            bean.updateActualPartitionCount(actualPartitionCounts.getOrDefault(instanceName, 0L));
           }
-          if (activeStateTopStatePartitionCounts != null) {
-            bean.updateActiveStateTopStatePartitionCount(
-                activeStateTopStatePartitionCounts.getOrDefault(instanceName, 0L));
+          if (actualTopStatePartitionCounts != null) {
+            bean.updateActualTopStatePartitionCount(
+                actualTopStatePartitionCounts.getOrDefault(instanceName, 0L));
           }
         }
       }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -470,6 +470,31 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   /**
+   * Updates the per-instance actual partition gauges from CurrentState-derived counts. Unlike
+   * {@link #setPerInstanceResourceStatus} which reflects the controller's target assignment, these
+   * gauges reflect what each instance actually hosts. Instances that are registered but absent from
+   * the supplied maps (for example, instances that are not live) are reset to 0.
+   * @param actualPartitionCounts instance name -&gt; number of partitions currently hosted
+   * @param actualTopStatePartitionCounts instance name -&gt; number of top-state partitions currently
+   *          hosted
+   */
+  public void setInstanceActualPartitionStatus(Map<String, Long> actualPartitionCounts,
+      Map<String, Long> actualTopStatePartitionCounts) {
+    synchronized (_instanceMonitorMap) {
+      for (Map.Entry<String, InstanceMonitor> entry : _instanceMonitorMap.entrySet()) {
+        String instanceName = entry.getKey();
+        InstanceMonitor bean = entry.getValue();
+        long actualPartitionCount = actualPartitionCounts != null
+            ? actualPartitionCounts.getOrDefault(instanceName, 0L) : 0L;
+        long actualTopStatePartitionCount = actualTopStatePartitionCounts != null
+            ? actualTopStatePartitionCounts.getOrDefault(instanceName, 0L) : 0L;
+        bean.updateActualPartitionCount(actualPartitionCount);
+        bean.updateActualTopStatePartitionCount(actualTopStatePartitionCount);
+      }
+    }
+  }
+
+  /**
    * Updates the domain info validity gauge for each instance. Instances in the invalidInstances
    * set will have their gauge set to 0 (invalid), all other registered instances will be set
    * to 1 (valid).

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -341,6 +341,31 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
       Map<String, List<String>> oldDisabledPartitions, Map<String, Set<String>> tags,
       Map<String, Set<Message>> instanceMessageMap, Map<String, InstanceConfig> instanceConfigMap,
       Map<String, Long> errorPartitionCounts) {
+    setClusterInstanceStatus(liveInstanceSet, instanceSet, disabledInstanceSet, disabledPartitions,
+        oldDisabledPartitions, tags, instanceMessageMap, instanceConfigMap, errorPartitionCounts,
+        null, null);
+  }
+
+  /**
+   * Update the gauges for all instances in the cluster, including the CurrentState-derived actual
+   * partition gauges.
+   * <p>
+   * The actual partition counts are applied in the same {@code _instanceMonitorMap} critical
+   * section that registers and unregisters the instance beans. Updating them separately would leave
+   * a window in which a bean is registered but its actual gauges have not been populated yet, so a
+   * live instance could briefly publish 0 for partitions it is really hosting.
+   * @param errorPartitionCounts a map of instance name to the count of partitions in ERROR state
+   * @param actualPartitionCounts instance name to number of partitions currently hosted, or null to
+   *          leave the actual partition gauges untouched
+   * @param actualTopStatePartitionCounts instance name to number of top-state partitions currently
+   *          hosted, or null to leave the actual top-state partition gauges untouched
+   */
+  public void setClusterInstanceStatus(Set<String> liveInstanceSet, Set<String> instanceSet,
+      Set<String> disabledInstanceSet, Map<String, Map<String, List<String>>> disabledPartitions,
+      Map<String, List<String>> oldDisabledPartitions, Map<String, Set<String>> tags,
+      Map<String, Set<Message>> instanceMessageMap, Map<String, InstanceConfig> instanceConfigMap,
+      Map<String, Long> errorPartitionCounts, Map<String, Long> actualPartitionCounts,
+      Map<String, Long> actualTopStatePartitionCounts) {
     synchronized (_instanceMonitorMap) {
       // Unregister beans for instances that are no longer configured
       Set<String> toUnregister = Sets.newHashSet(_instanceMonitorMap.keySet());
@@ -466,30 +491,23 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
           }
         }
       }
-    }
-  }
 
-  /**
-   * Updates the per-instance actual partition gauges from CurrentState-derived counts. Unlike
-   * {@link #setPerInstanceResourceStatus} which reflects the controller's target assignment, these
-   * gauges reflect what each instance actually hosts. Instances that are registered but absent from
-   * the supplied maps (for example, instances that are not live) are reset to 0.
-   * @param actualPartitionCounts instance name -&gt; number of partitions currently hosted
-   * @param actualTopStatePartitionCounts instance name -&gt; number of top-state partitions currently
-   *          hosted
-   */
-  public void setInstanceActualPartitionStatus(Map<String, Long> actualPartitionCounts,
-      Map<String, Long> actualTopStatePartitionCounts) {
-    synchronized (_instanceMonitorMap) {
-      for (Map.Entry<String, InstanceMonitor> entry : _instanceMonitorMap.entrySet()) {
-        String instanceName = entry.getKey();
-        InstanceMonitor bean = entry.getValue();
-        long actualPartitionCount = actualPartitionCounts != null
-            ? actualPartitionCounts.getOrDefault(instanceName, 0L) : 0L;
-        long actualTopStatePartitionCount = actualTopStatePartitionCounts != null
-            ? actualTopStatePartitionCounts.getOrDefault(instanceName, 0L) : 0L;
-        bean.updateActualPartitionCount(actualPartitionCount);
-        bean.updateActualTopStatePartitionCount(actualTopStatePartitionCount);
+      // Apply the CurrentState-derived actual partition gauges while still holding the lock, so
+      // that bean registration and gauge population are observed together. Registered instances
+      // absent from the supplied maps (for example, instances that are no longer live) are reset
+      // to 0 rather than left holding a stale value.
+      if (actualPartitionCounts != null || actualTopStatePartitionCounts != null) {
+        for (Map.Entry<String, InstanceMonitor> entry : _instanceMonitorMap.entrySet()) {
+          String instanceName = entry.getKey();
+          InstanceMonitor bean = entry.getValue();
+          if (actualPartitionCounts != null) {
+            bean.updateActualPartitionCount(actualPartitionCounts.getOrDefault(instanceName, 0L));
+          }
+          if (actualTopStatePartitionCounts != null) {
+            bean.updateActualTopStatePartitionCount(
+                actualTopStatePartitionCounts.getOrDefault(instanceName, 0L));
+          }
+        }
       }
     }
   }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/ClusterStatusMonitor.java
@@ -347,25 +347,25 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
   }
 
   /**
-   * Update the gauges for all instances in the cluster, including the CurrentState-derived actual
-   * partition gauges.
+   * Update the gauges for all instances in the cluster, including the CurrentState-derived
+   * active-state partition gauges.
    * <p>
-   * The actual partition counts are applied in the same {@code _instanceMonitorMap} critical
+   * The active-state partition counts are applied in the same {@code _instanceMonitorMap} critical
    * section that registers and unregisters the instance beans. Updating them separately would leave
-   * a window in which a bean is registered but its actual gauges have not been populated yet, so a
-   * live instance could briefly publish 0 for partitions it is really hosting.
+   * a window in which a bean is registered but its active-state gauges have not been populated yet,
+   * so a live instance could briefly publish 0 for partitions it really holds.
    * @param errorPartitionCounts a map of instance name to the count of partitions in ERROR state
-   * @param actualPartitionCounts instance name to number of partitions currently hosted, or null to
-   *          leave the actual partition gauges untouched
-   * @param actualTopStatePartitionCounts instance name to number of top-state partitions currently
-   *          hosted, or null to leave the actual top-state partition gauges untouched
+   * @param activeStatePartitionCounts instance name to number of partitions in a non-initial state,
+   *          or null to leave the active-state partition gauges untouched
+   * @param activeStateTopStatePartitionCounts instance name to number of top-state partitions, or
+   *          null to leave the active-state top-state partition gauges untouched
    */
   public void setClusterInstanceStatus(Set<String> liveInstanceSet, Set<String> instanceSet,
       Set<String> disabledInstanceSet, Map<String, Map<String, List<String>>> disabledPartitions,
       Map<String, List<String>> oldDisabledPartitions, Map<String, Set<String>> tags,
       Map<String, Set<Message>> instanceMessageMap, Map<String, InstanceConfig> instanceConfigMap,
-      Map<String, Long> errorPartitionCounts, Map<String, Long> actualPartitionCounts,
-      Map<String, Long> actualTopStatePartitionCounts) {
+      Map<String, Long> errorPartitionCounts, Map<String, Long> activeStatePartitionCounts,
+      Map<String, Long> activeStateTopStatePartitionCounts) {
     synchronized (_instanceMonitorMap) {
       // Unregister beans for instances that are no longer configured
       Set<String> toUnregister = Sets.newHashSet(_instanceMonitorMap.keySet());
@@ -492,20 +492,20 @@ public class ClusterStatusMonitor implements ClusterStatusMonitorMBean {
         }
       }
 
-      // Apply the CurrentState-derived actual partition gauges while still holding the lock, so
-      // that bean registration and gauge population are observed together. Registered instances
+      // Apply the CurrentState-derived active-state partition gauges while still holding the lock,
+      // so that bean registration and gauge population are observed together. Registered instances
       // absent from the supplied maps (for example, instances that are no longer live) are reset
       // to 0 rather than left holding a stale value.
-      if (actualPartitionCounts != null || actualTopStatePartitionCounts != null) {
+      if (activeStatePartitionCounts != null || activeStateTopStatePartitionCounts != null) {
         for (Map.Entry<String, InstanceMonitor> entry : _instanceMonitorMap.entrySet()) {
           String instanceName = entry.getKey();
           InstanceMonitor bean = entry.getValue();
-          if (actualPartitionCounts != null) {
-            bean.updateActualPartitionCount(actualPartitionCounts.getOrDefault(instanceName, 0L));
+          if (activeStatePartitionCounts != null) {
+            bean.updateActiveStatePartitionCount(activeStatePartitionCounts.getOrDefault(instanceName, 0L));
           }
-          if (actualTopStatePartitionCounts != null) {
-            bean.updateActualTopStatePartitionCount(
-                actualTopStatePartitionCounts.getOrDefault(instanceName, 0L));
+          if (activeStateTopStatePartitionCounts != null) {
+            bean.updateActiveStateTopStatePartitionCount(
+                activeStateTopStatePartitionCounts.getOrDefault(instanceName, 0L));
           }
         }
       }

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -61,6 +61,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     INSTANCE_OPERATION_DURATION_UNKNOWN_GAUGE("InstanceOperationDuration_UNKNOWN"),
     PARTITION_COUNT_GAUGE("PartitionGauge"),
     TOP_STATE_PARTITION_COUNT_GAUGE("TopStatePartitionGauge"),
+    ACTUAL_PARTITION_COUNT_GAUGE("ActualPartitionGauge"),
+    ACTUAL_TOP_STATE_PARTITION_COUNT_GAUGE("ActualTopStatePartitionGauge"),
     DOMAIN_INFO_VALID_GAUGE("DomainInfoValidGauge");
 
     private final String metricName;
@@ -94,6 +96,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   private SimpleDynamicMetric<Long> _errorPartitionsGauge;
   private SimpleDynamicMetric<Long> _partitionCountGauge;
   private SimpleDynamicMetric<Long> _topStatePartitionCountGauge;
+  private SimpleDynamicMetric<Long> _actualPartitionCountGauge;
+  private SimpleDynamicMetric<Long> _actualTopStatePartitionCountGauge;
   private SimpleDynamicMetric<Long> _domainInfoValidGauge;
 
   // Instance Operation Duration Gauges (in milliseconds)
@@ -161,6 +165,11 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     _topStatePartitionCountGauge =
         new SimpleDynamicMetric<>(InstanceMonitorMetric.TOP_STATE_PARTITION_COUNT_GAUGE.metricName(),
             0L);
+    _actualPartitionCountGauge =
+        new SimpleDynamicMetric<>(InstanceMonitorMetric.ACTUAL_PARTITION_COUNT_GAUGE.metricName(),
+            0L);
+    _actualTopStatePartitionCountGauge = new SimpleDynamicMetric<>(
+        InstanceMonitorMetric.ACTUAL_TOP_STATE_PARTITION_COUNT_GAUGE.metricName(), 0L);
 
     // Initialize instance operation duration gauges
     _instanceOperationDurationEnableGauge = new SimpleDynamicMetric<>(
@@ -191,6 +200,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
         _errorPartitionsGauge,
         _partitionCountGauge,
         _topStatePartitionCountGauge,
+        _actualPartitionCountGauge,
+        _actualTopStatePartitionCountGauge,
         _instanceOperationDurationEnableGauge,
         _instanceOperationDurationDisableGauge,
         _instanceOperationDurationEvacuateGauge,
@@ -235,6 +246,12 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   protected long getPartitionCount() { return _partitionCountGauge.getValue(); }
 
   protected long getTopStatePartitionCount() { return _topStatePartitionCountGauge.getValue(); }
+
+  protected long getActualPartitionCount() { return _actualPartitionCountGauge.getValue(); }
+
+  protected long getActualTopStatePartitionCount() {
+    return _actualTopStatePartitionCountGauge.getValue();
+  }
 
   protected long getDomainInfoValid() { return _domainInfoValidGauge.getValue(); }
 
@@ -472,6 +489,27 @@ public class InstanceMonitor extends DynamicMBeanProvider {
    */
   public synchronized void updateTopStatePartitionCount(long topStatePartitionCount) {
     _topStatePartitionCountGauge.updateValue(topStatePartitionCount);
+  }
+
+  /**
+   * Updates the number of partitions this instance actually hosts, as reported in its CurrentState.
+   * This is the actual-state analog of {@link #updatePartitionCount(long)}, which reflects the
+   * controller's target assignment.
+   * @param actualPartitionCount number of non-DROPPED partitions on this instance from CurrentState
+   */
+  public synchronized void updateActualPartitionCount(long actualPartitionCount) {
+    _actualPartitionCountGauge.updateValue(actualPartitionCount);
+  }
+
+  /**
+   * Updates the number of partitions this instance actually hosts in the resource top state, as
+   * reported in its CurrentState. This is the actual-state analog of
+   * {@link #updateTopStatePartitionCount(long)}, which reflects the controller's target assignment.
+   * @param actualTopStatePartitionCount number of top-state partitions on this instance from
+   *          CurrentState
+   */
+  public synchronized void updateActualTopStatePartitionCount(long actualTopStatePartitionCount) {
+    _actualTopStatePartitionCountGauge.updateValue(actualTopStatePartitionCount);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -495,7 +495,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
    * Updates the number of partitions this instance actually hosts, as reported in its CurrentState.
    * This is the actual-state analog of {@link #updatePartitionCount(long)}, which reflects the
    * controller's target assignment.
-   * @param actualPartitionCount number of non-DROPPED partitions on this instance from CurrentState
+   * @param actualPartitionCount number of partitions on this instance from CurrentState, excluding
+   *          DROPPED and initial-state (e.g. OFFLINE) partitions
    */
   public synchronized void updateActualPartitionCount(long actualPartitionCount) {
     _actualPartitionCountGauge.updateValue(actualPartitionCount);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -495,6 +495,13 @@ public class InstanceMonitor extends DynamicMBeanProvider {
    * Updates the number of partitions this instance actually hosts, as reported in its CurrentState.
    * This is the actual-state analog of {@link #updatePartitionCount(long)}, which reflects the
    * controller's target assignment.
+   * <p>
+   * Definition: partitions this instance has actually transitioned into a functional state, that
+   * is, any state other than the state model's initial state (typically OFFLINE). This is a measure
+   * of state machine progress, not of disk residency. Initial-state partitions are excluded on
+   * purpose: an instance that is live but stuck part way through its transitions would otherwise
+   * report the same count as a fully caught up one, which is exactly the condition this gauge
+   * exists to expose.
    * @param actualPartitionCount number of partitions on this instance from CurrentState, excluding
    *          initial-state (e.g. OFFLINE) partitions
    */

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -61,8 +61,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     INSTANCE_OPERATION_DURATION_UNKNOWN_GAUGE("InstanceOperationDuration_UNKNOWN"),
     PARTITION_COUNT_GAUGE("PartitionGauge"),
     TOP_STATE_PARTITION_COUNT_GAUGE("TopStatePartitionGauge"),
-    ACTUAL_PARTITION_COUNT_GAUGE("ActualPartitionGauge"),
-    ACTUAL_TOP_STATE_PARTITION_COUNT_GAUGE("ActualTopStatePartitionGauge"),
+    ACTIVE_STATE_PARTITION_COUNT_GAUGE("ActiveStatePartitionGauge"),
+    ACTIVE_STATE_TOP_STATE_PARTITION_COUNT_GAUGE("ActiveStateTopStatePartitionGauge"),
     DOMAIN_INFO_VALID_GAUGE("DomainInfoValidGauge");
 
     private final String metricName;
@@ -96,8 +96,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   private SimpleDynamicMetric<Long> _errorPartitionsGauge;
   private SimpleDynamicMetric<Long> _partitionCountGauge;
   private SimpleDynamicMetric<Long> _topStatePartitionCountGauge;
-  private SimpleDynamicMetric<Long> _actualPartitionCountGauge;
-  private SimpleDynamicMetric<Long> _actualTopStatePartitionCountGauge;
+  private SimpleDynamicMetric<Long> _activeStatePartitionCountGauge;
+  private SimpleDynamicMetric<Long> _activeStateTopStatePartitionCountGauge;
   private SimpleDynamicMetric<Long> _domainInfoValidGauge;
 
   // Instance Operation Duration Gauges (in milliseconds)
@@ -165,11 +165,11 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     _topStatePartitionCountGauge =
         new SimpleDynamicMetric<>(InstanceMonitorMetric.TOP_STATE_PARTITION_COUNT_GAUGE.metricName(),
             0L);
-    _actualPartitionCountGauge =
-        new SimpleDynamicMetric<>(InstanceMonitorMetric.ACTUAL_PARTITION_COUNT_GAUGE.metricName(),
+    _activeStatePartitionCountGauge =
+        new SimpleDynamicMetric<>(InstanceMonitorMetric.ACTIVE_STATE_PARTITION_COUNT_GAUGE.metricName(),
             0L);
-    _actualTopStatePartitionCountGauge = new SimpleDynamicMetric<>(
-        InstanceMonitorMetric.ACTUAL_TOP_STATE_PARTITION_COUNT_GAUGE.metricName(), 0L);
+    _activeStateTopStatePartitionCountGauge = new SimpleDynamicMetric<>(
+        InstanceMonitorMetric.ACTIVE_STATE_TOP_STATE_PARTITION_COUNT_GAUGE.metricName(), 0L);
 
     // Initialize instance operation duration gauges
     _instanceOperationDurationEnableGauge = new SimpleDynamicMetric<>(
@@ -200,8 +200,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
         _errorPartitionsGauge,
         _partitionCountGauge,
         _topStatePartitionCountGauge,
-        _actualPartitionCountGauge,
-        _actualTopStatePartitionCountGauge,
+        _activeStatePartitionCountGauge,
+        _activeStateTopStatePartitionCountGauge,
         _instanceOperationDurationEnableGauge,
         _instanceOperationDurationDisableGauge,
         _instanceOperationDurationEvacuateGauge,
@@ -247,10 +247,10 @@ public class InstanceMonitor extends DynamicMBeanProvider {
 
   protected long getTopStatePartitionCount() { return _topStatePartitionCountGauge.getValue(); }
 
-  protected long getActualPartitionCount() { return _actualPartitionCountGauge.getValue(); }
+  protected long getActiveStatePartitionCount() { return _activeStatePartitionCountGauge.getValue(); }
 
-  protected long getActualTopStatePartitionCount() {
-    return _actualTopStatePartitionCountGauge.getValue();
+  protected long getActiveStateTopStatePartitionCount() {
+    return _activeStateTopStatePartitionCountGauge.getValue();
   }
 
   protected long getDomainInfoValid() { return _domainInfoValidGauge.getValue(); }
@@ -492,32 +492,34 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   }
 
   /**
-   * Updates the number of partitions this instance actually hosts, as reported in its CurrentState.
-   * This is the actual-state analog of {@link #updatePartitionCount(long)}, which reflects the
-   * controller's target assignment.
+   * Updates the number of partitions this instance holds in an active state, as reported in its
+   * CurrentState. This is the observed-state counterpart of {@link #updatePartitionCount(long)},
+   * which reflects the controller's target assignment.
    * <p>
-   * Definition: partitions this instance has actually transitioned into a functional state, that
-   * is, any state other than the state model's initial state (typically OFFLINE). This is a measure
-   * of state machine progress, not of disk residency. Initial-state partitions are excluded on
-   * purpose: an instance that is live but stuck part way through its transitions would otherwise
+   * Definition: partitions this instance has transitioned into a functional state, that is, any
+   * state other than the state model's initial state (typically OFFLINE). This measures state
+   * machine progress, not disk residency: a partition may well occupy disk while sitting in the
+   * initial state, and it is deliberately not counted here. Initial-state partitions are excluded
+   * because an instance that is live but stuck part way through its transitions would otherwise
    * report the same count as a fully caught up one, which is exactly the condition this gauge
    * exists to expose.
-   * @param actualPartitionCount number of partitions on this instance from CurrentState, excluding
-   *          initial-state (e.g. OFFLINE) partitions
+   * @param activeStatePartitionCount number of partitions on this instance from CurrentState,
+   *          excluding initial-state (e.g. OFFLINE) partitions
    */
-  public synchronized void updateActualPartitionCount(long actualPartitionCount) {
-    _actualPartitionCountGauge.updateValue(actualPartitionCount);
+  public synchronized void updateActiveStatePartitionCount(long activeStatePartitionCount) {
+    _activeStatePartitionCountGauge.updateValue(activeStatePartitionCount);
   }
 
   /**
-   * Updates the number of partitions this instance actually hosts in the resource top state, as
-   * reported in its CurrentState. This is the actual-state analog of
+   * Updates the number of partitions this instance holds in the resource top state, as reported in
+   * its CurrentState. This is the observed-state counterpart of
    * {@link #updateTopStatePartitionCount(long)}, which reflects the controller's target assignment.
-   * @param actualTopStatePartitionCount number of top-state partitions on this instance from
+   * @param activeStateTopStatePartitionCount number of top-state partitions on this instance from
    *          CurrentState
    */
-  public synchronized void updateActualTopStatePartitionCount(long actualTopStatePartitionCount) {
-    _actualTopStatePartitionCountGauge.updateValue(actualTopStatePartitionCount);
+  public synchronized void updateActiveStateTopStatePartitionCount(
+      long activeStateTopStatePartitionCount) {
+    _activeStateTopStatePartitionCountGauge.updateValue(activeStateTopStatePartitionCount);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -496,7 +496,7 @@ public class InstanceMonitor extends DynamicMBeanProvider {
    * This is the actual-state analog of {@link #updatePartitionCount(long)}, which reflects the
    * controller's target assignment.
    * @param actualPartitionCount number of partitions on this instance from CurrentState, excluding
-   *          DROPPED and initial-state (e.g. OFFLINE) partitions
+   *          initial-state (e.g. OFFLINE) partitions
    */
   public synchronized void updateActualPartitionCount(long actualPartitionCount) {
     _actualPartitionCountGauge.updateValue(actualPartitionCount);

--- a/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
+++ b/helix-core/src/main/java/org/apache/helix/monitoring/mbeans/InstanceMonitor.java
@@ -61,8 +61,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     INSTANCE_OPERATION_DURATION_UNKNOWN_GAUGE("InstanceOperationDuration_UNKNOWN"),
     PARTITION_COUNT_GAUGE("PartitionGauge"),
     TOP_STATE_PARTITION_COUNT_GAUGE("TopStatePartitionGauge"),
-    ACTIVE_STATE_PARTITION_COUNT_GAUGE("ActiveStatePartitionGauge"),
-    ACTIVE_STATE_TOP_STATE_PARTITION_COUNT_GAUGE("ActiveStateTopStatePartitionGauge"),
+    ACTUAL_PARTITION_COUNT_GAUGE("ActualPartitionGauge"),
+    ACTUAL_TOP_STATE_PARTITION_COUNT_GAUGE("ActualTopStatePartitionGauge"),
     DOMAIN_INFO_VALID_GAUGE("DomainInfoValidGauge");
 
     private final String metricName;
@@ -96,8 +96,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   private SimpleDynamicMetric<Long> _errorPartitionsGauge;
   private SimpleDynamicMetric<Long> _partitionCountGauge;
   private SimpleDynamicMetric<Long> _topStatePartitionCountGauge;
-  private SimpleDynamicMetric<Long> _activeStatePartitionCountGauge;
-  private SimpleDynamicMetric<Long> _activeStateTopStatePartitionCountGauge;
+  private SimpleDynamicMetric<Long> _actualPartitionCountGauge;
+  private SimpleDynamicMetric<Long> _actualTopStatePartitionCountGauge;
   private SimpleDynamicMetric<Long> _domainInfoValidGauge;
 
   // Instance Operation Duration Gauges (in milliseconds)
@@ -165,11 +165,11 @@ public class InstanceMonitor extends DynamicMBeanProvider {
     _topStatePartitionCountGauge =
         new SimpleDynamicMetric<>(InstanceMonitorMetric.TOP_STATE_PARTITION_COUNT_GAUGE.metricName(),
             0L);
-    _activeStatePartitionCountGauge =
-        new SimpleDynamicMetric<>(InstanceMonitorMetric.ACTIVE_STATE_PARTITION_COUNT_GAUGE.metricName(),
+    _actualPartitionCountGauge =
+        new SimpleDynamicMetric<>(InstanceMonitorMetric.ACTUAL_PARTITION_COUNT_GAUGE.metricName(),
             0L);
-    _activeStateTopStatePartitionCountGauge = new SimpleDynamicMetric<>(
-        InstanceMonitorMetric.ACTIVE_STATE_TOP_STATE_PARTITION_COUNT_GAUGE.metricName(), 0L);
+    _actualTopStatePartitionCountGauge = new SimpleDynamicMetric<>(
+        InstanceMonitorMetric.ACTUAL_TOP_STATE_PARTITION_COUNT_GAUGE.metricName(), 0L);
 
     // Initialize instance operation duration gauges
     _instanceOperationDurationEnableGauge = new SimpleDynamicMetric<>(
@@ -200,8 +200,8 @@ public class InstanceMonitor extends DynamicMBeanProvider {
         _errorPartitionsGauge,
         _partitionCountGauge,
         _topStatePartitionCountGauge,
-        _activeStatePartitionCountGauge,
-        _activeStateTopStatePartitionCountGauge,
+        _actualPartitionCountGauge,
+        _actualTopStatePartitionCountGauge,
         _instanceOperationDurationEnableGauge,
         _instanceOperationDurationDisableGauge,
         _instanceOperationDurationEvacuateGauge,
@@ -247,10 +247,10 @@ public class InstanceMonitor extends DynamicMBeanProvider {
 
   protected long getTopStatePartitionCount() { return _topStatePartitionCountGauge.getValue(); }
 
-  protected long getActiveStatePartitionCount() { return _activeStatePartitionCountGauge.getValue(); }
+  protected long getActualPartitionCount() { return _actualPartitionCountGauge.getValue(); }
 
-  protected long getActiveStateTopStatePartitionCount() {
-    return _activeStateTopStatePartitionCountGauge.getValue();
+  protected long getActualTopStatePartitionCount() {
+    return _actualTopStatePartitionCountGauge.getValue();
   }
 
   protected long getDomainInfoValid() { return _domainInfoValidGauge.getValue(); }
@@ -492,34 +492,45 @@ public class InstanceMonitor extends DynamicMBeanProvider {
   }
 
   /**
-   * Updates the number of partitions this instance holds in an active state, as reported in its
-   * CurrentState. This is the observed-state counterpart of {@link #updatePartitionCount(long)},
-   * which reflects the controller's target assignment.
+   * Updates the number of partitions this instance actually holds, as reported in its CurrentState.
+   * This is the observed-state counterpart of {@link #updatePartitionCount(long)}, which reflects
+   * the controller's target assignment.
    * <p>
    * Definition: partitions this instance has transitioned into a functional state, that is, any
-   * state other than the state model's initial state (typically OFFLINE). This measures state
-   * machine progress, not disk residency: a partition may well occupy disk while sitting in the
-   * initial state, and it is deliberately not counted here. Initial-state partitions are excluded
-   * because an instance that is live but stuck part way through its transitions would otherwise
-   * report the same count as a fully caught up one, which is exactly the condition this gauge
-   * exists to expose.
-   * @param activeStatePartitionCount number of partitions on this instance from CurrentState,
-   *          excluding initial-state (e.g. OFFLINE) partitions
+   * state other than the state model's initial state (typically OFFLINE), plus the partitions that
+   * are in the initial state <i>because that is where the controller wants them</i>. The
+   * rebalancer parks a partition in the initial state when the instance is disabled, when that
+   * partition is disabled on the instance, or when the whole resource is disabled, and those
+   * partitions are counted: they are exactly where they are supposed to be.
+   * <p>
+   * A partition left in the initial state with no such reason is not counted, because it means the
+   * transition has either not finished or has failed. That is the condition this gauge exists to
+   * expose: without the exclusion, an instance stuck part way through its transitions would report
+   * the same count as a fully caught up one.
+   * <p>
+   * Note that this measures state machine progress, not disk residency. A partition may occupy
+   * disk while sitting in the initial state; whether it is counted here depends on whether being
+   * OFFLINE is intended, not on whether its data is present.
+   * @param actualPartitionCount number of partitions this instance holds according to CurrentState
    */
-  public synchronized void updateActiveStatePartitionCount(long activeStatePartitionCount) {
-    _activeStatePartitionCountGauge.updateValue(activeStatePartitionCount);
+  public synchronized void updateActualPartitionCount(long actualPartitionCount) {
+    _actualPartitionCountGauge.updateValue(actualPartitionCount);
   }
 
   /**
    * Updates the number of partitions this instance holds in the resource top state, as reported in
    * its CurrentState. This is the observed-state counterpart of
    * {@link #updateTopStatePartitionCount(long)}, which reflects the controller's target assignment.
-   * @param activeStateTopStatePartitionCount number of top-state partitions on this instance from
+   * <p>
+   * Unlike {@link #updateActualPartitionCount(long)}, this gauge has no disablement allowance to
+   * make: a disabled instance, partition, or resource has no top-state replica by design, so both
+   * this gauge and the target it is compared against are legitimately zero.
+   * @param actualTopStatePartitionCount number of top-state partitions on this instance from
    *          CurrentState
    */
-  public synchronized void updateActiveStateTopStatePartitionCount(
-      long activeStateTopStatePartitionCount) {
-    _activeStateTopStatePartitionCountGauge.updateValue(activeStateTopStatePartitionCount);
+  public synchronized void updateActualTopStatePartitionCount(
+      long actualTopStatePartitionCount) {
+    _actualTopStatePartitionCountGauge.updateValue(actualTopStatePartitionCount);
   }
 
   /**

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStagePartitionCounts.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStagePartitionCounts.java
@@ -24,10 +24,13 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
 import org.apache.helix.controller.stages.ReadClusterDataStage.InstancePartitionCounts;
 import org.apache.helix.model.BuiltInStateModelDefinitions;
 import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.model.LiveInstance.LiveInstanceProperty;
 import org.apache.helix.model.StateModelDefinition;
@@ -41,7 +44,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Covers the CurrentState-derived per-instance partition counts that back the ERROR,
- * ActiveStatePartitionGauge and ActiveStateTopStatePartitionGauge metrics.
+ * ActualPartitionGauge and ActualTopStatePartitionGauge metrics.
  */
 public class TestReadClusterDataStagePartitionCounts {
   private static final String INSTANCE = "instance_0";
@@ -89,10 +92,38 @@ public class TestReadClusterDataStagePartitionCounts {
     return currentState;
   }
 
+  /** Mark the instance itself as disabled, as {@code BaseControllerDataProvider} would report it. */
+  private void mockDisabledInstance() {
+    when(_dataProvider.getDisabledInstances()).thenReturn(Collections.singleton(INSTANCE));
+  }
+
+  /** Publish an {@link InstanceConfig} for the instance under test. */
+  private void mockInstanceConfig(InstanceConfig instanceConfig) {
+    when(_dataProvider.getInstanceConfigMap())
+        .thenReturn(Collections.singletonMap(INSTANCE, instanceConfig));
+  }
+
+  /** Disable the named partitions of {@code resourceName} on the instance under test. */
+  private void mockDisabledPartitions(String resourceName, String... partitionNames) {
+    InstanceConfig instanceConfig = new InstanceConfig(INSTANCE);
+    for (String partitionName : partitionNames) {
+      instanceConfig.setInstanceEnabledForPartition(resourceName, partitionName, false);
+    }
+    mockInstanceConfig(instanceConfig);
+  }
+
+  /** Publish an IdealState for {@code resourceName} with HELIX_ENABLED set to {@code enabled}. */
+  private void mockResourceEnabled(String resourceName, boolean enabled) {
+    IdealState idealState = new IdealState(resourceName);
+    idealState.enable(enabled);
+    when(_dataProvider.getIdealState(resourceName)).thenReturn(idealState);
+  }
+
   /**
-   * OFFLINE is the MasterSlave initial state, so those partitions are not being served and must not
-   * be reported as actually hosted. DROPPED is filtered defensively; participants subtract the
-   * partition entry rather than persisting DROPPED, so it is not expected in a real CurrentState.
+   * OFFLINE is the MasterSlave initial state. With nothing disabled, an OFFLINE partition is one
+   * whose transition has not finished, so it must not be reported as held. DROPPED is filtered
+   * defensively; participants subtract the partition entry rather than persisting DROPPED, so it is
+   * not expected in a real CurrentState.
    */
   @Test
   public void testExcludesInitialStateAndDroppedPartitions() {
@@ -106,9 +137,9 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.activeStatePartitionCount, 3L,
+    Assert.assertEquals(counts.actualPartitionCount, 3L,
         "OFFLINE must not count as actually hosted; DROPPED is filtered defensively");
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
     Assert.assertEquals(counts.errorCount, 0L);
   }
 
@@ -128,8 +159,8 @@ public class TestReadClusterDataStagePartitionCounts {
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
     Assert.assertEquals(counts.errorCount, 2L);
-    Assert.assertEquals(counts.activeStatePartitionCount, 3L);
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.actualPartitionCount, 3L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
   }
 
   /**
@@ -152,8 +183,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.activeStatePartitionCount, 4L);
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 2L,
+    Assert.assertEquals(counts.actualPartitionCount, 4L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 2L,
         "MASTER and LEADER are both top states for their own resource");
     Assert.assertEquals(counts.errorCount, 0L);
   }
@@ -163,7 +194,7 @@ public class TestReadClusterDataStagePartitionCounts {
    * no actual counts. ERROR is state model agnostic and is still counted.
    */
   @Test
-  public void testUnresolvedStateModelSkipsActiveStateCountsButKeepsErrorCount() {
+  public void testUnresolvedStateModelSkipsActualCountsButKeepsErrorCount() {
     Map<String, String> partitionStates = new HashMap<>();
     partitionStates.put("p0", "MASTER");
     partitionStates.put("p1", "ERROR");
@@ -174,8 +205,8 @@ public class TestReadClusterDataStagePartitionCounts {
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
     Assert.assertEquals(counts.errorCount, 1L);
-    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
   }
 
   /**
@@ -201,9 +232,9 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.activeStatePartitionCount, 2L,
+    Assert.assertEquals(counts.actualPartitionCount, 2L,
         "A single failing resource must not zero out counts from healthy resources");
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
   }
 
   @Test
@@ -213,8 +244,8 @@ public class TestReadClusterDataStagePartitionCounts {
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
     Assert.assertEquals(counts.errorCount, 0L);
-    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
   }
 
   /**
@@ -228,8 +259,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
     Assert.assertEquals(counts.errorCount, 0L);
   }
 
@@ -239,8 +270,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
   }
 
   /**
@@ -260,8 +291,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.activeStatePartitionCount, 1L);
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.actualPartitionCount, 1L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
     Assert.assertEquals(counts.errorCount, 0L);
   }
 
@@ -274,7 +305,184 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
-    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+  }
+
+  /**
+   * A disabled instance is deliberately held in the initial state by the rebalancer, so its OFFLINE
+   * partitions are exactly where the controller wants them and must be counted as held. Reporting
+   * zero here would make an intentionally disabled host indistinguishable from a broken one.
+   */
+  @Test
+  public void testDisabledInstanceCountsInitialStatePartitionsAsHeld() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "OFFLINE");
+    partitionStates.put("p1", "OFFLINE");
+    partitionStates.put("p2", "OFFLINE");
+    mockCurrentStates(currentState("db", MASTER_SLAVE, partitionStates));
+    mockDisabledInstance();
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 3L,
+        "A disabled instance holds its partitions OFFLINE on purpose");
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L,
+        "A disabled instance has no top-state replica, and the target it is compared against is "
+            + "zero too");
+    Assert.assertEquals(counts.errorCount, 0L);
+  }
+
+  /**
+   * Disabling every resource on an instance is expressed with the ALL_RESOURCES key rather than the
+   * DISABLE instance operation, and the data provider treats both as disabled for every partition.
+   */
+  @Test
+  public void testAllResourcesDisabledKeyCountsInitialStatePartitionsAsHeld() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "OFFLINE");
+    partitionStates.put("p1", "MASTER");
+    mockCurrentStates(currentState("db", MASTER_SLAVE, partitionStates));
+    mockDisabledPartitions(InstanceConstants.ALL_RESOURCES_DISABLED_PARTITION_KEY, "p0");
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 2L,
+        "The ALL_RESOURCES key disables the instance for every partition");
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+  }
+
+  /**
+   * A disabled resource is parked in the initial state for every instance, and the credit must not
+   * leak to resources that are still enabled.
+   */
+  @Test
+  public void testDisabledResourceCountsOnlyItsOwnInitialStatePartitions() {
+    Map<String, String> disabledResourceStates = new HashMap<>();
+    disabledResourceStates.put("p0", "OFFLINE");
+    disabledResourceStates.put("p1", "OFFLINE");
+
+    Map<String, String> enabledResourceStates = new HashMap<>();
+    enabledResourceStates.put("p0", "OFFLINE");
+    enabledResourceStates.put("p1", "LEADER");
+
+    mockCurrentStates(currentState("db", MASTER_SLAVE, disabledResourceStates),
+        currentState("service", LEADER_STANDBY, enabledResourceStates));
+    mockResourceEnabled("db", false);
+    mockResourceEnabled("service", true);
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 3L,
+        "Both partitions of the disabled resource count, but the enabled resource's OFFLINE "
+            + "partition does not");
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+  }
+
+  /**
+   * A partition disabled on this instance is held in the initial state on purpose, while an OFFLINE
+   * partition with no disablement behind it is still treated as not held.
+   */
+  @Test
+  public void testDisabledPartitionsCountAsHeldButOtherOfflinePartitionsDoNot() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "OFFLINE");
+    partitionStates.put("p1", "OFFLINE");
+    partitionStates.put("p2", "MASTER");
+    mockCurrentStates(currentState("db", MASTER_SLAVE, partitionStates));
+    mockDisabledPartitions("db", "p0");
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 2L,
+        "Only the disabled OFFLINE partition is credited, not the one that is merely OFFLINE");
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+  }
+
+  /**
+   * Disabled partitions are recorded per resource, so a partition name disabled on one resource
+   * must not credit the same partition name on another.
+   */
+  @Test
+  public void testDisabledPartitionsAreScopedToTheirOwnResource() {
+    mockCurrentStates(
+        currentState("db", MASTER_SLAVE, Collections.singletonMap("p0", "OFFLINE")),
+        currentState("service", LEADER_STANDBY, Collections.singletonMap("p0", "OFFLINE")));
+    mockDisabledPartitions("db", "p0");
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 1L,
+        "Disabling db's p0 must not credit service's p0");
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+  }
+
+  /**
+   * DROPPED means the partition is gone, which disablement does not change.
+   */
+  @Test
+  public void testDroppedIsStillExcludedWhenTheInstanceIsDisabled() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "OFFLINE");
+    partitionStates.put("p1", "DROPPED");
+    mockCurrentStates(currentState("db", MASTER_SLAVE, partitionStates));
+    mockDisabledInstance();
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 1L,
+        "Disablement credits initial-state partitions, never DROPPED ones");
+  }
+
+  /**
+   * A missing IdealState means the resource is being removed, so its partitions are on their way to
+   * DROPPED rather than parked in the initial state. That must not be read as a disabled resource.
+   */
+  @Test
+  public void testMissingIdealStateIsNotTreatedAsADisabledResource() {
+    mockCurrentStates(currentState("db", MASTER_SLAVE, Collections.singletonMap("p0", "OFFLINE")));
+    when(_dataProvider.getIdealState("db")).thenReturn(null);
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+  }
+
+  /**
+   * If the disablement lookup fails the instance's counts must still be produced. Losing the
+   * disablement credit understates the gauge, but losing the instance entirely would report zero
+   * for a healthy host.
+   */
+  @Test
+  public void testDisablementLookupFailureStillProducesCounts() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "MASTER");
+    partitionStates.put("p1", "SLAVE");
+    partitionStates.put("p2", "OFFLINE");
+    mockCurrentStates(currentState("db", MASTER_SLAVE, partitionStates));
+    when(_dataProvider.getInstanceConfigMap()).thenThrow(new RuntimeException("config read failed"));
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 2L,
+        "A failed disablement lookup degrades to no disablement rather than dropping the instance");
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+  }
+
+  /**
+   * An instance with no InstanceConfig at all must not throw, and gets no disablement credit.
+   */
+  @Test
+  public void testMissingInstanceConfigYieldsNoDisablementCredit() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "MASTER");
+    partitionStates.put("p1", "OFFLINE");
+    mockCurrentStates(currentState("db", MASTER_SLAVE, partitionStates));
+    when(_dataProvider.getInstanceConfigMap()).thenReturn(Collections.emptyMap());
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 1L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStagePartitionCounts.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStagePartitionCounts.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Covers the CurrentState-derived per-instance partition counts that back the ERROR,
- * ActualPartitionGauge and ActualTopStatePartitionGauge metrics.
+ * ActiveStatePartitionGauge and ActiveStateTopStatePartitionGauge metrics.
  */
 public class TestReadClusterDataStagePartitionCounts {
   private static final String INSTANCE = "instance_0";
@@ -106,9 +106,9 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.actualPartitionCount, 3L,
+    Assert.assertEquals(counts.activeStatePartitionCount, 3L,
         "OFFLINE must not count as actually hosted; DROPPED is filtered defensively");
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 1L);
     Assert.assertEquals(counts.errorCount, 0L);
   }
 
@@ -128,8 +128,8 @@ public class TestReadClusterDataStagePartitionCounts {
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
     Assert.assertEquals(counts.errorCount, 2L);
-    Assert.assertEquals(counts.actualPartitionCount, 3L);
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.activeStatePartitionCount, 3L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 1L);
   }
 
   /**
@@ -152,8 +152,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.actualPartitionCount, 4L);
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 2L,
+    Assert.assertEquals(counts.activeStatePartitionCount, 4L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 2L,
         "MASTER and LEADER are both top states for their own resource");
     Assert.assertEquals(counts.errorCount, 0L);
   }
@@ -163,7 +163,7 @@ public class TestReadClusterDataStagePartitionCounts {
    * no actual counts. ERROR is state model agnostic and is still counted.
    */
   @Test
-  public void testUnresolvedStateModelSkipsActualCountsButKeepsErrorCount() {
+  public void testUnresolvedStateModelSkipsActiveStateCountsButKeepsErrorCount() {
     Map<String, String> partitionStates = new HashMap<>();
     partitionStates.put("p0", "MASTER");
     partitionStates.put("p1", "ERROR");
@@ -174,8 +174,8 @@ public class TestReadClusterDataStagePartitionCounts {
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
     Assert.assertEquals(counts.errorCount, 1L);
-    Assert.assertEquals(counts.actualPartitionCount, 0L);
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
   }
 
   /**
@@ -201,9 +201,9 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.actualPartitionCount, 2L,
+    Assert.assertEquals(counts.activeStatePartitionCount, 2L,
         "A single failing resource must not zero out counts from healthy resources");
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 1L);
   }
 
   @Test
@@ -213,8 +213,8 @@ public class TestReadClusterDataStagePartitionCounts {
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
     Assert.assertEquals(counts.errorCount, 0L);
-    Assert.assertEquals(counts.actualPartitionCount, 0L);
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
   }
 
   /**
@@ -228,8 +228,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.actualPartitionCount, 0L);
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
     Assert.assertEquals(counts.errorCount, 0L);
   }
 
@@ -239,8 +239,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.actualPartitionCount, 0L);
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
   }
 
   /**
@@ -260,8 +260,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.actualPartitionCount, 1L);
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.activeStatePartitionCount, 1L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 1L);
     Assert.assertEquals(counts.errorCount, 0L);
   }
 
@@ -274,7 +274,7 @@ public class TestReadClusterDataStagePartitionCounts {
 
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
-    Assert.assertEquals(counts.actualPartitionCount, 0L);
-    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStatePartitionCount, 0L);
+    Assert.assertEquals(counts.activeStateTopStatePartitionCount, 0L);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStagePartitionCounts.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStagePartitionCounts.java
@@ -1,0 +1,279 @@
+package org.apache.helix.controller.stages;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.helix.controller.dataproviders.BaseControllerDataProvider;
+import org.apache.helix.controller.stages.ReadClusterDataStage.InstancePartitionCounts;
+import org.apache.helix.model.BuiltInStateModelDefinitions;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.LiveInstance.LiveInstanceProperty;
+import org.apache.helix.model.StateModelDefinition;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Covers the CurrentState-derived per-instance partition counts that back the ERROR,
+ * ActualPartitionGauge and ActualTopStatePartitionGauge metrics.
+ */
+public class TestReadClusterDataStagePartitionCounts {
+  private static final String INSTANCE = "instance_0";
+  private static final String SESSION = "session_0";
+  private static final String MASTER_SLAVE = "MasterSlave";
+  private static final String LEADER_STANDBY = "LeaderStandby";
+
+  private ReadClusterDataStage _stage;
+  private BaseControllerDataProvider _dataProvider;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    _stage = new ReadClusterDataStage();
+    _dataProvider = Mockito.mock(BaseControllerDataProvider.class);
+
+    LiveInstance liveInstance = new LiveInstance(INSTANCE);
+    liveInstance.getRecord()
+        .setSimpleField(LiveInstanceProperty.SESSION_ID.toString(), SESSION);
+    when(_dataProvider.getLiveInstances())
+        .thenReturn(Collections.singletonMap(INSTANCE, liveInstance));
+
+    when(_dataProvider.getStateModelDef(MASTER_SLAVE))
+        .thenReturn(stateModelDef(BuiltInStateModelDefinitions.MasterSlave));
+    when(_dataProvider.getStateModelDef(LEADER_STANDBY))
+        .thenReturn(stateModelDef(BuiltInStateModelDefinitions.LeaderStandby));
+  }
+
+  private static StateModelDefinition stateModelDef(BuiltInStateModelDefinitions definition) {
+    return definition.getStateModelDefinition();
+  }
+
+  private void mockCurrentStates(CurrentState... currentStates) {
+    Map<String, CurrentState> currentStateMap = new HashMap<>();
+    for (CurrentState currentState : currentStates) {
+      currentStateMap.put(currentState.getResourceName(), currentState);
+    }
+    when(_dataProvider.getCurrentState(INSTANCE, SESSION, false)).thenReturn(currentStateMap);
+  }
+
+  private static CurrentState currentState(String resourceName, String stateModelDefRef,
+      Map<String, String> partitionStates) {
+    CurrentState currentState = new CurrentState(resourceName);
+    currentState.setStateModelDefRef(stateModelDefRef);
+    partitionStates.forEach(currentState::setState);
+    return currentState;
+  }
+
+  /**
+   * OFFLINE is the MasterSlave initial state, so those partitions are not being served and must not
+   * be reported as actually hosted. DROPPED partitions are no longer hosted at all.
+   */
+  @Test
+  public void testExcludesInitialStateAndDroppedPartitions() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "MASTER");
+    partitionStates.put("p1", "SLAVE");
+    partitionStates.put("p2", "SLAVE");
+    partitionStates.put("p3", "OFFLINE");
+    partitionStates.put("p4", "DROPPED");
+    mockCurrentStates(currentState("db", MASTER_SLAVE, partitionStates));
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 3L,
+        "OFFLINE and DROPPED partitions must not count as actually hosted");
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.errorCount, 0L);
+  }
+
+  /**
+   * ERROR partitions are still hosted by the instance, so they count towards the actual partition
+   * count as well as the dedicated error count.
+   */
+  @Test
+  public void testErrorPartitionsCountAsHosted() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "MASTER");
+    partitionStates.put("p1", "ERROR");
+    partitionStates.put("p2", "ERROR");
+    partitionStates.put("p3", "OFFLINE");
+    mockCurrentStates(currentState("db", MASTER_SLAVE, partitionStates));
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.errorCount, 2L);
+    Assert.assertEquals(counts.actualPartitionCount, 3L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+  }
+
+  /**
+   * Counts are summed across resources, and the top state is resolved per resource rather than
+   * globally, so a LeaderStandby LEADER and a MasterSlave MASTER both count.
+   */
+  @Test
+  public void testCountsAggregateAcrossResourcesWithDifferentStateModels() {
+    Map<String, String> masterSlaveStates = new HashMap<>();
+    masterSlaveStates.put("p0", "MASTER");
+    masterSlaveStates.put("p1", "SLAVE");
+
+    Map<String, String> leaderStandbyStates = new HashMap<>();
+    leaderStandbyStates.put("p0", "LEADER");
+    leaderStandbyStates.put("p1", "STANDBY");
+    leaderStandbyStates.put("p2", "OFFLINE");
+
+    mockCurrentStates(currentState("db", MASTER_SLAVE, masterSlaveStates),
+        currentState("service", LEADER_STANDBY, leaderStandbyStates));
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 4L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 2L,
+        "MASTER and LEADER are both top states for their own resource");
+    Assert.assertEquals(counts.errorCount, 0L);
+  }
+
+  /**
+   * Without a state model definition the states cannot be interpreted, so the resource contributes
+   * no actual counts. ERROR is state model agnostic and is still counted.
+   */
+  @Test
+  public void testUnresolvedStateModelSkipsActualCountsButKeepsErrorCount() {
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "MASTER");
+    partitionStates.put("p1", "ERROR");
+    CurrentState unknown = currentState("db", "UnknownStateModel", partitionStates);
+    when(_dataProvider.getStateModelDef("UnknownStateModel")).thenReturn(null);
+    mockCurrentStates(unknown);
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.errorCount, 1L);
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+  }
+
+  /**
+   * A resource that throws while being processed must not discard the counts already accumulated
+   * from the resources that were read successfully.
+   */
+  @Test
+  public void testFailingResourceDoesNotDiscardOtherResourceCounts() {
+    Map<String, String> healthyStates = new HashMap<>();
+    healthyStates.put("p0", "MASTER");
+    healthyStates.put("p1", "SLAVE");
+
+    CurrentState failing = Mockito.mock(CurrentState.class);
+    when(failing.getResourceName()).thenReturn("broken");
+    when(failing.getPartitionStateMap()).thenThrow(new RuntimeException("boom"));
+
+    // Ordered so the failing resource is processed first, proving the failure is contained rather
+    // than abandoning the resources that follow it.
+    Map<String, CurrentState> currentStateMap = new LinkedHashMap<>();
+    currentStateMap.put("broken", failing);
+    currentStateMap.put("db", currentState("db", MASTER_SLAVE, healthyStates));
+    when(_dataProvider.getCurrentState(INSTANCE, SESSION, false)).thenReturn(currentStateMap);
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 2L,
+        "A single failing resource must not zero out counts from healthy resources");
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+  }
+
+  @Test
+  public void testNonLiveInstanceYieldsZeroCounts() {
+    when(_dataProvider.getLiveInstances()).thenReturn(Collections.emptyMap());
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.errorCount, 0L);
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+  }
+
+  /**
+   * A failure reading live instances or current states must be contained, since the caller updates
+   * every other instance metric in the same pass.
+   */
+  @Test
+  public void testCurrentStateReadFailureIsContained() {
+    when(_dataProvider.getCurrentState(INSTANCE, SESSION, false))
+        .thenThrow(new RuntimeException("zk read failed"));
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+    Assert.assertEquals(counts.errorCount, 0L);
+  }
+
+  @Test
+  public void testNullCurrentStateMapYieldsZeroCounts() {
+    when(_dataProvider.getCurrentState(INSTANCE, SESSION, false)).thenReturn(null);
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+  }
+
+  /**
+   * Partitions carrying no current state value are skipped rather than counted or throwing.
+   */
+  @Test
+  public void testNullPartitionStateIsSkipped() {
+    CurrentState withNullState = Mockito.mock(CurrentState.class);
+    when(withNullState.getResourceName()).thenReturn("db");
+    when(withNullState.getStateModelDefRef()).thenReturn(MASTER_SLAVE);
+    Map<String, String> partitionStates = new HashMap<>();
+    partitionStates.put("p0", "MASTER");
+    partitionStates.put("p1", null);
+    when(withNullState.getPartitionStateMap()).thenReturn(partitionStates);
+    when(_dataProvider.getCurrentState(INSTANCE, SESSION, false))
+        .thenReturn(Collections.singletonMap("db", withNullState));
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 1L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
+    Assert.assertEquals(counts.errorCount, 0L);
+  }
+
+  /**
+   * An instance hosting nothing must report zero rather than retaining a stale value.
+   */
+  @Test
+  public void testEmptyCurrentStateYieldsZeroCounts() {
+    mockCurrentStates(currentState("db", MASTER_SLAVE, Collections.emptyMap()));
+
+    InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
+
+    Assert.assertEquals(counts.actualPartitionCount, 0L);
+    Assert.assertEquals(counts.actualTopStatePartitionCount, 0L);
+  }
+}

--- a/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStagePartitionCounts.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/stages/TestReadClusterDataStagePartitionCounts.java
@@ -91,7 +91,8 @@ public class TestReadClusterDataStagePartitionCounts {
 
   /**
    * OFFLINE is the MasterSlave initial state, so those partitions are not being served and must not
-   * be reported as actually hosted. DROPPED partitions are no longer hosted at all.
+   * be reported as actually hosted. DROPPED is filtered defensively; participants subtract the
+   * partition entry rather than persisting DROPPED, so it is not expected in a real CurrentState.
    */
   @Test
   public void testExcludesInitialStateAndDroppedPartitions() {
@@ -106,7 +107,7 @@ public class TestReadClusterDataStagePartitionCounts {
     InstancePartitionCounts counts = _stage.computeInstancePartitionCounts(_dataProvider, INSTANCE);
 
     Assert.assertEquals(counts.actualPartitionCount, 3L,
-        "OFFLINE and DROPPED partitions must not count as actually hosted");
+        "OFFLINE must not count as actually hosted; DROPPED is filtered defensively");
     Assert.assertEquals(counts.actualTopStatePartitionCount, 1L);
     Assert.assertEquals(counts.errorCount, 0L);
   }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -670,7 +671,10 @@ public class TestClusterStatusMonitor {
     actualTopStatePartitionCounts.put("instance_1", 3L);
     actualTopStatePartitionCounts.put("instance_2", 0L);
 
-    monitor.setInstanceActualPartitionStatus(actualPartitionCounts, actualTopStatePartitionCounts);
+    monitor.setClusterInstanceStatus(instanceSet, instanceSet, Collections.emptySet(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        actualPartitionCounts, actualTopStatePartitionCounts);
 
     ObjectName instance0 = monitor.getObjectName(monitor.getInstanceBeanName("instance_0"));
     Assert.assertEquals(_server.getAttribute(instance0, "ActualPartitionGauge"), 10L);
@@ -690,20 +694,42 @@ public class TestClusterStatusMonitor {
     Assert.assertEquals(_server.getAttribute(instance0, "TopStatePartitionGauge"), 0L);
 
     // A subsequent update that no longer reports instance_0 must clear its previous value.
-    monitor.setInstanceActualPartitionStatus(Collections.singletonMap("instance_1", 5L),
-        Collections.singletonMap("instance_1", 2L));
+    monitor.setClusterInstanceStatus(instanceSet, instanceSet, Collections.emptySet(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.singletonMap("instance_1", 5L), Collections.singletonMap("instance_1", 2L));
     Assert.assertEquals(_server.getAttribute(instance0, "ActualPartitionGauge"), 0L);
     Assert.assertEquals(_server.getAttribute(instance0, "ActualTopStatePartitionGauge"), 0L);
     Assert.assertEquals(_server.getAttribute(instance1, "ActualPartitionGauge"), 5L);
     Assert.assertEquals(_server.getAttribute(instance1, "ActualTopStatePartitionGauge"), 2L);
 
-    // Null maps are tolerated and reset every registered instance.
-    monitor.setInstanceActualPartitionStatus(null, null);
-    for (String instance : instanceSet) {
-      ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
-      Assert.assertEquals(_server.getAttribute(objName, "ActualPartitionGauge"), 0L);
-      Assert.assertEquals(_server.getAttribute(objName, "ActualTopStatePartitionGauge"), 0L);
-    }
+    // An instance registered for the first time gets its counts populated in the same call, so a
+    // freshly registered bean never publishes 0 for partitions it is really hosting.
+    Set<String> grownInstanceSet = new HashSet<>(instanceSet);
+    grownInstanceSet.add("instance_4");
+    monitor.setClusterInstanceStatus(grownInstanceSet, grownInstanceSet, Collections.emptySet(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.singletonMap("instance_4", 9L), Collections.singletonMap("instance_4", 6L));
+    ObjectName instance4 = monitor.getObjectName(monitor.getInstanceBeanName("instance_4"));
+    Assert.assertTrue(_server.isRegistered(instance4));
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
+
+    // Null maps mean "no information supplied" and must leave the existing gauges untouched,
+    // so callers that do not compute these counts cannot zero them out.
+    monitor.setClusterInstanceStatus(grownInstanceSet, grownInstanceSet, Collections.emptySet(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), null, null);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
+
+    // The backward-compatible overload likewise leaves the actual gauges alone.
+    monitor.setClusterInstanceStatus(grownInstanceSet, grownInstanceSet, Collections.emptySet(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
 
     monitor.reset();
     Assert.assertFalse(_server.isRegistered(clusterMonitorObjName));

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -632,6 +632,83 @@ public class TestClusterStatusMonitor {
     Assert.assertFalse(_server.isRegistered(clusterMonitorObjName));
   }
 
+  @Test
+  public void testSetInstanceActualPartitionStatus() throws Exception {
+    String clusterName = "TestCluster_ActualPartitionStatus";
+    ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
+    monitor.active();
+
+    ObjectName clusterMonitorObjName = monitor.getObjectName(monitor.clusterBeanName());
+    Assert.assertTrue(_server.isRegistered(clusterMonitorObjName));
+
+    int numInstances = 4;
+    Set<String> instanceSet = Sets.newHashSet();
+    for (int i = 0; i < numInstances; i++) {
+      instanceSet.add("instance_" + i);
+    }
+
+    // Register instance monitors via setClusterInstanceStatus
+    monitor.setClusterInstanceStatus(instanceSet, instanceSet, Collections.emptySet(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+
+    // Gauges default to 0 before any actual-state update.
+    for (String instance : instanceSet) {
+      ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
+      Assert.assertTrue(_server.isRegistered(objName));
+      Assert.assertEquals(_server.getAttribute(objName, "ActualPartitionGauge"), 0L);
+      Assert.assertEquals(_server.getAttribute(objName, "ActualTopStatePartitionGauge"), 0L);
+    }
+
+    // instance_3 is intentionally absent, standing in for an instance that is not live.
+    Map<String, Long> actualPartitionCounts = Maps.newHashMap();
+    actualPartitionCounts.put("instance_0", 10L);
+    actualPartitionCounts.put("instance_1", 7L);
+    actualPartitionCounts.put("instance_2", 0L);
+    Map<String, Long> actualTopStatePartitionCounts = Maps.newHashMap();
+    actualTopStatePartitionCounts.put("instance_0", 4L);
+    actualTopStatePartitionCounts.put("instance_1", 3L);
+    actualTopStatePartitionCounts.put("instance_2", 0L);
+
+    monitor.setInstanceActualPartitionStatus(actualPartitionCounts, actualTopStatePartitionCounts);
+
+    ObjectName instance0 = monitor.getObjectName(monitor.getInstanceBeanName("instance_0"));
+    Assert.assertEquals(_server.getAttribute(instance0, "ActualPartitionGauge"), 10L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActualTopStatePartitionGauge"), 4L);
+
+    ObjectName instance1 = monitor.getObjectName(monitor.getInstanceBeanName("instance_1"));
+    Assert.assertEquals(_server.getAttribute(instance1, "ActualPartitionGauge"), 7L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActualTopStatePartitionGauge"), 3L);
+
+    // Instances missing from the supplied maps are reset to 0 rather than left stale.
+    ObjectName instance3 = monitor.getObjectName(monitor.getInstanceBeanName("instance_3"));
+    Assert.assertEquals(_server.getAttribute(instance3, "ActualPartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance3, "ActualTopStatePartitionGauge"), 0L);
+
+    // The actual gauges are independent of the best-possible PartitionGauge on the same bean.
+    Assert.assertEquals(_server.getAttribute(instance0, "PartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance0, "TopStatePartitionGauge"), 0L);
+
+    // A subsequent update that no longer reports instance_0 must clear its previous value.
+    monitor.setInstanceActualPartitionStatus(Collections.singletonMap("instance_1", 5L),
+        Collections.singletonMap("instance_1", 2L));
+    Assert.assertEquals(_server.getAttribute(instance0, "ActualPartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActualTopStatePartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActualPartitionGauge"), 5L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActualTopStatePartitionGauge"), 2L);
+
+    // Null maps are tolerated and reset every registered instance.
+    monitor.setInstanceActualPartitionStatus(null, null);
+    for (String instance : instanceSet) {
+      ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
+      Assert.assertEquals(_server.getAttribute(objName, "ActualPartitionGauge"), 0L);
+      Assert.assertEquals(_server.getAttribute(objName, "ActualTopStatePartitionGauge"), 0L);
+    }
+
+    monitor.reset();
+    Assert.assertFalse(_server.isRegistered(clusterMonitorObjName));
+  }
+
   private void verifyCapacityMetrics(ClusterStatusMonitor monitor, Map<String, Double> maxUsageMap,
       Map<String, Map<String, Integer>> instanceCapacityMap)
       throws MalformedObjectNameException, IOException, AttributeNotFoundException, MBeanException,

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -634,8 +634,8 @@ public class TestClusterStatusMonitor {
   }
 
   @Test
-  public void testSetInstanceActiveStatePartitionStatus() throws Exception {
-    String clusterName = "TestCluster_ActiveStatePartitionStatus";
+  public void testSetClusterInstanceStatusActualPartitionGauges() throws Exception {
+    String clusterName = "TestCluster_ActualPartitionStatus";
     ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
     monitor.active();
 
@@ -653,41 +653,41 @@ public class TestClusterStatusMonitor {
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
 
-    // Gauges default to 0 before any actual-state update.
+    // Gauges default to 0 before any actual partition count update.
     for (String instance : instanceSet) {
       ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
       Assert.assertTrue(_server.isRegistered(objName));
-      Assert.assertEquals(_server.getAttribute(objName, "ActiveStatePartitionGauge"), 0L);
-      Assert.assertEquals(_server.getAttribute(objName, "ActiveStateTopStatePartitionGauge"), 0L);
+      Assert.assertEquals(_server.getAttribute(objName, "ActualPartitionGauge"), 0L);
+      Assert.assertEquals(_server.getAttribute(objName, "ActualTopStatePartitionGauge"), 0L);
     }
 
     // instance_3 is intentionally absent, standing in for an instance that is not live.
-    Map<String, Long> activeStatePartitionCounts = Maps.newHashMap();
-    activeStatePartitionCounts.put("instance_0", 10L);
-    activeStatePartitionCounts.put("instance_1", 7L);
-    activeStatePartitionCounts.put("instance_2", 0L);
-    Map<String, Long> activeStateTopStatePartitionCounts = Maps.newHashMap();
-    activeStateTopStatePartitionCounts.put("instance_0", 4L);
-    activeStateTopStatePartitionCounts.put("instance_1", 3L);
-    activeStateTopStatePartitionCounts.put("instance_2", 0L);
+    Map<String, Long> actualPartitionCounts = Maps.newHashMap();
+    actualPartitionCounts.put("instance_0", 10L);
+    actualPartitionCounts.put("instance_1", 7L);
+    actualPartitionCounts.put("instance_2", 0L);
+    Map<String, Long> actualTopStatePartitionCounts = Maps.newHashMap();
+    actualTopStatePartitionCounts.put("instance_0", 4L);
+    actualTopStatePartitionCounts.put("instance_1", 3L);
+    actualTopStatePartitionCounts.put("instance_2", 0L);
 
     monitor.setClusterInstanceStatus(instanceSet, instanceSet, Collections.emptySet(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-        activeStatePartitionCounts, activeStateTopStatePartitionCounts);
+        actualPartitionCounts, actualTopStatePartitionCounts);
 
     ObjectName instance0 = monitor.getObjectName(monitor.getInstanceBeanName("instance_0"));
-    Assert.assertEquals(_server.getAttribute(instance0, "ActiveStatePartitionGauge"), 10L);
-    Assert.assertEquals(_server.getAttribute(instance0, "ActiveStateTopStatePartitionGauge"), 4L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActualPartitionGauge"), 10L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActualTopStatePartitionGauge"), 4L);
 
     ObjectName instance1 = monitor.getObjectName(monitor.getInstanceBeanName("instance_1"));
-    Assert.assertEquals(_server.getAttribute(instance1, "ActiveStatePartitionGauge"), 7L);
-    Assert.assertEquals(_server.getAttribute(instance1, "ActiveStateTopStatePartitionGauge"), 3L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActualPartitionGauge"), 7L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActualTopStatePartitionGauge"), 3L);
 
     // Instances missing from the supplied maps are reset to 0 rather than left stale.
     ObjectName instance3 = monitor.getObjectName(monitor.getInstanceBeanName("instance_3"));
-    Assert.assertEquals(_server.getAttribute(instance3, "ActiveStatePartitionGauge"), 0L);
-    Assert.assertEquals(_server.getAttribute(instance3, "ActiveStateTopStatePartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance3, "ActualPartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance3, "ActualTopStatePartitionGauge"), 0L);
 
     // The actual gauges are independent of the best-possible PartitionGauge on the same bean.
     Assert.assertEquals(_server.getAttribute(instance0, "PartitionGauge"), 0L);
@@ -698,10 +698,10 @@ public class TestClusterStatusMonitor {
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.singletonMap("instance_1", 5L), Collections.singletonMap("instance_1", 2L));
-    Assert.assertEquals(_server.getAttribute(instance0, "ActiveStatePartitionGauge"), 0L);
-    Assert.assertEquals(_server.getAttribute(instance0, "ActiveStateTopStatePartitionGauge"), 0L);
-    Assert.assertEquals(_server.getAttribute(instance1, "ActiveStatePartitionGauge"), 5L);
-    Assert.assertEquals(_server.getAttribute(instance1, "ActiveStateTopStatePartitionGauge"), 2L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActualPartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActualTopStatePartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActualPartitionGauge"), 5L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActualTopStatePartitionGauge"), 2L);
 
     // An instance registered for the first time gets its counts populated in the same call, so a
     // freshly registered bean never publishes 0 for partitions it is really hosting.
@@ -713,23 +713,23 @@ public class TestClusterStatusMonitor {
         Collections.singletonMap("instance_4", 9L), Collections.singletonMap("instance_4", 6L));
     ObjectName instance4 = monitor.getObjectName(monitor.getInstanceBeanName("instance_4"));
     Assert.assertTrue(_server.isRegistered(instance4));
-    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStatePartitionGauge"), 9L);
-    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStateTopStatePartitionGauge"), 6L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
 
     // Null maps mean "no information supplied" and must leave the existing gauges untouched,
     // so callers that do not compute these counts cannot zero them out.
     monitor.setClusterInstanceStatus(grownInstanceSet, grownInstanceSet, Collections.emptySet(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), null, null);
-    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStatePartitionGauge"), 9L);
-    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStateTopStatePartitionGauge"), 6L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
 
     // The backward-compatible overload likewise leaves the actual gauges alone.
     monitor.setClusterInstanceStatus(grownInstanceSet, grownInstanceSet, Collections.emptySet(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
-    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStatePartitionGauge"), 9L);
-    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStateTopStatePartitionGauge"), 6L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
 
     monitor.reset();
     Assert.assertFalse(_server.isRegistered(clusterMonitorObjName));

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestClusterStatusMonitor.java
@@ -634,8 +634,8 @@ public class TestClusterStatusMonitor {
   }
 
   @Test
-  public void testSetInstanceActualPartitionStatus() throws Exception {
-    String clusterName = "TestCluster_ActualPartitionStatus";
+  public void testSetInstanceActiveStatePartitionStatus() throws Exception {
+    String clusterName = "TestCluster_ActiveStatePartitionStatus";
     ClusterStatusMonitor monitor = new ClusterStatusMonitor(clusterName);
     monitor.active();
 
@@ -657,37 +657,37 @@ public class TestClusterStatusMonitor {
     for (String instance : instanceSet) {
       ObjectName objName = monitor.getObjectName(monitor.getInstanceBeanName(instance));
       Assert.assertTrue(_server.isRegistered(objName));
-      Assert.assertEquals(_server.getAttribute(objName, "ActualPartitionGauge"), 0L);
-      Assert.assertEquals(_server.getAttribute(objName, "ActualTopStatePartitionGauge"), 0L);
+      Assert.assertEquals(_server.getAttribute(objName, "ActiveStatePartitionGauge"), 0L);
+      Assert.assertEquals(_server.getAttribute(objName, "ActiveStateTopStatePartitionGauge"), 0L);
     }
 
     // instance_3 is intentionally absent, standing in for an instance that is not live.
-    Map<String, Long> actualPartitionCounts = Maps.newHashMap();
-    actualPartitionCounts.put("instance_0", 10L);
-    actualPartitionCounts.put("instance_1", 7L);
-    actualPartitionCounts.put("instance_2", 0L);
-    Map<String, Long> actualTopStatePartitionCounts = Maps.newHashMap();
-    actualTopStatePartitionCounts.put("instance_0", 4L);
-    actualTopStatePartitionCounts.put("instance_1", 3L);
-    actualTopStatePartitionCounts.put("instance_2", 0L);
+    Map<String, Long> activeStatePartitionCounts = Maps.newHashMap();
+    activeStatePartitionCounts.put("instance_0", 10L);
+    activeStatePartitionCounts.put("instance_1", 7L);
+    activeStatePartitionCounts.put("instance_2", 0L);
+    Map<String, Long> activeStateTopStatePartitionCounts = Maps.newHashMap();
+    activeStateTopStatePartitionCounts.put("instance_0", 4L);
+    activeStateTopStatePartitionCounts.put("instance_1", 3L);
+    activeStateTopStatePartitionCounts.put("instance_2", 0L);
 
     monitor.setClusterInstanceStatus(instanceSet, instanceSet, Collections.emptySet(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-        actualPartitionCounts, actualTopStatePartitionCounts);
+        activeStatePartitionCounts, activeStateTopStatePartitionCounts);
 
     ObjectName instance0 = monitor.getObjectName(monitor.getInstanceBeanName("instance_0"));
-    Assert.assertEquals(_server.getAttribute(instance0, "ActualPartitionGauge"), 10L);
-    Assert.assertEquals(_server.getAttribute(instance0, "ActualTopStatePartitionGauge"), 4L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActiveStatePartitionGauge"), 10L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActiveStateTopStatePartitionGauge"), 4L);
 
     ObjectName instance1 = monitor.getObjectName(monitor.getInstanceBeanName("instance_1"));
-    Assert.assertEquals(_server.getAttribute(instance1, "ActualPartitionGauge"), 7L);
-    Assert.assertEquals(_server.getAttribute(instance1, "ActualTopStatePartitionGauge"), 3L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActiveStatePartitionGauge"), 7L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActiveStateTopStatePartitionGauge"), 3L);
 
     // Instances missing from the supplied maps are reset to 0 rather than left stale.
     ObjectName instance3 = monitor.getObjectName(monitor.getInstanceBeanName("instance_3"));
-    Assert.assertEquals(_server.getAttribute(instance3, "ActualPartitionGauge"), 0L);
-    Assert.assertEquals(_server.getAttribute(instance3, "ActualTopStatePartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance3, "ActiveStatePartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance3, "ActiveStateTopStatePartitionGauge"), 0L);
 
     // The actual gauges are independent of the best-possible PartitionGauge on the same bean.
     Assert.assertEquals(_server.getAttribute(instance0, "PartitionGauge"), 0L);
@@ -698,10 +698,10 @@ public class TestClusterStatusMonitor {
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.singletonMap("instance_1", 5L), Collections.singletonMap("instance_1", 2L));
-    Assert.assertEquals(_server.getAttribute(instance0, "ActualPartitionGauge"), 0L);
-    Assert.assertEquals(_server.getAttribute(instance0, "ActualTopStatePartitionGauge"), 0L);
-    Assert.assertEquals(_server.getAttribute(instance1, "ActualPartitionGauge"), 5L);
-    Assert.assertEquals(_server.getAttribute(instance1, "ActualTopStatePartitionGauge"), 2L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActiveStatePartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance0, "ActiveStateTopStatePartitionGauge"), 0L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActiveStatePartitionGauge"), 5L);
+    Assert.assertEquals(_server.getAttribute(instance1, "ActiveStateTopStatePartitionGauge"), 2L);
 
     // An instance registered for the first time gets its counts populated in the same call, so a
     // freshly registered bean never publishes 0 for partitions it is really hosting.
@@ -713,23 +713,23 @@ public class TestClusterStatusMonitor {
         Collections.singletonMap("instance_4", 9L), Collections.singletonMap("instance_4", 6L));
     ObjectName instance4 = monitor.getObjectName(monitor.getInstanceBeanName("instance_4"));
     Assert.assertTrue(_server.isRegistered(instance4));
-    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
-    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStatePartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStateTopStatePartitionGauge"), 6L);
 
     // Null maps mean "no information supplied" and must leave the existing gauges untouched,
     // so callers that do not compute these counts cannot zero them out.
     monitor.setClusterInstanceStatus(grownInstanceSet, grownInstanceSet, Collections.emptySet(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), null, null);
-    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
-    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStatePartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStateTopStatePartitionGauge"), 6L);
 
     // The backward-compatible overload likewise leaves the actual gauges alone.
     monitor.setClusterInstanceStatus(grownInstanceSet, grownInstanceSet, Collections.emptySet(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
         Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
-    Assert.assertEquals(_server.getAttribute(instance4, "ActualPartitionGauge"), 9L);
-    Assert.assertEquals(_server.getAttribute(instance4, "ActualTopStatePartitionGauge"), 6L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStatePartitionGauge"), 9L);
+    Assert.assertEquals(_server.getAttribute(instance4, "ActiveStateTopStatePartitionGauge"), 6L);
 
     monitor.reset();
     Assert.assertFalse(_server.isRegistered(clusterMonitorObjName));

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
@@ -398,7 +398,7 @@ public class TestInstanceMonitor {
   }
 
   @Test
-  public void testActualPartitionCountMetrics() throws JMException {
+  public void testActiveStatePartitionCountMetrics() throws JMException {
     String testCluster = "testCluster";
     String testInstance = "testInstance";
     String testDomain = "testDomain:key=value";
@@ -406,34 +406,34 @@ public class TestInstanceMonitor {
         new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
 
     // Verify initial state
-    Assert.assertEquals(monitor.getActualPartitionCount(), 0L);
-    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 0L);
+    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 0L);
+    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 0L);
 
     // Update actual partition counts
-    monitor.updateActualPartitionCount(15L);
-    monitor.updateActualTopStatePartitionCount(4L);
+    monitor.updateActiveStatePartitionCount(15L);
+    monitor.updateActiveStateTopStatePartitionCount(4L);
 
     // Verify updated values
-    Assert.assertEquals(monitor.getActualPartitionCount(), 15L);
-    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 4L);
+    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 15L);
+    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 4L);
 
     // Actual gauges are independent from the target partition gauges
     monitor.updatePartitionCount(3L);
     monitor.updateTopStatePartitionCount(1L);
-    Assert.assertEquals(monitor.getActualPartitionCount(), 15L);
-    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 4L);
+    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 15L);
+    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 4L);
 
     // Update again with different values
-    monitor.updateActualPartitionCount(22L);
-    monitor.updateActualTopStatePartitionCount(9L);
-    Assert.assertEquals(monitor.getActualPartitionCount(), 22L);
-    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 9L);
+    monitor.updateActiveStatePartitionCount(22L);
+    monitor.updateActiveStateTopStatePartitionCount(9L);
+    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 22L);
+    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 9L);
 
     // Test with zero counts
-    monitor.updateActualPartitionCount(0L);
-    monitor.updateActualTopStatePartitionCount(0L);
-    Assert.assertEquals(monitor.getActualPartitionCount(), 0L);
-    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 0L);
+    monitor.updateActiveStatePartitionCount(0L);
+    monitor.updateActiveStateTopStatePartitionCount(0L);
+    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 0L);
+    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 0L);
 
     monitor.unregister();
   }

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
@@ -398,6 +398,47 @@ public class TestInstanceMonitor {
   }
 
   @Test
+  public void testActualPartitionCountMetrics() throws JMException {
+    String testCluster = "testCluster";
+    String testInstance = "testInstance";
+    String testDomain = "testDomain:key=value";
+    InstanceMonitor monitor =
+        new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
+
+    // Verify initial state
+    Assert.assertEquals(monitor.getActualPartitionCount(), 0L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 0L);
+
+    // Update actual partition counts
+    monitor.updateActualPartitionCount(15L);
+    monitor.updateActualTopStatePartitionCount(4L);
+
+    // Verify updated values
+    Assert.assertEquals(monitor.getActualPartitionCount(), 15L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 4L);
+
+    // Actual gauges are independent from the target partition gauges
+    monitor.updatePartitionCount(3L);
+    monitor.updateTopStatePartitionCount(1L);
+    Assert.assertEquals(monitor.getActualPartitionCount(), 15L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 4L);
+
+    // Update again with different values
+    monitor.updateActualPartitionCount(22L);
+    monitor.updateActualTopStatePartitionCount(9L);
+    Assert.assertEquals(monitor.getActualPartitionCount(), 22L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 9L);
+
+    // Test with zero counts
+    monitor.updateActualPartitionCount(0L);
+    monitor.updateActualTopStatePartitionCount(0L);
+    Assert.assertEquals(monitor.getActualPartitionCount(), 0L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 0L);
+
+    monitor.unregister();
+  }
+
+  @Test
   public void testErrorPartitionsWithDisabledPartitions() throws JMException {
     String testCluster = "testCluster";
     String testInstance = "testInstance";

--- a/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
+++ b/helix-core/src/test/java/org/apache/helix/monitoring/mbeans/TestInstanceMonitor.java
@@ -398,7 +398,7 @@ public class TestInstanceMonitor {
   }
 
   @Test
-  public void testActiveStatePartitionCountMetrics() throws JMException {
+  public void testActualPartitionCountMetrics() throws JMException {
     String testCluster = "testCluster";
     String testInstance = "testInstance";
     String testDomain = "testDomain:key=value";
@@ -406,34 +406,34 @@ public class TestInstanceMonitor {
         new InstanceMonitor(testCluster, testInstance, new ObjectName(testDomain));
 
     // Verify initial state
-    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 0L);
-    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 0L);
+    Assert.assertEquals(monitor.getActualPartitionCount(), 0L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 0L);
 
     // Update actual partition counts
-    monitor.updateActiveStatePartitionCount(15L);
-    monitor.updateActiveStateTopStatePartitionCount(4L);
+    monitor.updateActualPartitionCount(15L);
+    monitor.updateActualTopStatePartitionCount(4L);
 
     // Verify updated values
-    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 15L);
-    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 4L);
+    Assert.assertEquals(monitor.getActualPartitionCount(), 15L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 4L);
 
     // Actual gauges are independent from the target partition gauges
     monitor.updatePartitionCount(3L);
     monitor.updateTopStatePartitionCount(1L);
-    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 15L);
-    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 4L);
+    Assert.assertEquals(monitor.getActualPartitionCount(), 15L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 4L);
 
     // Update again with different values
-    monitor.updateActiveStatePartitionCount(22L);
-    monitor.updateActiveStateTopStatePartitionCount(9L);
-    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 22L);
-    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 9L);
+    monitor.updateActualPartitionCount(22L);
+    monitor.updateActualTopStatePartitionCount(9L);
+    Assert.assertEquals(monitor.getActualPartitionCount(), 22L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 9L);
 
     // Test with zero counts
-    monitor.updateActiveStatePartitionCount(0L);
-    monitor.updateActiveStateTopStatePartitionCount(0L);
-    Assert.assertEquals(monitor.getActiveStatePartitionCount(), 0L);
-    Assert.assertEquals(monitor.getActiveStateTopStatePartitionCount(), 0L);
+    monitor.updateActualPartitionCount(0L);
+    monitor.updateActualTopStatePartitionCount(0L);
+    Assert.assertEquals(monitor.getActualPartitionCount(), 0L);
+    Assert.assertEquals(monitor.getActualTopStatePartitionCount(), 0L);
 
     monitor.unregister();
   }

--- a/website/1.4.3/src/site/markdown/Metrics.md
+++ b/website/1.4.3/src/site/markdown/Metrics.md
@@ -110,8 +110,8 @@ ObjectName: "ClusterStatus:cluster=[cluster-name],instanceName=[instance-name]"
 |DisabledPartitions|Get the total disabled partitions number for this instance|
 |PartitionGauge|Get number of partitions assigned to this instance in the best possible state|
 |TopStatePartitionGauge|Get number of partitions assigned to this instance in the top state in the best possible state|
-|ActiveStatePartitionGauge|Get number of partitions this instance holds in an active state according to its CurrentState, that is, any state other than the state model's initial state (e.g. OFFLINE). Measures state transition progress, not disk residency|
-|ActiveStateTopStatePartitionGauge|Get number of partitions this instance holds in the resource top state according to its CurrentState|
+|ActualPartitionGauge|Get number of partitions this instance actually holds according to its CurrentState. Counts any state other than the state model's initial state (e.g. OFFLINE), plus partitions held in the initial state on purpose because the instance, the partition, or the resource is disabled. Partitions left in the initial state for any other reason are not counted, since that means the transition has not finished or has failed|
+|ActualTopStatePartitionGauge|Get number of partitions this instance holds in the resource top state according to its CurrentState|
 
 #### MBean ResourceMonitor
 ObjectName: "ClusterStatus:cluster=[cluster-name],resourceName=[resource-name]"

--- a/website/1.4.3/src/site/markdown/Metrics.md
+++ b/website/1.4.3/src/site/markdown/Metrics.md
@@ -110,7 +110,7 @@ ObjectName: "ClusterStatus:cluster=[cluster-name],instanceName=[instance-name]"
 |DisabledPartitions|Get the total disabled partitions number for this instance|
 |PartitionGauge|Get number of partitions assigned to this instance in the best possible state|
 |TopStatePartitionGauge|Get number of partitions assigned to this instance in the top state in the best possible state|
-|ActualPartitionGauge|Get number of partitions this instance actually hosts according to its CurrentState, excluding DROPPED and initial-state (e.g. OFFLINE) partitions|
+|ActualPartitionGauge|Get number of partitions this instance actually hosts according to its CurrentState, excluding initial-state (e.g. OFFLINE) partitions|
 |ActualTopStatePartitionGauge|Get number of partitions this instance actually hosts in the resource top state according to its CurrentState|
 
 #### MBean ResourceMonitor

--- a/website/1.4.3/src/site/markdown/Metrics.md
+++ b/website/1.4.3/src/site/markdown/Metrics.md
@@ -108,6 +108,10 @@ ObjectName: "ClusterStatus:cluster=[cluster-name],instanceName=[instance-name]"
 |Enabled|This instance is Enabled (1) or Disabled (0)|
 |TotalMessageReceived|Number of messages sent to this instance by controller|
 |DisabledPartitions|Get the total disabled partitions number for this instance|
+|PartitionGauge|Get number of partitions assigned to this instance in the best possible state|
+|TopStatePartitionGauge|Get number of partitions assigned to this instance in the top state in the best possible state|
+|ActualPartitionGauge|Get number of partitions this instance actually hosts according to its CurrentState, excluding DROPPED and initial-state (e.g. OFFLINE) partitions|
+|ActualTopStatePartitionGauge|Get number of partitions this instance actually hosts in the resource top state according to its CurrentState|
 
 #### MBean ResourceMonitor
 ObjectName: "ClusterStatus:cluster=[cluster-name],resourceName=[resource-name]"

--- a/website/1.4.3/src/site/markdown/Metrics.md
+++ b/website/1.4.3/src/site/markdown/Metrics.md
@@ -110,8 +110,8 @@ ObjectName: "ClusterStatus:cluster=[cluster-name],instanceName=[instance-name]"
 |DisabledPartitions|Get the total disabled partitions number for this instance|
 |PartitionGauge|Get number of partitions assigned to this instance in the best possible state|
 |TopStatePartitionGauge|Get number of partitions assigned to this instance in the top state in the best possible state|
-|ActualPartitionGauge|Get number of partitions this instance actually hosts according to its CurrentState, excluding initial-state (e.g. OFFLINE) partitions|
-|ActualTopStatePartitionGauge|Get number of partitions this instance actually hosts in the resource top state according to its CurrentState|
+|ActiveStatePartitionGauge|Get number of partitions this instance holds in an active state according to its CurrentState, that is, any state other than the state model's initial state (e.g. OFFLINE). Measures state transition progress, not disk residency|
+|ActiveStateTopStatePartitionGauge|Get number of partitions this instance holds in the resource top state according to its CurrentState|
 
 #### MBean ResourceMonitor
 ObjectName: "ClusterStatus:cluster=[cluster-name],resourceName=[resource-name]"


### PR DESCRIPTION

# PR Description

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:
(https://github.com/linkedin/helix/pull/200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Adds two per-instance MBean gauges sourced from each instance's `CurrentState`:

| Attribute | Meaning |
|---|---|
| `ActualPartitionGauge` | Partitions the instance actually hosts, excluding initial-state (typically OFFLINE) partitions |
| `ActualTopStatePartitionGauge` | Of those, how many are in the resource top state (MASTER, LEADER, ...) |

**Why:** The existing `InstanceMonitor.PartitionGauge` and `TopStatePartitionGauge` are derived
from `BestPossibleStateOutput`, so they describe what the Sharding Controller *intends* to place on
an instance. There is currently no per-instance metric for what an instance is *actually* hosting.
Without it, an instance that is failing to complete state transitions looks identical to a healthy
one, since the target assignment is reported either way. These gauges make the gap between intent
and reality directly observable per instance.

**How:** The counts are computed in `ReadClusterDataStage`, in the same single pass over
`CurrentState` that already produces the per-instance ERROR partition count, so no additional
ZooKeeper read or extra traversal is introduced. They are routed to the instance beans through a
new `ClusterStatusMonitor#setInstanceActualPartitionStatus` entry point, which also resets
instances that are absent from the update (for example, instances that are no longer live) so that
values cannot go stale.

Counting convention, matching the one `PerInstanceResourceMonitor#update` already uses: a partition
counts as hosted when its state is not the state model's initial state. DROPPED is filtered
defensively only. On a successful drop the participant writes a `MergeOperation.SUBTRACT` delta that
removes the partition entry from `CurrentState` rather than persisting DROPPED, so DROPPED is not
expected to be observable there (see `HelixStateTransitionHandler`, lines 167 to 174).

Resources whose state model definition cannot be resolved are skipped for the actual counts, since
their states cannot be interpreted, but ERROR is still counted because that state is state model
agnostic. Failures are contained per resource, so one unreadable resource cannot discard the counts
already accumulated for an instance.

**Files changed**

```
 helix-core/.../controller/stages/ReadClusterDataStage.java         | 155 +++++++---
 helix-core/.../monitoring/mbeans/ClusterStatusMonitor.java         |  25 ++
 helix-core/.../monitoring/mbeans/InstanceMonitor.java              |  39 +++
 helix-core/.../stages/TestReadClusterDataStagePartitionCounts.java | 280 +++++++++++++++
 helix-core/.../monitoring/mbeans/TestClusterStatusMonitor.java     |  77 ++++++
 helix-core/.../monitoring/mbeans/TestInstanceMonitor.java          |  41 +++
 website/1.4.3/src/site/markdown/Metrics.md                         |   4 +
 7 files changed, 583 insertions(+), 38 deletions(-)
```

### Tests

- [x] The following tests are written for this issue:

`TestReadClusterDataStagePartitionCounts` (new, 10 tests covering the count computation):

- `testExcludesInitialStateAndDroppedPartitions`
- `testErrorPartitionsCountAsHosted`
- `testCountsAggregateAcrossResourcesWithDifferentStateModels`
- `testUnresolvedStateModelSkipsActualCountsButKeepsErrorCount`
- `testFailingResourceDoesNotDiscardOtherResourceCounts`
- `testNonLiveInstanceYieldsZeroCounts`
- `testCurrentStateReadFailureIsContained`
- `testNullCurrentStateMapYieldsZeroCounts`
- `testNullPartitionStateIsSkipped`
- `testEmptyCurrentStateYieldsZeroCounts`

`TestClusterStatusMonitor` (added):

- `testSetInstanceActualPartitionStatus`, covering JMX attribute values, reset to zero for
  instances absent from an update, staleness across successive updates, and null input maps

`TestInstanceMonitor` (added):

- `testActualPartitionCountMetrics`, covering gauge initialization, updates, and independence
  from the existing best-possible partition gauges

The following is the result of the "mvn test" command on the appropriate module:

```
$ mvn test -pl helix-core \
    -Dtest='TestReadClusterDataStagePartitionCounts,TestClusterStatusMonitor,TestInstanceMonitor'

[INFO] --------------------< org.apache.helix:helix-core >---------------------
[INFO] -------------------------------[ bundle ]-------------------------------
[INFO] Running TestSuite
[INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.797 s - in TestSuite
[INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.650 s
```

Surrounding stages and monitors were also run to check for regressions
(`TestReadClusterDataStageDomainValidation`, `TestCurrentStateComputationStage`,
`TestBestPossibleStateCalcStage`, `TestResourceComputationStage`): 62 tests, 0 failures.

The new tests were validated by temporarily reintroducing the initial-state counting behaviour and
confirming that 3 of them fail, then restoring the fix and confirming all pass. This checks that
they are genuine regression guards rather than tests that pass either way.

### Changes that Break Backward Compatibility (Optional)

No breaking changes. Both gauges are new attributes on the existing `InstanceMonitor` bean, and
`setInstanceActualPartitionStatus` is a new method. No existing metric changes value or meaning.

One point reviewers should be aware of, since it affects how these metrics are used rather than
compatibility:

`ActualPartitionGauge` excludes initial-state (OFFLINE) partitions, while the existing
`InstanceMonitor.PartitionGauge` counts every entry in the best possible state map, including
OFFLINE and DROPPED. The two are therefore **not directly subtractable**. Note that
`PerInstanceResourceMonitor.PartitionGauge`, which shares a name with the `InstanceMonitor` one,
already excludes both. Aligning `InstanceMonitor.PartitionGauge` with that convention would make
target versus actual comparisons exact, but it changes an already released metric, so it is
deliberately left out of this PR.

### Documentation (Optional)

In case of new functionality, my PR adds documentation in the following wiki page:

Documented in-repo rather than in the wiki: `website/1.4.3/src/site/markdown/Metrics.md`, under
`MBean InstanceMonitor`. That table previously listed none of the per-instance partition gauges, so
this adds `PartitionGauge`, `TopStatePartitionGauge`, `ActualPartitionGauge` and
`ActualTopStatePartitionGauge`.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In
  addition, my commits follow the guidelines from "How to write a good git commit message":
  - [x] Subject is separated from body by a blank line
  - [ ] Subject is limited to 50 characters (not including Jira issue reference)
  - [x] Subject does not end with a period
  - [x] Subject uses the imperative mood ("add", not "adding")
  - [ ] Body wraps at 72 characters
  - [x] Body explains "what" and "why", not "how"

> Deviation, stated rather than silently checked: commit subjects run 53 to 67 characters, above the
> 50 character guideline, which is consistent with existing commits on this branch of the fork. Two
> commit bodies have a single line at 73 and 74 characters. Say the word and these can be reworded
> and force pushed, since the branch has no review history yet.

### Code Quality

- [x] My diff has been formatted using `helix-style.xml`
  (`helix-style-intellij.xml` if IntelliJ IDE is used)
