### PR TITLE
Support per-connection TLS for ZooKeeper clients

### DIFF
--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/HelixZkClient.java
@@ -20,6 +20,7 @@ package org.apache.helix.zookeeper.api.client;
  */
 
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
+import org.apache.helix.zookeeper.zkclient.ZkClientSslConfig;
 import org.apache.helix.zookeeper.zkclient.serialize.PathBasedZkSerializer;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 
@@ -42,6 +43,8 @@ public interface HelixZkClient extends RealmAwareZkClient {
     // Connection configs
     private final String _zkServers;
     private int _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
+    // Optional SSL/TLS config. When set and enabled, the connection is established over TLS.
+    private ZkClientSslConfig _sslConfig;
 
     public ZkConnectionConfig(String zkServers) {
       _zkServers = zkServers;
@@ -81,6 +84,15 @@ public interface HelixZkClient extends RealmAwareZkClient {
 
     public int getSessionTimeout() {
       return _sessionTimeout;
+    }
+
+    public ZkConnectionConfig setSslConfig(ZkClientSslConfig sslConfig) {
+      this._sslConfig = sslConfig;
+      return this;
+    }
+
+    public ZkClientSslConfig getSslConfig() {
+      return _sslConfig;
     }
   }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/api/client/RealmAwareZkClient.java
@@ -32,6 +32,7 @@ import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
+import org.apache.helix.zookeeper.zkclient.ZkClientSslConfig;
 import org.apache.helix.zookeeper.zkclient.callback.ZkAsyncCallbacks;
 import org.apache.helix.zookeeper.zkclient.exception.ZkTimeoutException;
 import org.apache.helix.zookeeper.zkclient.serialize.BasicZkSerializer;
@@ -424,12 +425,15 @@ public interface RealmAwareZkClient {
     private String _routingDataSourceType;
     private String _routingDataSourceEndpoint;
     private int _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
+    // Optional SSL/TLS config. When set and enabled, connections to ZK realms are established over TLS.
+    private ZkClientSslConfig _sslConfig;
 
     private RealmAwareZkConnectionConfig(Builder builder) {
       _zkRealmShardingKey = builder._zkRealmShardingKey;
       _routingDataSourceType = builder._routingDataSourceType;
       _routingDataSourceEndpoint = builder._routingDataSourceEndpoint;
       _sessionTimeout = builder._sessionTimeout;
+      _sslConfig = builder._sslConfig;
     }
 
     @Override
@@ -477,12 +481,17 @@ public interface RealmAwareZkClient {
       return _routingDataSourceEndpoint;
     }
 
+    public ZkClientSslConfig getSslConfig() {
+      return _sslConfig;
+    }
+
     public static class Builder {
       private RealmMode _realmMode;
       private String _zkRealmShardingKey;
       private String _routingDataSourceType;
       private String _routingDataSourceEndpoint;
       private int _sessionTimeout = DEFAULT_SESSION_TIMEOUT;
+      private ZkClientSslConfig _sslConfig;
 
       public Builder() {
       }
@@ -515,6 +524,18 @@ public interface RealmAwareZkClient {
 
       public Builder setSessionTimeout(int sessionTimeout) {
         _sessionTimeout = sessionTimeout;
+        return this;
+      }
+
+      /**
+       * Sets the SSL/TLS config used to establish secure connections to ZK realms. When set and
+       * enabled, certs are passed to the ZooKeeper client on a per-connection basis (no global
+       * JVM system properties required).
+       * @param sslConfig
+       * @return
+       */
+      public Builder setSslConfig(ZkClientSslConfig sslConfig) {
+        _sslConfig = sslConfig;
         return this;
       }
 

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/DedicatedZkClient.java
@@ -101,7 +101,8 @@ public class DedicatedZkClient implements RealmAwareZkClient {
 
     // Create a ZK connection
     IZkConnection zkConnection =
-        new ZkConnection(zkRealmAddress, connectionConfig.getSessionTimeout());
+        new ZkConnection(zkRealmAddress, connectionConfig.getSessionTimeout(),
+            connectionConfig.getSslConfig());
 
     // Create a ZkClient
     _rawZkClient = new ZkClient(zkConnection, (int) clientConfig.getConnectInitTimeout(),

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/FederatedZkClient.java
@@ -719,7 +719,9 @@ public class FederatedZkClient implements RealmAwareZkClient {
 
   private ZkClient createZkClient(String zkAddress) {
     LOG.debug("Creating ZkClient for realm: {}.", zkAddress);
-    return new ZkClient(new ZkConnection(zkAddress), (int) _clientConfig.getConnectInitTimeout(),
+    return new ZkClient(
+        new ZkConnection(zkAddress, _connectionConfig.getSessionTimeout(),
+            _connectionConfig.getSslConfig()), (int) _clientConfig.getConnectInitTimeout(),
         _clientConfig.getOperationRetryTimeout(), _pathBasedZkSerializer,
         _clientConfig.getMonitorType(), _clientConfig.getMonitorKey(),
         _clientConfig.getMonitorInstanceName(), _clientConfig.isMonitorRootPathOnly());

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/client/SharedZkClient.java
@@ -97,7 +97,8 @@ public class SharedZkClient implements RealmAwareZkClient {
     // sharedInnerZkClient is closed.
     HelixZkClient.ZkConnectionConfig zkConnectionConfig =
         new HelixZkClient.ZkConnectionConfig(zkRealmAddress)
-            .setSessionTimeout(connectionConfig.getSessionTimeout());
+            .setSessionTimeout(connectionConfig.getSessionTimeout())
+            .setSslConfig(connectionConfig.getSslConfig());
     HelixZkClient.ZkClientConfig zkClientConfig = new HelixZkClient.ZkClientConfig();
     zkClientConfig.setZkSerializer(clientConfig.getZkSerializer())
         .setConnectInitTimeout(clientConfig.getConnectInitTimeout())

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/HelixZkClientFactory.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/impl/factory/HelixZkClientFactory.java
@@ -65,7 +65,7 @@ public abstract class HelixZkClientFactory implements RealmAwareZkClientFactory 
           "Failed to build ZkClient since no connection or ZK server address is specified.");
     } else {
       return new ZkConnection(connectionConfig.getZkServers(),
-          connectionConfig.getSessionTimeout());
+          connectionConfig.getSessionTimeout(), connectionConfig.getSslConfig());
     }
   }
 }

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClientSslConfig.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkClientSslConfig.java
@@ -1,0 +1,162 @@
+package org.apache.helix.zookeeper.zkclient;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.zookeeper.client.ZKClientConfig;
+
+
+/**
+ * SSL/TLS configuration for a single ZooKeeper connection.
+ * <p>
+ * This lets Helix establish a secure (TLS/mTLS) connection to ZooKeeper on a
+ * <b>per-connection</b> basis, instead of relying on the caller setting global JVM
+ * system properties (e.g. {@code -Dzookeeper.ssl.keyStore.location=...}) before the
+ * client connects. When enabled, the config is materialized into a
+ * {@link ZKClientConfig} that is passed to the underlying
+ * {@code new ZooKeeper(connectString, sessionTimeout, watcher, zkClientConfig)} constructor
+ * by {@link ZkConnection}.
+ * <p>
+ * The keystore holds the client identity certificate (used for mutual TLS) and the
+ * truststore holds the CA/certs used to verify the ZooKeeper server.
+ */
+public class ZkClientSslConfig {
+  // The ZooKeeper client connection socket. TLS is only supported over the Netty socket.
+  private static final String DEFAULT_CLIENT_CNXN_SOCKET =
+      "org.apache.zookeeper.ClientCnxnSocketNetty";
+  private static final String DEFAULT_TRUST_STORE_TYPE = "JKS";
+
+  // ZooKeeper client SSL system-property keys (ZK 3.6.x). Set on a per-connection ZKClientConfig
+  // rather than globally via System.setProperty.
+  private static final String ZK_CLIENT_SECURE = "zookeeper.client.secure";
+  private static final String ZK_CLIENT_CNXN_SOCKET = "zookeeper.clientCnxnSocket";
+  private static final String ZK_SSL_KEYSTORE_LOCATION = "zookeeper.ssl.keyStore.location";
+  private static final String ZK_SSL_KEYSTORE_PASSWORD = "zookeeper.ssl.keyStore.password";
+  private static final String ZK_SSL_KEYSTORE_TYPE = "zookeeper.ssl.keyStore.type";
+  private static final String ZK_SSL_TRUSTSTORE_LOCATION = "zookeeper.ssl.trustStore.location";
+  private static final String ZK_SSL_TRUSTSTORE_PASSWORD = "zookeeper.ssl.trustStore.password";
+  private static final String ZK_SSL_TRUSTSTORE_TYPE = "zookeeper.ssl.trustStore.type";
+
+  private boolean _sslEnabled;
+  private String _clientCnxnSocket = DEFAULT_CLIENT_CNXN_SOCKET;
+  private String _keyStoreLocation;
+  private String _keyStorePassword;
+  private String _keyStoreType;
+  private String _trustStoreLocation;
+  private String _trustStorePassword;
+  private String _trustStoreType = DEFAULT_TRUST_STORE_TYPE;
+
+  public boolean isSslEnabled() {
+    return _sslEnabled;
+  }
+
+  public ZkClientSslConfig setSslEnabled(boolean sslEnabled) {
+    _sslEnabled = sslEnabled;
+    return this;
+  }
+
+  public String getClientCnxnSocket() {
+    return _clientCnxnSocket;
+  }
+
+  public ZkClientSslConfig setClientCnxnSocket(String clientCnxnSocket) {
+    _clientCnxnSocket = clientCnxnSocket;
+    return this;
+  }
+
+  public String getKeyStoreLocation() {
+    return _keyStoreLocation;
+  }
+
+  public ZkClientSslConfig setKeyStoreLocation(String keyStoreLocation) {
+    _keyStoreLocation = keyStoreLocation;
+    return this;
+  }
+
+  public String getKeyStorePassword() {
+    return _keyStorePassword;
+  }
+
+  public ZkClientSslConfig setKeyStorePassword(String keyStorePassword) {
+    _keyStorePassword = keyStorePassword;
+    return this;
+  }
+
+  public String getKeyStoreType() {
+    return _keyStoreType;
+  }
+
+  public ZkClientSslConfig setKeyStoreType(String keyStoreType) {
+    _keyStoreType = keyStoreType;
+    return this;
+  }
+
+  public String getTrustStoreLocation() {
+    return _trustStoreLocation;
+  }
+
+  public ZkClientSslConfig setTrustStoreLocation(String trustStoreLocation) {
+    _trustStoreLocation = trustStoreLocation;
+    return this;
+  }
+
+  public String getTrustStorePassword() {
+    return _trustStorePassword;
+  }
+
+  public ZkClientSslConfig setTrustStorePassword(String trustStorePassword) {
+    _trustStorePassword = trustStorePassword;
+    return this;
+  }
+
+  public String getTrustStoreType() {
+    return _trustStoreType;
+  }
+
+  public ZkClientSslConfig setTrustStoreType(String trustStoreType) {
+    _trustStoreType = trustStoreType;
+    return this;
+  }
+
+  /**
+   * Materialize this config into a {@link ZKClientConfig} carrying the SSL properties so the
+   * underlying ZooKeeper client performs a TLS/mTLS handshake using the configured keystore
+   * (client identity) and truststore (server verification).
+   *
+   * @return a {@link ZKClientConfig} with the secure-client and SSL keystore/truststore properties set
+   */
+  public ZKClientConfig createZKClientConfig() {
+    ZKClientConfig zkClientConfig = new ZKClientConfig();
+    zkClientConfig.setProperty(ZK_CLIENT_SECURE, Boolean.toString(true));
+    zkClientConfig.setProperty(ZK_CLIENT_CNXN_SOCKET, _clientCnxnSocket);
+    setIfNotEmpty(zkClientConfig, ZK_SSL_KEYSTORE_LOCATION, _keyStoreLocation);
+    setIfNotEmpty(zkClientConfig, ZK_SSL_KEYSTORE_PASSWORD, _keyStorePassword);
+    setIfNotEmpty(zkClientConfig, ZK_SSL_KEYSTORE_TYPE, _keyStoreType);
+    setIfNotEmpty(zkClientConfig, ZK_SSL_TRUSTSTORE_LOCATION, _trustStoreLocation);
+    setIfNotEmpty(zkClientConfig, ZK_SSL_TRUSTSTORE_PASSWORD, _trustStorePassword);
+    setIfNotEmpty(zkClientConfig, ZK_SSL_TRUSTSTORE_TYPE, _trustStoreType);
+    return zkClientConfig;
+  }
+
+  private static void setIfNotEmpty(ZKClientConfig zkClientConfig, String key, String value) {
+    if (value != null && !value.isEmpty()) {
+      zkClientConfig.setProperty(key, value);
+    }
+  }
+}

--- a/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkConnection.java
+++ b/zookeeper-api/src/main/java/org/apache/helix/zookeeper/zkclient/ZkConnection.java
@@ -61,14 +61,22 @@ public class ZkConnection implements IZkConnection {
 
   private final String _servers;
   private final int _sessionTimeOut;
+  // Optional per-connection SSL/TLS config. When enabled, a ZKClientConfig carrying the
+  // keystore/truststore is passed to the ZooKeeper client so the connection is established over TLS.
+  private final ZkClientSslConfig _sslConfig;
 
   public ZkConnection(String zkServers) {
     this(zkServers, DEFAULT_SESSION_TIMEOUT);
   }
 
   public ZkConnection(String zkServers, int sessionTimeOut) {
+    this(zkServers, sessionTimeOut, null);
+  }
+
+  public ZkConnection(String zkServers, int sessionTimeOut, ZkClientSslConfig sslConfig) {
     _servers = zkServers;
     _sessionTimeOut = sessionTimeOut;
+    _sslConfig = sslConfig;
   }
 
   @Override
@@ -80,7 +88,7 @@ public class ZkConnection implements IZkConnection {
       }
       try {
         LOG.debug("Creating new ZookKeeper instance to connect to " + _servers + ".");
-        _zk = new ZooKeeper(_servers, _sessionTimeOut, watcher);
+        _zk = newZookeeper(watcher);
       } catch (IOException e) {
         throw new ZkException("Unable to connect to " + _servers, e);
       }
@@ -112,7 +120,7 @@ public class ZkConnection implements IZkConnection {
       ZooKeeper prevZk = _zk;
       try {
         LOG.debug("Creating new ZookKeeper instance to reconnect to " + _servers + ".");
-        _zk = new ZooKeeper(_servers, _sessionTimeOut, watcher);
+        _zk = newZookeeper(watcher);
         prevZk.close();
       } catch (IOException e) {
         throw new ZkException("Unable to connect to " + _servers, e);
@@ -120,6 +128,19 @@ public class ZkConnection implements IZkConnection {
     } finally {
       _zookeeperLock.unlock();
     }
+  }
+
+  /**
+   * Creates a new {@link ZooKeeper} instance. When a {@link ZkClientSslConfig} is present and
+   * enabled, a per-connection {@link org.apache.zookeeper.client.ZKClientConfig} carrying the
+   * keystore/truststore is supplied so the connection is established over TLS/mTLS; otherwise a
+   * plaintext connection is created.
+   */
+  private ZooKeeper newZookeeper(Watcher watcher) throws IOException {
+    if (_sslConfig != null && _sslConfig.isSslEnabled()) {
+      return new ZooKeeper(_servers, _sessionTimeOut, watcher, _sslConfig.createZKClientConfig());
+    }
+    return new ZooKeeper(_servers, _sessionTimeOut, watcher);
   }
 
   @Override

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestSecureZkConnection.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestSecureZkConnection.java
@@ -1,0 +1,275 @@
+package org.apache.helix.zookeeper.zkclient;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
+import org.apache.helix.zookeeper.zkclient.exception.ZkException;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * End-to-end verification that Helix actually passes TLS certs to ZooKeeper over the wire when a
+ * per-connection {@link ZkClientSslConfig} is supplied.
+ * <p>
+ * The test stands up a real, TLS-only ZooKeeper server (Netty transport, mutual TLS / client-auth
+ * required). The server reads its keystore/truststore from JVM system properties (the only way a ZK
+ * server can be configured for SSL). The Helix client, by contrast, receives its certs solely
+ * through a per-connection {@link ZkClientSslConfig} that is threaded down to the 4-arg
+ * {@code new ZooKeeper(..., ZKClientConfig)} constructor by {@link ZkConnection}.
+ * <p>
+ * Because {@code zookeeper.client.secure} and {@code zookeeper.clientCnxnSocket} are client-only
+ * settings that the server never sets, and they are cleared from the JVM in setup, the only thing
+ * that flips the Helix client into TLS mode is the per-connection {@link ZkClientSslConfig}:
+ * <ul>
+ *   <li>{@code testSecureClientWithSslConfigConnects} — a client built <b>with</b> the SSL config
+ *       completes a mutually-authenticated TLS handshake and can create/read/delete a znode.</li>
+ *   <li>{@code testPlaintextClientRejectedBySecurePort} — a client built <b>without</b> the SSL
+ *       config (same JVM, same system properties) cannot establish a session with the TLS-only
+ *       port.</li>
+ * </ul>
+ * The delta between the two isolates the per-connection cert passing as the enabler.
+ * <p>
+ * {@link DedicatedZkClientFactory} is used (not the shared factory) so each client gets its own
+ * {@link ZkConnection}; the shared factory pools connections by a config key that intentionally
+ * ignores certs, which would otherwise let the two clients share one underlying connection.
+ */
+@SuppressWarnings("deprecation")
+public class TestSecureZkConnection {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSecureZkConnection.class);
+
+  private static final String KEYSTORE_PASSWORD = "helixtest";
+  private static final String STORE_TYPE = "JKS";
+  private static final String CERT_ALIAS = "helixtest";
+
+  private File _certDir;
+  private File _snapDir;
+  private File _logDir;
+  private String _keyStorePath;
+  private String _trustStorePath;
+  private int _securePort;
+  private ServerCnxnFactory _cnxnFactory;
+  private final Map<String, String> _originalSystemProps = new LinkedHashMap<>();
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _certDir = Files.createTempDirectory("helix-zk-secure-certs").toFile();
+    _snapDir = Files.createTempDirectory("helix-zk-secure-snap").toFile();
+    _logDir = Files.createTempDirectory("helix-zk-secure-log").toFile();
+
+    generateSelfSignedStores();
+
+    // ZooKeeper only supports TLS over the Netty transport, so force the server to use the Netty
+    // connection factory (the default is NIO, which is plaintext-only).
+    overrideSystemProperty(ServerCnxnFactory.ZOOKEEPER_SERVER_CNXN_FACTORY,
+        "org.apache.zookeeper.server.NettyServerCnxnFactory");
+    // Require client certificates so the server authenticates the Helix client (mutual TLS).
+    overrideSystemProperty("zookeeper.ssl.clientAuth", "need");
+    // Register ZooKeeper's X509 authentication provider so the server can validate the client
+    // certificate presented during the mutual-TLS handshake (required when clientAuth=need).
+    overrideSystemProperty("zookeeper.authProvider.x509",
+        "org.apache.zookeeper.server.auth.X509AuthenticationProvider");
+    // Server-side SSL config can only be supplied via system properties.
+    overrideSystemProperty("zookeeper.ssl.keyStore.location", _keyStorePath);
+    overrideSystemProperty("zookeeper.ssl.keyStore.password", KEYSTORE_PASSWORD);
+    overrideSystemProperty("zookeeper.ssl.keyStore.type", STORE_TYPE);
+    overrideSystemProperty("zookeeper.ssl.trustStore.location", _trustStorePath);
+    overrideSystemProperty("zookeeper.ssl.trustStore.password", KEYSTORE_PASSWORD);
+    overrideSystemProperty("zookeeper.ssl.trustStore.type", STORE_TYPE);
+    // Connecting to localhost/127.0.0.1 - keep cert trust as the sole check, not hostname matching.
+    overrideSystemProperty("zookeeper.ssl.hostnameVerification", "false");
+    // Ensure the client only goes secure via the per-connection ZkClientSslConfig, never via
+    // inherited system properties.
+    overrideSystemProperty("zookeeper.client.secure", null);
+    overrideSystemProperty("zookeeper.clientCnxnSocket", null);
+
+    _securePort = findFreePort();
+    startSecureZkServer();
+  }
+
+  @AfterClass
+  public void afterClass() {
+    if (_cnxnFactory != null) {
+      _cnxnFactory.shutdown();
+    }
+    restoreSystemProperties();
+    deleteRecursively(_certDir);
+    deleteRecursively(_snapDir);
+    deleteRecursively(_logDir);
+  }
+
+  @Test
+  public void testSecureClientWithSslConfigConnects() {
+    ZkClientSslConfig sslConfig = new ZkClientSslConfig()
+        .setSslEnabled(true)
+        .setKeyStoreLocation(_keyStorePath)
+        .setKeyStorePassword(KEYSTORE_PASSWORD)
+        .setKeyStoreType(STORE_TYPE)
+        .setTrustStoreLocation(_trustStorePath)
+        .setTrustStorePassword(KEYSTORE_PASSWORD)
+        .setTrustStoreType(STORE_TYPE);
+
+    HelixZkClient client = DedicatedZkClientFactory.getInstance().buildZkClient(
+        new HelixZkClient.ZkConnectionConfig("localhost:" + _securePort).setSessionTimeout(30000)
+            .setSslConfig(sslConfig),
+        new HelixZkClient.ZkClientConfig().setConnectInitTimeout(30000));
+    try {
+      Assert.assertTrue(client.waitUntilConnected(30, TimeUnit.SECONDS),
+          "Secure Helix client should establish a TLS session with the secure ZK port");
+
+      String path = "/helixSecureZkTest";
+      client.createPersistent(path);
+      Assert.assertTrue(client.exists(path),
+          "znode created over the TLS connection should exist");
+      client.delete(path);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testPlaintextClientRejectedBySecurePort() {
+    HelixZkClient client = null;
+    try {
+      // No ZkClientSslConfig => plaintext client. It must not be able to talk to the TLS-only port.
+      client = DedicatedZkClientFactory.getInstance().buildZkClient(
+          new HelixZkClient.ZkConnectionConfig("localhost:" + _securePort).setSessionTimeout(30000),
+          new HelixZkClient.ZkClientConfig().setConnectInitTimeout(5000));
+      boolean connected = client.waitUntilConnected(6, TimeUnit.SECONDS);
+      Assert.assertFalse(connected,
+          "A plaintext client must NOT establish a session with the TLS-only secure port");
+    } catch (ZkException expected) {
+      // Expected: the plaintext client times out / fails to connect to the TLS-only port.
+      LOG.info("Plaintext client was correctly rejected by the secure port: {}",
+          expected.getMessage());
+    } finally {
+      if (client != null) {
+        client.close();
+      }
+    }
+  }
+
+  private void startSecureZkServer() throws Exception {
+    ZooKeeperServer zkServer = new ZooKeeperServer(_snapDir, _logDir, 3000);
+    // createFactory() reads zookeeper.serverCnxnFactory (set to Netty in beforeClass) to pick the
+    // transport; NettyServerCnxnFactory's constructor is package-private so it cannot be newed here.
+    _cnxnFactory = ServerCnxnFactory.createFactory();
+    // (address, maxClientCnxns, listenBacklog=-1 for default, secure=true)
+    _cnxnFactory.configure(new InetSocketAddress("127.0.0.1", _securePort), 60, -1, true);
+    _cnxnFactory.startup(zkServer);
+    Assert.assertTrue(zkServer.isRunning(), "Secure ZooKeeper server should be running");
+    LOG.info("Started TLS-only ZooKeeper server on port {}", _securePort);
+  }
+
+  private void generateSelfSignedStores() throws Exception {
+    _keyStorePath = new File(_certDir, "keystore.jks").getAbsolutePath();
+    _trustStorePath = new File(_certDir, "truststore.jks").getAbsolutePath();
+    File certFile = new File(_certDir, "cert.pem");
+
+    // A single self-signed cert used for both server identity and mutual-TLS client identity;
+    // the truststore trusts that same cert so both directions of the handshake succeed.
+    runKeytool("-genkeypair", "-alias", CERT_ALIAS, "-keyalg", "RSA", "-keysize", "2048",
+        "-validity", "3650", "-dname", "CN=localhost,OU=helix,O=apache,C=US",
+        "-ext", "SAN=dns:localhost,ip:127.0.0.1",
+        "-keystore", _keyStorePath, "-storepass", KEYSTORE_PASSWORD, "-keypass", KEYSTORE_PASSWORD,
+        "-storetype", STORE_TYPE);
+    runKeytool("-exportcert", "-alias", CERT_ALIAS, "-keystore", _keyStorePath, "-storepass",
+        KEYSTORE_PASSWORD, "-rfc", "-file", certFile.getAbsolutePath());
+    runKeytool("-importcert", "-alias", CERT_ALIAS, "-file", certFile.getAbsolutePath(),
+        "-keystore", _trustStorePath, "-storepass", KEYSTORE_PASSWORD, "-storetype", STORE_TYPE,
+        "-noprompt");
+  }
+
+  private static void runKeytool(String... args) throws Exception {
+    List<String> command = new ArrayList<>();
+    command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "keytool");
+    command.addAll(Arrays.asList(args));
+    Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    int exitCode = process.waitFor();
+    if (exitCode != 0) {
+      throw new IllegalStateException(
+          "keytool failed (exit " + exitCode + "): " + output + "\ncommand=" + command);
+    }
+  }
+
+  private static int findFreePort() throws Exception {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      socket.setReuseAddress(true);
+      return socket.getLocalPort();
+    }
+  }
+
+  private void overrideSystemProperty(String key, String value) {
+    if (!_originalSystemProps.containsKey(key)) {
+      _originalSystemProps.put(key, System.getProperty(key));
+    }
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+
+  private void restoreSystemProperties() {
+    for (Map.Entry<String, String> entry : _originalSystemProps.entrySet()) {
+      if (entry.getValue() == null) {
+        System.clearProperty(entry.getKey());
+      } else {
+        System.setProperty(entry.getKey(), entry.getValue());
+      }
+    }
+    _originalSystemProps.clear();
+  }
+
+  private static void deleteRecursively(File file) {
+    if (file == null || !file.exists()) {
+      return;
+    }
+    File[] children = file.listFiles();
+    if (children != null) {
+      for (File child : children) {
+        deleteRecursively(child);
+      }
+    }
+    if (!file.delete()) {
+      file.deleteOnExit();
+    }
+  }
+}

--- a/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientSslConfig.java
+++ b/zookeeper-api/src/test/java/org/apache/helix/zookeeper/zkclient/TestZkClientSslConfig.java
@@ -1,0 +1,105 @@
+package org.apache.helix.zookeeper.zkclient;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.helix.zookeeper.api.client.HelixZkClient;
+import org.apache.helix.zookeeper.api.client.RealmAwareZkClient;
+import org.apache.zookeeper.client.ZKClientConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestZkClientSslConfig {
+
+  @Test
+  public void testCreateZKClientConfigWithAllFields() {
+    ZkClientSslConfig sslConfig = new ZkClientSslConfig()
+        .setSslEnabled(true)
+        .setClientCnxnSocket("org.apache.zookeeper.ClientCnxnSocketNetty")
+        .setKeyStoreLocation("/certs/identity.keystore.p12")
+        .setKeyStorePassword("ks-pass")
+        .setKeyStoreType("PKCS12")
+        .setTrustStoreLocation("/certs/truststore.jks")
+        .setTrustStorePassword("ts-pass")
+        .setTrustStoreType("JKS");
+
+    ZKClientConfig zkClientConfig = sslConfig.createZKClientConfig();
+
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.client.secure"), "true");
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.clientCnxnSocket"),
+        "org.apache.zookeeper.ClientCnxnSocketNetty");
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.ssl.keyStore.location"),
+        "/certs/identity.keystore.p12");
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.ssl.keyStore.password"), "ks-pass");
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.ssl.keyStore.type"), "PKCS12");
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.ssl.trustStore.location"),
+        "/certs/truststore.jks");
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.ssl.trustStore.password"), "ts-pass");
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.ssl.trustStore.type"), "JKS");
+  }
+
+  @Test
+  public void testCreateZKClientConfigUsesDefaults() {
+    // Only set the required stores; cnxn socket and trust store type should fall back to defaults.
+    ZkClientSslConfig sslConfig = new ZkClientSslConfig()
+        .setSslEnabled(true)
+        .setKeyStoreLocation("/certs/identity.keystore.p12")
+        .setKeyStorePassword("ks-pass")
+        .setTrustStoreLocation("/certs/truststore.jks")
+        .setTrustStorePassword("ts-pass");
+
+    ZKClientConfig zkClientConfig = sslConfig.createZKClientConfig();
+
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.clientCnxnSocket"),
+        "org.apache.zookeeper.ClientCnxnSocketNetty");
+    Assert.assertEquals(zkClientConfig.getProperty("zookeeper.ssl.trustStore.type"), "JKS");
+    // Optional keystore type was never set and must not be added.
+    Assert.assertNull(zkClientConfig.getProperty("zookeeper.ssl.keyStore.type"));
+  }
+
+  @Test
+  public void testRealmAwareZkConnectionConfigCarriesSslConfig() {
+    ZkClientSslConfig sslConfig = new ZkClientSslConfig().setSslEnabled(true);
+
+    RealmAwareZkClient.RealmAwareZkConnectionConfig connectionConfig =
+        new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder().setSslConfig(sslConfig)
+            .build();
+
+    Assert.assertSame(connectionConfig.getSslConfig(), sslConfig);
+    Assert.assertTrue(connectionConfig.getSslConfig().isSslEnabled());
+  }
+
+  @Test
+  public void testHelixZkConnectionConfigCarriesSslConfig() {
+    ZkClientSslConfig sslConfig = new ZkClientSslConfig().setSslEnabled(true);
+
+    HelixZkClient.ZkConnectionConfig connectionConfig =
+        new HelixZkClient.ZkConnectionConfig("localhost:2281").setSslConfig(sslConfig);
+
+    Assert.assertSame(connectionConfig.getSslConfig(), sslConfig);
+  }
+
+  @Test
+  public void testDefaultConnectionConfigsHaveNoSslConfig() {
+    Assert.assertNull(
+        new RealmAwareZkClient.RealmAwareZkConnectionConfig.Builder().build().getSslConfig());
+    Assert.assertNull(new HelixZkClient.ZkConnectionConfig("localhost:2181").getSslConfig());
+  }
+}


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

No public Apache Helix issue is linked. This is an internal LinkedIn enhancement to give Helix native, per-connection ZooKeeper TLS support (parity with what `helixacm-service` does today via JVM-global system properties).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What:** Adds the ability for Helix to pass TLS certs to ZooKeeper on a per-connection basis instead of relying on JVM-global `zookeeper.ssl.*` system properties.

**Why:** Today, secure ZK connections require setting global `System.setProperty("zookeeper.ssl.*", ...)` before any client connects (the approach `helixacm-service` uses). That is process-global and cannot vary per connection. This change lets Helix carry keystore/truststore settings on the connection config itself.

**How:**
- New `ZkClientSslConfig` holds the secure flag, client cnxn socket (defaults to Netty), and keystore/truststore location/password/type (truststore type defaults to `JKS`). Its `createZKClientConfig()` builds an `org.apache.zookeeper.client.ZKClientConfig` with the same `zookeeper.client.secure`, `zookeeper.clientCnxnSocket`, and `zookeeper.ssl.keyStore.*` / `zookeeper.ssl.trustStore.*` keys.
- `ZkConnection` gains a constructor accepting a `ZkClientSslConfig` and uses the 4-arg `new ZooKeeper(connectString, sessionTimeout, watcher, ZKClientConfig)` when SSL is enabled, otherwise the existing 3-arg constructor.
- The SSL config is threaded through `RealmAwareZkConnectionConfig` and the deprecated `ZkConnectionConfig` (fields + builder/fluent setters), `HelixZkClientFactory`, and the `Shared`/`Dedicated`/`Federated` ZK clients.

**Follow-up (separate PR):** plumbing `ZkClientSslConfig` through helix-rest `ServerContext` / `HelixRestNamespace` so callers like `helixacm-service` can drop their `System.setProperty` calls.

### Tests

- [x] The following tests are written for this issue:

1. `TestZkClientSslConfig` (zookeeper-api) — 5 TestNG cases covering: property-key mapping to `ZKClientConfig`, defaults (Netty cnxn socket, `JKS` truststore type), threading the SSL config through both `RealmAwareZkConnectionConfig` and `ZkConnectionConfig`, and null/absent SSL config (no-op) behavior.
2. `TestSecureZkConnection` (zookeeper-api) — end-to-end proof that certs are passed over the wire. Starts a real TLS-only ZooKeeper server (Netty transport, mutual TLS / `clientAuth=need`) and asserts:
   - a Helix client built **with** a per-connection `ZkClientSslConfig` completes the mutual-TLS handshake and can create/read/delete a znode;
   - a plaintext Helix client (no SSL config) is **rejected** by the TLS-only port.
   The server receives its certs via system properties (the only server-side option); the Helix client receives its certs **only** through the per-connection `ZkClientSslConfig`, and the client-only `zookeeper.client.secure` / `zookeeper.clientCnxnSocket` properties are cleared from the JVM — so the per-connection config is the sole thing that flips the client into TLS mode. The pass/reject delta isolates the per-connection cert passing as the enabler.

- The following is the result of the "mvn test" command on the appropriate module:

```
$ mvn -pl zookeeper-api test -Dtest='TestZkClientSslConfig,TestSecureZkConnection'
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

(Run locally with the JaCoCo agent disabled because it fails to instrument JDK classes on the machine's JDK 25 — an environment-only issue unrelated to this change; CI runs on a supported JDK.)

- [x] Local code review completed

### Changes that Break Backward Compatibility (Optional)

None. The change is purely additive: new constructor overloads, new config fields, and new builder/setter methods. Connections without an SSL config use the existing 3-arg `ZooKeeper` constructor, so plaintext behavior is unchanged. `equals()`/`hashCode()` on the connection-config classes are intentionally left unmodified so `SharedZkClientFactory` connection-pool sharing semantics are preserved.

### Documentation (Optional)

N/A — internal enhancement; no new user-facing wiki functionality.

### Commits

- [x] My commits reference the change in the subject line and follow the standard git commit message guidelines (imperative subject separated from body by a blank line; body explains what and why).

### Code Quality

- [x] My diff follows the existing `zookeeper-api` formatting and style conventions (consistent with the surrounding code in the modified files).

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
