### PR TITLE
Fix data loss when bucketized payload is an exact multiple of bucket size

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZkBucketDataAccessor.java
@@ -188,9 +188,10 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     while (counter < numBuckets) {
       paths.add(versionedDataPath + "/" + counter);
       if (counter == numBuckets - 1) {
-        // Special treatment for the last bucket
-        buckets.add(
-            Arrays.copyOfRange(compressedRecord, ptr, ptr + compressedRecord.length % _bucketSize));
+        // The last bucket holds whatever is left. Copying to the end of the array is required
+        // because the remainder is a *full* bucket when the payload happens to be an exact
+        // multiple of the bucket size, in which case length % _bucketSize is 0.
+        buckets.add(Arrays.copyOfRange(compressedRecord, ptr, compressedRecord.length));
       } else {
         buckets.add(Arrays.copyOfRange(compressedRecord, ptr, ptr + _bucketSize));
       }
@@ -298,8 +299,10 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     int bucketSize = Integer.parseInt((String) bucketSizeObj);
     int dataSize = Integer.parseInt((String) dataSizeObj);
 
-    // Compute N - number of buckets
-    int numBuckets = (dataSize + _bucketSize - 1) / _bucketSize;
+    // Compute N - number of buckets. Use the bucket size the writer recorded in the metadata
+    // rather than this reader's configured size, otherwise an accessor constructed with a
+    // different bucket size than the writer would look for the wrong number of buckets.
+    int numBuckets = (dataSize + bucketSize - 1) / bucketSize;
     byte[] compressedRecord = new byte[dataSize];
     String dataPath = path + "/" + versionToRead;
 
@@ -314,13 +317,17 @@ public class ZkBucketDataAccessor implements BucketDataAccessor, AutoCloseable {
     // Combine buckets into one byte array
     int copyPtr = 0;
     for (int i = 0; i < numBuckets; i++) {
-      if (i == numBuckets - 1) {
-        // Special treatment for the last bucket
-        System.arraycopy(buckets.get(i), 0, compressedRecord, copyPtr, dataSize % bucketSize);
-      } else {
-        System.arraycopy(buckets.get(i), 0, compressedRecord, copyPtr, bucketSize);
-        copyPtr += bucketSize;
+      // The last bucket holds whatever is left, which is a full bucket when the payload is an
+      // exact multiple of the bucket size.
+      int copyLength = Math.min(bucketSize, dataSize - copyPtr);
+      byte[] bucket = buckets.get(i);
+      if (bucket == null || bucket.length < copyLength) {
+        throw new HelixException(String
+            .format("Bucket %d is truncated for path: %s! Expected %d bytes but found %d.", i, path,
+                copyLength, bucket == null ? 0 : bucket.length));
       }
+      System.arraycopy(bucket, 0, compressedRecord, copyPtr, copyLength);
+      copyPtr += copyLength;
     }
 
     // Decompress the byte array

--- a/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
+++ b/helix-core/src/test/java/org/apache/helix/manager/zk/TestZkBucketDataAccessor.java
@@ -38,7 +38,9 @@ import org.apache.helix.TestHelper;
 import org.apache.helix.common.ZkTestBase;
 import org.apache.helix.zookeeper.api.client.HelixZkClient;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordJacksonSerializer;
 import org.apache.helix.zookeeper.impl.factory.DedicatedZkClientFactory;
+import org.apache.helix.zookeeper.util.GZipCompressionUtil;
 import org.apache.helix.zookeeper.zkclient.exception.ZkMarshallingError;
 import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.testng.Assert;
@@ -190,6 +192,62 @@ public class TestZkBucketDataAccessor extends ZkTestBase {
 
     // Check against the original HelixProperty
     Assert.assertEquals(readRecord, property);
+  }
+
+  /**
+   * The bucket slicing arithmetic has a boundary case when the compressed payload length is an
+   * exact multiple of the bucket size: the remainder is zero, so a naive "length % bucketSize"
+   * final bucket would be empty and those bytes would be lost, making the record undecodable.
+   */
+  @Test(dependsOnMethods = "testLargeWriteAndRead")
+  public void testWriteAndReadWhenSizeIsExactMultipleOfBucketSize() throws IOException {
+    String path = PATH + "_" + TestHelper.getTestMethodName();
+    ZNRecord largeRecord = new ZNRecord(NAME_KEY);
+    for (int i = 0; i < 4000; i++) {
+      largeRecord.setSimpleField("key_" + i, "value_" + i);
+    }
+
+    int compressedLength =
+        GZipCompressionUtil.compress(new ZNRecordJacksonSerializer().serialize(largeRecord)).length;
+    // Pick a bucket size that divides the compressed payload exactly.
+    int exactBucketSize = compressedLength % 2 == 0 ? compressedLength / 2 : compressedLength;
+    Assert.assertEquals(compressedLength % exactBucketSize, 0,
+        "Test setup requires the payload to be an exact multiple of the bucket size");
+
+    ZkBucketDataAccessor exactSizeAccessor =
+        new ZkBucketDataAccessor(_zkClient, exactBucketSize, VERSION_TTL_MS);
+    try {
+      Assert.assertTrue(
+          exactSizeAccessor.compressedBucketWrite(path, new HelixProperty(largeRecord)));
+      HelixProperty readRecord =
+          exactSizeAccessor.compressedBucketRead(path, HelixProperty.class);
+      Assert.assertEquals(readRecord.getRecord().getSimpleFields(),
+          largeRecord.getSimpleFields());
+      exactSizeAccessor.compressedBucketDelete(path);
+    } finally {
+      exactSizeAccessor.disconnect();
+    }
+  }
+
+  /**
+   * A reader configured with a different bucket size than the writer must still reassemble the
+   * record correctly, since the authoritative bucket size is the one recorded in the metadata.
+   */
+  @Test(dependsOnMethods = "testLargeWriteAndRead")
+  public void testReadWithDifferentBucketSizeThanWriter() throws IOException {
+    String path = PATH + "_" + TestHelper.getTestMethodName();
+    HelixProperty property = createLargeHelixProperty("mismatchedBucketSize", 2000);
+
+    ZkBucketDataAccessor writer = new ZkBucketDataAccessor(_zkClient, 10 * 1024, VERSION_TTL_MS);
+    ZkBucketDataAccessor reader = new ZkBucketDataAccessor(_zkClient, 50 * 1024, VERSION_TTL_MS);
+    try {
+      Assert.assertTrue(writer.compressedBucketWrite(path, property));
+      Assert.assertEquals(reader.compressedBucketRead(path, HelixProperty.class), property);
+      reader.compressedBucketDelete(path);
+    } finally {
+      writer.disconnect();
+      reader.disconnect();
+    }
   }
 
   /**


### PR DESCRIPTION
The bucketized writer sliced the final bucket using "compressedRecord.length % _bucketSize". When the GZIP compressed payload length happens to be an exact multiple of the bucket size that remainder is zero, so the last bucket was written empty and its bytes were dropped. The reader then reassembled a truncated buffer and every subsequent read of that path failed with "Failed to decompress path". The record was effectively unrecoverable until the next write landed on a non-multiple length.

The reader had the mirror image of the same bug in its final-bucket arraycopy, and it also advanced its copy pointer only on the non-final branch, so the final chunk was copied to the wrong offset.

Slice and copy to the end of the payload instead of relying on the remainder, which is correct for both the exact-multiple and the partial final bucket cases.

The reader additionally computed the bucket count from its own configured _bucketSize rather than the BUCKET_SIZE the writer recorded in the metadata ZNode. An accessor constructed with a different bucket size than the writer therefore looked for the wrong number of buckets and failed the same way. Use the persisted bucket size, which is the authoritative value, and fail with an explicit message if a bucket is missing or short rather than throwing an opaque ArrayIndexOutOfBoundsException.

Both cases are covered by new tests that fail without this fix.

### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)

### Tests

- [ ] The following tests are written for this issue:

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
