### PR TITLE
Add endpoint for Helix-computed offline instance count

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
+++ b/helix-core/src/main/java/org/apache/helix/controller/dataproviders/BaseControllerDataProvider.java
@@ -64,6 +64,7 @@ import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.task.TaskConstants;
 import org.apache.helix.util.HelixUtil;
+import org.apache.helix.util.InstanceUtil;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.slf4j.Logger;
@@ -759,16 +760,10 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    * auto Maintenance Mode (MAX_OFFLINE_INSTANCES_ALLOWED at entry,
    * NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT at exit).
    *
-   * <p>An instance counts when all three conditions hold:
-   * <ul>
-   *   <li>Its InstanceOperation is routable, i.e. not in
-   *       {@link InstanceConstants#UNROUTABLE_INSTANCE_OPERATIONS}.</li>
-   *   <li>It is not currently enabled-and-live.</li>
-   *   <li>It does not carry a valid (unexpired) instance-operation maintenance marker.</li>
-   * </ul>
-   * EVACUATE and DISABLE instances are included because they cannot accept new ONLINE
-   * replicas; ENABLE+offline instances are included for the same reason. SWAP_IN and
-   * UNKNOWN are excluded because they do not represent assignable cluster capacity.
+   * <p>Membership rules live in
+   * {@link InstanceUtil#getInstancesUnableToAcceptOnlineReplicas(Map, java.util.Collection, long)}
+   * so that the controller and the read-only helix-rest endpoint that reports this number to
+   * clients share one implementation.
    *
    * <p>Used by both BestPossibleStateCalcStage (MM entry) and MaintenanceRecoveryStage
    * (MM exit) so that the same population is measured against each threshold.
@@ -777,18 +772,8 @@ public class BaseControllerDataProvider implements ControlContextProvider {
    * @return a fresh modifiable set of instance names.
    */
   public Set<String> getInstancesUnableToAcceptOnlineReplicas(long nowMs) {
-    Map<String, InstanceConfig> instanceConfigMap = getInstanceConfigMap();
-    Set<String> result = instanceConfigMap.entrySet().stream()
-        .filter(e -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
-            e.getValue().getInstanceOperation().getOperation()))
-        .map(Map.Entry::getKey)
-        .collect(Collectors.toCollection(HashSet::new));
-    result.removeAll(getEnabledLiveInstances());
-    result.removeIf(name -> {
-      InstanceConfig cfg = instanceConfigMap.get(name);
-      return cfg != null && cfg.isUnderInstanceOperationMaintenance(nowMs);
-    });
-    return result;
+    return InstanceUtil.getInstancesUnableToAcceptOnlineReplicas(getInstanceConfigMap(),
+        getLiveInstances().keySet(), nowMs);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -327,7 +327,7 @@ public class InstanceUtil {
    * @param liveInstanceNames names of the currently live instances.
    * @return a fresh modifiable set of instance names.
    */
-  public static Set<String> getEnabledLiveInstances(
+  private static Set<String> getEnabledLiveInstances(
       Map<String, InstanceConfig> instanceConfigMap, Collection<String> liveInstanceNames) {
     if (instanceConfigMap == null || liveInstanceNames == null) {
       return new HashSet<>();
@@ -389,27 +389,6 @@ public class InstanceUtil {
       return config != null && config.isUnderInstanceOperationMaintenance(nowMs);
     });
     return result;
-  }
-
-  /**
-   * Returns the instances carrying a valid (unexpired) instance-operation maintenance marker,
-   * i.e. the instances that are exempted from the offline budget by
-   * {@link #getInstancesUnableToAcceptOnlineReplicas(Map, Collection, long)}.
-   *
-   * @param instanceConfigMap all instance configs in the cluster, keyed by instance name.
-   * @param nowMs current wall-clock millis used for marker-expiry comparison.
-   * @return a fresh modifiable set of instance names.
-   */
-  public static Set<String> getInstancesUnderInstanceOperationMaintenance(
-      Map<String, InstanceConfig> instanceConfigMap, long nowMs) {
-    if (instanceConfigMap == null || instanceConfigMap.isEmpty()) {
-      return new HashSet<>();
-    }
-    return instanceConfigMap.entrySet().stream()
-        .filter(e -> e.getValue() != null && e.getValue()
-            .isUnderInstanceOperationMaintenance(nowMs))
-        .map(Map.Entry::getKey)
-        .collect(Collectors.toCollection(HashSet::new));
   }
 
   private static String formatMatchingInstances(List<InstanceConfig> matchingInstances) {

--- a/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
+++ b/helix-core/src/main/java/org/apache/helix/util/InstanceUtil.java
@@ -19,8 +19,12 @@ package org.apache.helix.util;
  * under the License.
  */
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -312,6 +316,100 @@ public class InstanceUtil {
               + (instanceOperation != null ? instanceOperation.getOperation() : "ENABLE")
               + "). The ZooKeeper update did not succeed.");
     }
+  }
+
+  /**
+   * Returns the live instances that are also marked with
+   * {@link InstanceConstants.InstanceOperation#ENABLE}. These are the instances that can
+   * currently accept ONLINE replicas.
+   *
+   * @param instanceConfigMap all instance configs in the cluster, keyed by instance name.
+   * @param liveInstanceNames names of the currently live instances.
+   * @return a fresh modifiable set of instance names.
+   */
+  public static Set<String> getEnabledLiveInstances(
+      Map<String, InstanceConfig> instanceConfigMap, Collection<String> liveInstanceNames) {
+    if (instanceConfigMap == null || liveInstanceNames == null) {
+      return new HashSet<>();
+    }
+    Set<String> enabledLiveInstances = new HashSet<>();
+    for (String instanceName : liveInstanceNames) {
+      InstanceConfig config = instanceConfigMap.get(instanceName);
+      if (config != null && config.getInstanceOperation().getOperation()
+          == InstanceConstants.InstanceOperation.ENABLE) {
+        enabledLiveInstances.add(instanceName);
+      }
+    }
+    return enabledLiveInstances;
+  }
+
+  /**
+   * Returns the set of instances that count toward the cluster-wide offline budget driving
+   * auto Maintenance Mode ({@code MAX_OFFLINE_INSTANCES_ALLOWED} at entry,
+   * {@code NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT} at exit).
+   *
+   * <p>An instance counts when all three conditions hold:
+   * <ul>
+   *   <li>Its InstanceOperation is routable, i.e. not in
+   *       {@link InstanceConstants#UNROUTABLE_INSTANCE_OPERATIONS}.</li>
+   *   <li>It is not currently enabled-and-live.</li>
+   *   <li>It does not carry a valid (unexpired) instance-operation maintenance marker.</li>
+   * </ul>
+   * EVACUATE and DISABLE instances are included because they cannot accept new ONLINE
+   * replicas; ENABLE+offline instances are included for the same reason. SWAP_IN and
+   * UNKNOWN are excluded because they do not represent assignable cluster capacity.
+   *
+   * <p>This is the single definition of the offline-budget population. The controller
+   * (MM entry in {@code BestPossibleStateCalcStage}, MM exit in
+   * {@code MaintenanceRecoveryStage}) reaches it through
+   * {@code BaseControllerDataProvider#getInstancesUnableToAcceptOnlineReplicas}, and
+   * helix-rest exposes the same computation read-only so clients never have to reimplement
+   * (and drift from) these rules.
+   *
+   * @param instanceConfigMap all instance configs in the cluster, keyed by instance name.
+   * @param liveInstanceNames names of the currently live instances.
+   * @param nowMs current wall-clock millis used for marker-expiry comparison.
+   * @return a fresh modifiable set of instance names.
+   */
+  public static Set<String> getInstancesUnableToAcceptOnlineReplicas(
+      Map<String, InstanceConfig> instanceConfigMap, Collection<String> liveInstanceNames,
+      long nowMs) {
+    if (instanceConfigMap == null || instanceConfigMap.isEmpty()) {
+      return new HashSet<>();
+    }
+    Set<String> result = instanceConfigMap.entrySet().stream()
+        .filter(e -> e.getValue() != null)
+        .filter(e -> !InstanceConstants.UNROUTABLE_INSTANCE_OPERATIONS.contains(
+            e.getValue().getInstanceOperation().getOperation()))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toCollection(HashSet::new));
+    result.removeAll(getEnabledLiveInstances(instanceConfigMap, liveInstanceNames));
+    result.removeIf(name -> {
+      InstanceConfig config = instanceConfigMap.get(name);
+      return config != null && config.isUnderInstanceOperationMaintenance(nowMs);
+    });
+    return result;
+  }
+
+  /**
+   * Returns the instances carrying a valid (unexpired) instance-operation maintenance marker,
+   * i.e. the instances that are exempted from the offline budget by
+   * {@link #getInstancesUnableToAcceptOnlineReplicas(Map, Collection, long)}.
+   *
+   * @param instanceConfigMap all instance configs in the cluster, keyed by instance name.
+   * @param nowMs current wall-clock millis used for marker-expiry comparison.
+   * @return a fresh modifiable set of instance names.
+   */
+  public static Set<String> getInstancesUnderInstanceOperationMaintenance(
+      Map<String, InstanceConfig> instanceConfigMap, long nowMs) {
+    if (instanceConfigMap == null || instanceConfigMap.isEmpty()) {
+      return new HashSet<>();
+    }
+    return instanceConfigMap.entrySet().stream()
+        .filter(e -> e.getValue() != null && e.getValue()
+            .isUnderInstanceOperationMaintenance(nowMs))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toCollection(HashSet::new));
   }
 
   private static String formatMatchingInstances(List<InstanceConfig> matchingInstances) {

--- a/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestInstancesUnableToAcceptOnlineReplicas.java
+++ b/helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestInstancesUnableToAcceptOnlineReplicas.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -52,7 +53,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testEnableLiveExcluded() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.ENABLE)),
-        enabledLive("h1"));
+        liveInstances("h1"));
     Assert.assertTrue(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS).isEmpty(),
         "Healthy ENABLE+live instance must not count toward the offline budget");
   }
@@ -61,7 +62,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testEnableOfflineIncluded() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.ENABLE)),
-        enabledLive());
+        liveInstances());
     Assert.assertEquals(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS),
         setOf("h1"), "ENABLE+offline is the canonical 'real outage' case and must count");
   }
@@ -70,7 +71,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testDisableLiveIncluded() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.DISABLE)),
-        enabledLive());
+        liveInstances("h1"));
     Assert.assertEquals(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS),
         setOf("h1"),
         "DISABLE instances cannot accept ONLINE replicas and must count regardless of liveness");
@@ -80,7 +81,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testDisableOfflineIncluded() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.DISABLE)),
-        enabledLive());
+        liveInstances());
     Assert.assertEquals(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS),
         setOf("h1"));
   }
@@ -89,7 +90,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testEvacuateLiveIncluded() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.EVACUATE)),
-        enabledLive());
+        liveInstances("h1"));
     Assert.assertEquals(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS),
         setOf("h1"),
         "EVACUATE is the asymmetric op pre-fix; both entry and exit must now count it");
@@ -99,7 +100,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testEvacuateOfflineIncluded() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.EVACUATE)),
-        enabledLive());
+        liveInstances());
     Assert.assertEquals(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS),
         setOf("h1"));
   }
@@ -108,7 +109,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testSwapInExcluded() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.SWAP_IN)),
-        enabledLive());
+        liveInstances());
     Assert.assertTrue(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS).isEmpty(),
         "SWAP_IN is in UNROUTABLE_INSTANCE_OPERATIONS and must never count");
   }
@@ -117,7 +118,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testUnknownExcluded() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.UNKNOWN)),
-        enabledLive());
+        liveInstances());
     Assert.assertTrue(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS).isEmpty(),
         "UNKNOWN is in UNROUTABLE_INSTANCE_OPERATIONS and must never count");
   }
@@ -128,7 +129,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testValidMarkerExemptsEnableOffline() {
     BaseControllerDataProvider provider = providerWith(
         configs(configWithMarker("h1", InstanceConstants.InstanceOperation.ENABLE, FUTURE_MS)),
-        enabledLive());
+        liveInstances());
     Assert.assertTrue(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS).isEmpty(),
         "Valid marker on ENABLE+offline must exempt the instance from the budget");
   }
@@ -137,7 +138,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testValidMarkerExemptsEvacuate() {
     BaseControllerDataProvider provider = providerWith(
         configs(configWithMarker("h1", InstanceConstants.InstanceOperation.EVACUATE, FUTURE_MS)),
-        enabledLive());
+        liveInstances());
     Assert.assertTrue(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS).isEmpty(),
         "Valid marker on EVACUATE must exempt — this is the orchestrator-driven decom case");
   }
@@ -146,7 +147,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testValidMarkerExemptsDisable() {
     BaseControllerDataProvider provider = providerWith(
         configs(configWithMarker("h1", InstanceConstants.InstanceOperation.DISABLE, FUTURE_MS)),
-        enabledLive());
+        liveInstances());
     Assert.assertTrue(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS).isEmpty());
   }
 
@@ -154,7 +155,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testExpiredMarkerDoesNotExempt() {
     BaseControllerDataProvider provider = providerWith(
         configs(configWithMarker("h1", InstanceConstants.InstanceOperation.ENABLE, PAST_MS)),
-        enabledLive());
+        liveInstances());
     Assert.assertEquals(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS),
         setOf("h1"), "Expired marker must behave as if the marker were absent");
   }
@@ -165,7 +166,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
     // already past the window.
     BaseControllerDataProvider provider = providerWith(
         configs(configWithMarker("h1", InstanceConstants.InstanceOperation.ENABLE, NOW_MS)),
-        enabledLive());
+        liveInstances());
     Assert.assertEquals(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS),
         setOf("h1"), "nowMs == untilMs is no longer under maintenance; instance must count");
   }
@@ -175,7 +176,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
     // SWAP_IN is filtered out before the marker check; a marker on it must not change that.
     BaseControllerDataProvider provider = providerWith(
         configs(configWithMarker("h1", InstanceConstants.InstanceOperation.SWAP_IN, FUTURE_MS)),
-        enabledLive());
+        liveInstances());
     Assert.assertTrue(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS).isEmpty(),
         "Marker on a SWAP_IN instance must not change the (already excluded) outcome");
   }
@@ -184,7 +185,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
 
   @Test
   public void testEmptyCluster() {
-    BaseControllerDataProvider provider = providerWith(configs(), enabledLive());
+    BaseControllerDataProvider provider = providerWith(configs(), liveInstances());
     Assert.assertTrue(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS).isEmpty());
   }
 
@@ -194,11 +195,11 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
     // 1 DISABLE (counts), 1 EVACUATE (counts), 1 EVACUATE w/marker (exempt),
     // 1 SWAP_IN (excluded), 1 UNKNOWN (excluded).
     Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
-    Set<String> enabledLive = new HashSet<>();
+    Set<String> liveInstanceNames = new HashSet<>();
     for (int i = 0; i < 8; i++) {
       String name = "enable-live-" + i;
       instanceConfigMap.put(name, config(name, InstanceConstants.InstanceOperation.ENABLE));
-      enabledLive.add(name);
+      liveInstanceNames.add(name);
     }
     instanceConfigMap.put("enable-offline",
         config("enable-offline", InstanceConstants.InstanceOperation.ENABLE));
@@ -217,7 +218,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
     instanceConfigMap.put("unknown",
         config("unknown", InstanceConstants.InstanceOperation.UNKNOWN));
 
-    BaseControllerDataProvider provider = providerWith(instanceConfigMap, enabledLive);
+    BaseControllerDataProvider provider = providerWith(instanceConfigMap, liveInstanceNames);
 
     Assert.assertEquals(provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS),
         setOf("enable-offline", "disable", "evacuate"),
@@ -232,7 +233,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
     // particular) rely on this for downstream filtering. Verify both properties hold.
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.ENABLE)),
-        enabledLive());
+        liveInstances());
     Set<String> result = provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS);
     result.add("h99");
     Assert.assertTrue(result.contains("h99"), "Returned set must be modifiable");
@@ -242,7 +243,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   public void testReturnedSetIsIndependentOfFutureCalls() {
     BaseControllerDataProvider provider = providerWith(
         configs(config("h1", InstanceConstants.InstanceOperation.ENABLE)),
-        enabledLive());
+        liveInstances());
     Set<String> first = provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS);
     first.clear();
     Set<String> second = provider.getInstancesUnableToAcceptOnlineReplicas(NOW_MS);
@@ -254,13 +255,18 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
 
   /**
    * Builds a {@link BaseControllerDataProvider} whose only contract is to return the
-   * supplied instance-config map and enabled-live set. The accessor under test depends on
+   * supplied instance-config map and live-instance set. The accessor under test depends on
    * exactly those two hooks plus {@link InstanceConfig#isUnderInstanceOperationMaintenance},
    * so overriding the two getters is sufficient and avoids initializing the full cluster
-   * cache machinery.
+   * cache machinery. The enabled-live subset is derived from the configs the same way the
+   * controller derives it, so the ENABLE filter is exercised here rather than stubbed.
    */
   private static BaseControllerDataProvider providerWith(
-      Map<String, InstanceConfig> instanceConfigMap, Set<String> enabledLive) {
+      Map<String, InstanceConfig> instanceConfigMap, Set<String> liveInstanceNames) {
+    Map<String, LiveInstance> liveInstanceMap = new HashMap<>();
+    for (String name : liveInstanceNames) {
+      liveInstanceMap.put(name, new LiveInstance(name));
+    }
     return new BaseControllerDataProvider() {
       @Override
       public Map<String, InstanceConfig> getInstanceConfigMap() {
@@ -268,8 +274,8 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
       }
 
       @Override
-      public Set<String> getEnabledLiveInstances() {
-        return Collections.unmodifiableSet(enabledLive);
+      public Map<String, LiveInstance> getLiveInstances() {
+        return Collections.unmodifiableMap(liveInstanceMap);
       }
     };
   }
@@ -297,7 +303,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
   }
 
   /**
-   * Test-side set builder. Used for both the enabled-live input set and the expected-result
+   * Test-side set builder. Used for both the live-instance input set and the expected-result
    * set so that assertions and setup share the same shape; the two readings sit at the call
    * site through the method name on the input side and explicit assertEquals on the result.
    */
@@ -307,7 +313,7 @@ public class TestInstancesUnableToAcceptOnlineReplicas {
     return set;
   }
 
-  private static Set<String> enabledLive(String... names) {
+  private static Set<String> liveInstances(String... names) {
     return setOf(names);
   }
 }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/AbstractResource.java
@@ -73,6 +73,7 @@ public class AbstractResource {
     delete,
     stoppable,
     instanceOperationMaintenance,
+    getInstancesUnableToAcceptOnlineReplicas,
     rebalance,
     reset,
     resetPartitions,

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -22,10 +22,12 @@ package org.apache.helix.rest.server.resources.helix;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -44,6 +46,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixException;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
 import org.apache.helix.model.ClusterConfig;
@@ -61,6 +64,7 @@ import org.apache.helix.rest.server.json.instance.StoppableCheck;
 import org.apache.helix.rest.server.resources.exceptions.HelixHealthException;
 import org.apache.helix.rest.server.service.ClusterService;
 import org.apache.helix.rest.server.service.ClusterServiceImpl;
+import org.apache.helix.util.InstanceUtil;
 import org.apache.helix.util.InstanceValidationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +91,13 @@ public class InstancesAccessor extends AbstractHelixResource {
     skip_stoppable_check_list,
     customized_values,
     instance_stoppable_parallel,
-    instance_not_stoppable_with_reasons
+    instance_not_stoppable_with_reasons,
+    instances_unable_to_accept_online_replicas,
+    instances_unable_to_accept_online_replicas_count,
+    instances_under_instance_operation_maintenance,
+    max_offline_instances_allowed,
+    num_offline_instances_for_auto_exit,
+    exceeds_max_offline_instances_allowed
   }
 
   public enum InstanceHealthSelectionBase {
@@ -184,10 +194,103 @@ public class InstancesAccessor extends AbstractHelixResource {
         return badRequest(e.getMessage());
       }
       return JSONRepresentation(validationResultMap);
+    case getInstancesUnableToAcceptOnlineReplicas:
+      return getInstancesUnableToAcceptOnlineReplicas(clusterId, accessor);
     default:
       _logger.error("Unsupported command :" + command);
       return badRequest("Unsupported command :" + command);
     }
+  }
+
+  /**
+   * Reports the number of instances Helix itself counts against the cluster-wide offline
+   * budget that drives auto Maintenance Mode, so clients do not have to reimplement (and
+   * drift from) the controller's membership rules.
+   *
+   * <p>The population is computed by
+   * {@link InstanceUtil#getInstancesUnableToAcceptOnlineReplicas(Map, java.util.Collection, long)},
+   * the same method the controller uses on MM entry ({@code BestPossibleStateCalcStage})
+   * and MM exit ({@code MaintenanceRecoveryStage}). An instance counts when it is routable,
+   * not enabled-and-live, and not covered by a valid instance-operation maintenance marker.
+   *
+   * <p>Response (HTTP 200):
+   * <pre>{@code
+   * { "id": "cluster0",
+   *   "instances_unable_to_accept_online_replicas": ["h3", "h4"],
+   *   "instances_unable_to_accept_online_replicas_count": 2,
+   *   "instances_under_instance_operation_maintenance": ["h1"],
+   *   "max_offline_instances_allowed": 4,
+   *   "num_offline_instances_for_auto_exit": 2,
+   *   "exceeds_max_offline_instances_allowed": false }
+   * }</pre>
+   *
+   * <p>{@code max_offline_instances_allowed} and {@code num_offline_instances_for_auto_exit}
+   * are echoed as configured; a negative value means the threshold is not set, in which case
+   * {@code exceeds_max_offline_instances_allowed} is always false because the controller
+   * never auto-enters MM for this reason.
+   */
+  private Response getInstancesUnableToAcceptOnlineReplicas(String clusterId,
+      HelixDataAccessor accessor) {
+    try {
+      return computeInstancesUnableToAcceptOnlineReplicas(clusterId, accessor);
+    } catch (Exception e) {
+      _logger.error("Failed to compute instances unable to accept online replicas for cluster {}",
+          clusterId, e);
+      return serverError(e);
+    }
+  }
+
+  private Response computeInstancesUnableToAcceptOnlineReplicas(String clusterId,
+      HelixDataAccessor accessor) {
+    ClusterConfig clusterConfig = getConfigAccessor().getClusterConfig(clusterId);
+    if (clusterConfig == null) {
+      return notFound();
+    }
+
+    PropertyKey.Builder keyBuilder = accessor.keyBuilder();
+    List<InstanceConfig> instanceConfigs =
+        accessor.getChildValues(keyBuilder.instanceConfigs(), true);
+    Map<String, InstanceConfig> instanceConfigMap = new HashMap<>();
+    if (instanceConfigs != null) {
+      for (InstanceConfig instanceConfig : instanceConfigs) {
+        if (instanceConfig != null) {
+          instanceConfigMap.put(instanceConfig.getInstanceName(), instanceConfig);
+        }
+      }
+    }
+    List<String> liveInstances = accessor.getChildNames(keyBuilder.liveInstances());
+
+    long nowMs = System.currentTimeMillis();
+    Set<String> unableToAcceptOnlineReplicas =
+        InstanceUtil.getInstancesUnableToAcceptOnlineReplicas(instanceConfigMap,
+            liveInstances == null ? Collections.emptyList() : liveInstances, nowMs);
+    Set<String> underMaintenance =
+        InstanceUtil.getInstancesUnderInstanceOperationMaintenance(instanceConfigMap, nowMs);
+
+    int maxOfflineInstancesAllowed = clusterConfig.getMaxOfflineInstancesAllowed();
+
+    ObjectNode root = JsonNodeFactory.instance.objectNode();
+    root.put(Properties.id.name(), clusterId);
+    ArrayNode countedNode =
+        root.putArray(InstancesProperties.instances_unable_to_accept_online_replicas.name());
+    // Sorted so the payload is stable across calls for the same cluster state.
+    for (String instanceName : new TreeSet<>(unableToAcceptOnlineReplicas)) {
+      countedNode.add(instanceName);
+    }
+    root.put(InstancesProperties.instances_unable_to_accept_online_replicas_count.name(),
+        unableToAcceptOnlineReplicas.size());
+    ArrayNode maintenanceNode =
+        root.putArray(InstancesProperties.instances_under_instance_operation_maintenance.name());
+    for (String instanceName : new TreeSet<>(underMaintenance)) {
+      maintenanceNode.add(instanceName);
+    }
+    root.put(InstancesProperties.max_offline_instances_allowed.name(), maxOfflineInstancesAllowed);
+    root.put(InstancesProperties.num_offline_instances_for_auto_exit.name(),
+        clusterConfig.getNumOfflineInstancesForAutoExit());
+    root.put(InstancesProperties.exceeds_max_offline_instances_allowed.name(),
+        maxOfflineInstancesAllowed >= 0
+            && unableToAcceptOnlineReplicas.size() > maxOfflineInstancesAllowed);
+    return JSONRepresentation(root);
   }
 
   @ResponseMetered(name = HttpConstants.WRITE_REQUEST)

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -49,6 +49,7 @@ import org.apache.helix.HelixException;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.constants.InstanceConstants;
 import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZKUtil;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.rest.client.CustomRestClientFactory;
@@ -129,7 +130,7 @@ public class InstancesAccessor extends AbstractHelixResource {
       ArrayNode instancesNode =
           root.putArray(InstancesAccessor.InstancesProperties.instances.name());
       instancesNode.addAll((ArrayNode) OBJECT_MAPPER.valueToTree(instances));
-      
+
       ArrayNode onlineNode = root.putArray(InstancesAccessor.InstancesProperties.online.name());
       ArrayNode enabledNode = root.putArray(InstancesAccessor.InstancesProperties.enabled.name());
       ArrayNode disabledNode = root.putArray(InstancesAccessor.InstancesProperties.disabled.name());
@@ -220,7 +221,8 @@ public class InstancesAccessor extends AbstractHelixResource {
    * available from the maintenance-signal endpoint; deriving either here would hand clients a
    * prediction where an authoritative answer already exists.
    */
-  private Response getInstancesUnableToAcceptOnlineReplicas(String clusterId,
+  private Response
+  getInstancesUnableToAcceptOnlineReplicas(String clusterId,
       HelixDataAccessor accessor) {
     try {
       return computeInstancesUnableToAcceptOnlineReplicas(clusterId, accessor);
@@ -233,7 +235,12 @@ public class InstancesAccessor extends AbstractHelixResource {
 
   private Response computeInstancesUnableToAcceptOnlineReplicas(String clusterId,
       HelixDataAccessor accessor) {
-    if (getConfigAccessor().getClusterConfig(clusterId) == null) {
+    // An unknown cluster must not fall through to an empty population: to a client, "no instances
+    // counted" reads as "the whole offline budget is free". The caller's null check cannot catch
+    // it because HelixDataAccessor#getChildNames normalizes a missing path to an empty list, so
+    // resolve the cluster explicitly, the same way ClusterAccessor does. ConfigAccessor is not
+    // used here because it throws on an unknown cluster, which would surface as a 500.
+    if (!ZKUtil.isClusterSetup(clusterId, getRealmAwareZkClient())) {
       return notFound();
     }
 

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/InstancesAccessor.java
@@ -92,12 +92,7 @@ public class InstancesAccessor extends AbstractHelixResource {
     customized_values,
     instance_stoppable_parallel,
     instance_not_stoppable_with_reasons,
-    instances_unable_to_accept_online_replicas,
-    instances_unable_to_accept_online_replicas_count,
-    instances_under_instance_operation_maintenance,
-    max_offline_instances_allowed,
-    num_offline_instances_for_auto_exit,
-    exceeds_max_offline_instances_allowed
+    instances_unable_to_accept_online_replicas
   }
 
   public enum InstanceHealthSelectionBase {
@@ -203,9 +198,9 @@ public class InstancesAccessor extends AbstractHelixResource {
   }
 
   /**
-   * Reports the number of instances Helix itself counts against the cluster-wide offline
-   * budget that drives auto Maintenance Mode, so clients do not have to reimplement (and
-   * drift from) the controller's membership rules.
+   * Reports the instances Helix itself counts against the cluster-wide offline budget that
+   * drives auto Maintenance Mode, so clients do not have to reimplement (and drift from) the
+   * controller's membership rules.
    *
    * <p>The population is computed by
    * {@link InstanceUtil#getInstancesUnableToAcceptOnlineReplicas(Map, java.util.Collection, long)},
@@ -213,21 +208,17 @@ public class InstancesAccessor extends AbstractHelixResource {
    * and MM exit ({@code MaintenanceRecoveryStage}). An instance counts when it is routable,
    * not enabled-and-live, and not covered by a valid instance-operation maintenance marker.
    *
-   * <p>Response (HTTP 200):
+   * <p>Response (HTTP 200), shaped like the {@code getAllInstances} response on this route:
    * <pre>{@code
    * { "id": "cluster0",
-   *   "instances_unable_to_accept_online_replicas": ["h3", "h4"],
-   *   "instances_unable_to_accept_online_replicas_count": 2,
-   *   "instances_under_instance_operation_maintenance": ["h1"],
-   *   "max_offline_instances_allowed": 4,
-   *   "num_offline_instances_for_auto_exit": 2,
-   *   "exceeds_max_offline_instances_allowed": false }
+   *   "instances_unable_to_accept_online_replicas": ["h3", "h4"] }
    * }</pre>
    *
-   * <p>{@code max_offline_instances_allowed} and {@code num_offline_instances_for_auto_exit}
-   * are echoed as configured; a negative value means the threshold is not set, in which case
-   * {@code exceeds_max_offline_instances_allowed} is always false because the controller
-   * never auto-enters MM for this reason.
+   * <p>Only the population is returned. The thresholds it is compared against
+   * ({@code MAX_OFFLINE_INSTANCES_ALLOWED}, {@code NUM_OFFLINE_INSTANCES_FOR_AUTO_EXIT}) are
+   * already available from the cluster-config endpoint, and the resulting maintenance state is
+   * available from the maintenance-signal endpoint; deriving either here would hand clients a
+   * prediction where an authoritative answer already exists.
    */
   private Response getInstancesUnableToAcceptOnlineReplicas(String clusterId,
       HelixDataAccessor accessor) {
@@ -242,8 +233,7 @@ public class InstancesAccessor extends AbstractHelixResource {
 
   private Response computeInstancesUnableToAcceptOnlineReplicas(String clusterId,
       HelixDataAccessor accessor) {
-    ClusterConfig clusterConfig = getConfigAccessor().getClusterConfig(clusterId);
-    if (clusterConfig == null) {
+    if (getConfigAccessor().getClusterConfig(clusterId) == null) {
       return notFound();
     }
 
@@ -260,14 +250,10 @@ public class InstancesAccessor extends AbstractHelixResource {
     }
     List<String> liveInstances = accessor.getChildNames(keyBuilder.liveInstances());
 
-    long nowMs = System.currentTimeMillis();
     Set<String> unableToAcceptOnlineReplicas =
         InstanceUtil.getInstancesUnableToAcceptOnlineReplicas(instanceConfigMap,
-            liveInstances == null ? Collections.emptyList() : liveInstances, nowMs);
-    Set<String> underMaintenance =
-        InstanceUtil.getInstancesUnderInstanceOperationMaintenance(instanceConfigMap, nowMs);
-
-    int maxOfflineInstancesAllowed = clusterConfig.getMaxOfflineInstancesAllowed();
+            liveInstances == null ? Collections.emptyList() : liveInstances,
+            System.currentTimeMillis());
 
     ObjectNode root = JsonNodeFactory.instance.objectNode();
     root.put(Properties.id.name(), clusterId);
@@ -277,19 +263,6 @@ public class InstancesAccessor extends AbstractHelixResource {
     for (String instanceName : new TreeSet<>(unableToAcceptOnlineReplicas)) {
       countedNode.add(instanceName);
     }
-    root.put(InstancesProperties.instances_unable_to_accept_online_replicas_count.name(),
-        unableToAcceptOnlineReplicas.size());
-    ArrayNode maintenanceNode =
-        root.putArray(InstancesProperties.instances_under_instance_operation_maintenance.name());
-    for (String instanceName : new TreeSet<>(underMaintenance)) {
-      maintenanceNode.add(instanceName);
-    }
-    root.put(InstancesProperties.max_offline_instances_allowed.name(), maxOfflineInstancesAllowed);
-    root.put(InstancesProperties.num_offline_instances_for_auto_exit.name(),
-        clusterConfig.getNumOfflineInstancesForAutoExit());
-    root.put(InstancesProperties.exceeds_max_offline_instances_allowed.name(),
-        maxOfflineInstancesAllowed >= 0
-            && unableToAcceptOnlineReplicas.size() > maxOfflineInstancesAllowed);
     return JSONRepresentation(root);
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -976,7 +976,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
   public void testGetInstancesUnableToAcceptOnlineReplicas() throws IOException {
     System.out.println("Start test :" + TestHelper.getTestMethodName());
 
-    // Dedicated cluster so the counts asserted here are not perturbed by other tests. No
+    // Dedicated cluster so the population asserted here is not perturbed by other tests. No
     // participants are started, so every routable instance is offline and counts against the
     // budget unless it carries a valid instance-operation maintenance marker.
     String clusterName = "TestOfflineBudgetCluster";
@@ -988,13 +988,7 @@ public class TestInstancesAccessor extends AbstractTestClass {
       _gSetupTool.addInstanceToCluster(clusterName, instance);
     }
 
-    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(clusterName);
-    clusterConfig.setMaxOfflineInstancesAllowed(4);
-    clusterConfig.setNumOfflineInstancesForAutoExit(2);
-    _configAccessor.setClusterConfig(clusterName, clusterConfig);
-
-    // Baseline: all 5 instances are offline and unmarked, so all 5 count and the configured
-    // MAX_OFFLINE_INSTANCES_ALLOWED of 4 is exceeded.
+    // Baseline: all 5 instances are offline and unmarked, so all 5 count.
     JsonNode node = OBJECT_MAPPER.readTree(
         new JerseyUriRequestBuilder(
             "clusters/{}/instances?command=getInstancesUnableToAcceptOnlineReplicas")
@@ -1003,18 +997,6 @@ public class TestInstancesAccessor extends AbstractTestClass {
         getSortedStringList(node,
             InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas
                 .name()), sorted(instances));
-    Assert.assertEquals(node.get(
-        InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas_count
-            .name()).intValue(), 5);
-    Assert.assertEquals(node.get(
-            InstancesAccessor.InstancesProperties.max_offline_instances_allowed.name()).intValue(),
-        4);
-    Assert.assertEquals(node.get(
-        InstancesAccessor.InstancesProperties.num_offline_instances_for_auto_exit.name())
-        .intValue(), 2);
-    Assert.assertTrue(node.get(
-            InstancesAccessor.InstancesProperties.exceeds_max_offline_instances_allowed.name())
-        .booleanValue(), "5 counted instances must exceed the configured limit of 4");
 
     // A valid marker exempts an instance; an expired marker does not. A SWAP_IN instance is
     // never counted regardless of marker state.
@@ -1036,34 +1018,23 @@ public class TestInstancesAccessor extends AbstractTestClass {
                 .name()),
         sorted(Arrays.asList("obInstance1", "obInstance3", "obInstance4")),
         "Valid marker and SWAP_IN must be excluded; the expired marker must still count");
-    Assert.assertEquals(node.get(
-        InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas_count
-            .name()).intValue(), 3);
-    Assert.assertEquals(
-        getSortedStringList(node,
-            InstancesAccessor.InstancesProperties
-                .instances_under_instance_operation_maintenance.name()),
-        Collections.singletonList("obInstance0"),
-        "Only the unexpired marker should be reported as under maintenance");
-    Assert.assertFalse(node.get(
-            InstancesAccessor.InstancesProperties.exceeds_max_offline_instances_allowed.name())
-        .booleanValue(), "3 counted instances is within the configured limit of 4");
 
-    // When the threshold is unset, the controller never auto-enters MM for this reason, so the
-    // endpoint must never report a breach.
-    clusterConfig = _configAccessor.getClusterConfig(clusterName);
-    clusterConfig.setMaxOfflineInstancesAllowed(-1);
+    // The population is a property of the instances alone. Changing the budget thresholds the
+    // controller compares it against must not change who is in it.
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(clusterName);
+    clusterConfig.setMaxOfflineInstancesAllowed(1);
+    clusterConfig.setNumOfflineInstancesForAutoExit(0);
     _configAccessor.setClusterConfig(clusterName, clusterConfig);
     node = OBJECT_MAPPER.readTree(
         new JerseyUriRequestBuilder(
             "clusters/{}/instances?command=getInstancesUnableToAcceptOnlineReplicas")
             .isBodyReturnExpected(true).format(clusterName).get(this));
-    Assert.assertEquals(node.get(
-        InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas_count
-            .name()).intValue(), 3);
-    Assert.assertFalse(node.get(
-            InstancesAccessor.InstancesProperties.exceeds_max_offline_instances_allowed.name())
-        .booleanValue(), "An unset MAX_OFFLINE_INSTANCES_ALLOWED can never be exceeded");
+    Assert.assertEquals(
+        getSortedStringList(node,
+            InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas
+                .name()),
+        sorted(Arrays.asList("obInstance1", "obInstance3", "obInstance4")),
+        "Offline-budget thresholds must not affect which instances are counted");
 
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -1036,6 +1036,13 @@ public class TestInstancesAccessor extends AbstractTestClass {
         sorted(Arrays.asList("obInstance1", "obInstance3", "obInstance4")),
         "Offline-budget thresholds must not affect which instances are counted");
 
+    // An unknown cluster must 404 like every other command on this route, not 500. Resolving the
+    // cluster through ConfigAccessor instead of the request's HelixDataAccessor would throw here.
+    new JerseyUriRequestBuilder(
+        "clusters/{}/instances?command=getInstancesUnableToAcceptOnlineReplicas")
+        .expectedReturnStatusCode(Response.Status.NOT_FOUND.getStatusCode())
+        .format("TestOfflineBudgetClusterDoesNotExist").get(this);
+
     System.out.println("End test :" + TestHelper.getTestMethodName());
   }
 

--- a/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
+++ b/helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java
@@ -22,6 +22,7 @@ package org.apache.helix.rest.server;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -969,6 +970,124 @@ public class TestInstancesAccessor extends AbstractTestClass {
         "Expected detailed reason to contain 'active replicas' but got: " + reason);
 
     System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  @Test
+  public void testGetInstancesUnableToAcceptOnlineReplicas() throws IOException {
+    System.out.println("Start test :" + TestHelper.getTestMethodName());
+
+    // Dedicated cluster so the counts asserted here are not perturbed by other tests. No
+    // participants are started, so every routable instance is offline and counts against the
+    // budget unless it carries a valid instance-operation maintenance marker.
+    String clusterName = "TestOfflineBudgetCluster";
+    _gSetupTool.addCluster(clusterName, true);
+    _clusters.add(clusterName);
+    List<String> instances =
+        Arrays.asList("obInstance0", "obInstance1", "obInstance2", "obInstance3", "obInstance4");
+    for (String instance : instances) {
+      _gSetupTool.addInstanceToCluster(clusterName, instance);
+    }
+
+    ClusterConfig clusterConfig = _configAccessor.getClusterConfig(clusterName);
+    clusterConfig.setMaxOfflineInstancesAllowed(4);
+    clusterConfig.setNumOfflineInstancesForAutoExit(2);
+    _configAccessor.setClusterConfig(clusterName, clusterConfig);
+
+    // Baseline: all 5 instances are offline and unmarked, so all 5 count and the configured
+    // MAX_OFFLINE_INSTANCES_ALLOWED of 4 is exceeded.
+    JsonNode node = OBJECT_MAPPER.readTree(
+        new JerseyUriRequestBuilder(
+            "clusters/{}/instances?command=getInstancesUnableToAcceptOnlineReplicas")
+            .isBodyReturnExpected(true).format(clusterName).get(this));
+    Assert.assertEquals(
+        getSortedStringList(node,
+            InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas
+                .name()), sorted(instances));
+    Assert.assertEquals(node.get(
+        InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas_count
+            .name()).intValue(), 5);
+    Assert.assertEquals(node.get(
+            InstancesAccessor.InstancesProperties.max_offline_instances_allowed.name()).intValue(),
+        4);
+    Assert.assertEquals(node.get(
+        InstancesAccessor.InstancesProperties.num_offline_instances_for_auto_exit.name())
+        .intValue(), 2);
+    Assert.assertTrue(node.get(
+            InstancesAccessor.InstancesProperties.exceeds_max_offline_instances_allowed.name())
+        .booleanValue(), "5 counted instances must exceed the configured limit of 4");
+
+    // A valid marker exempts an instance; an expired marker does not. A SWAP_IN instance is
+    // never counted regardless of marker state.
+    long nowMs = System.currentTimeMillis();
+    setInstanceOperationMaintenanceUntilMs(clusterName, "obInstance0", nowMs + 600_000L);
+    setInstanceOperationMaintenanceUntilMs(clusterName, "obInstance1", nowMs - 1L);
+    InstanceConfig swapInConfig = _configAccessor.getInstanceConfig(clusterName, "obInstance2");
+    swapInConfig.setInstanceOperation(new InstanceConfig.InstanceOperation.Builder()
+        .setOperation(InstanceConstants.InstanceOperation.SWAP_IN).build());
+    _configAccessor.setInstanceConfig(clusterName, "obInstance2", swapInConfig);
+
+    node = OBJECT_MAPPER.readTree(
+        new JerseyUriRequestBuilder(
+            "clusters/{}/instances?command=getInstancesUnableToAcceptOnlineReplicas")
+            .isBodyReturnExpected(true).format(clusterName).get(this));
+    Assert.assertEquals(
+        getSortedStringList(node,
+            InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas
+                .name()),
+        sorted(Arrays.asList("obInstance1", "obInstance3", "obInstance4")),
+        "Valid marker and SWAP_IN must be excluded; the expired marker must still count");
+    Assert.assertEquals(node.get(
+        InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas_count
+            .name()).intValue(), 3);
+    Assert.assertEquals(
+        getSortedStringList(node,
+            InstancesAccessor.InstancesProperties
+                .instances_under_instance_operation_maintenance.name()),
+        Collections.singletonList("obInstance0"),
+        "Only the unexpired marker should be reported as under maintenance");
+    Assert.assertFalse(node.get(
+            InstancesAccessor.InstancesProperties.exceeds_max_offline_instances_allowed.name())
+        .booleanValue(), "3 counted instances is within the configured limit of 4");
+
+    // When the threshold is unset, the controller never auto-enters MM for this reason, so the
+    // endpoint must never report a breach.
+    clusterConfig = _configAccessor.getClusterConfig(clusterName);
+    clusterConfig.setMaxOfflineInstancesAllowed(-1);
+    _configAccessor.setClusterConfig(clusterName, clusterConfig);
+    node = OBJECT_MAPPER.readTree(
+        new JerseyUriRequestBuilder(
+            "clusters/{}/instances?command=getInstancesUnableToAcceptOnlineReplicas")
+            .isBodyReturnExpected(true).format(clusterName).get(this));
+    Assert.assertEquals(node.get(
+        InstancesAccessor.InstancesProperties.instances_unable_to_accept_online_replicas_count
+            .name()).intValue(), 3);
+    Assert.assertFalse(node.get(
+            InstancesAccessor.InstancesProperties.exceeds_max_offline_instances_allowed.name())
+        .booleanValue(), "An unset MAX_OFFLINE_INSTANCES_ALLOWED can never be exceeded");
+
+    System.out.println("End test :" + TestHelper.getTestMethodName());
+  }
+
+  private void setInstanceOperationMaintenanceUntilMs(String clusterName, String instanceName,
+      long untilMs) {
+    InstanceConfig instanceConfig = _configAccessor.getInstanceConfig(clusterName, instanceName);
+    instanceConfig.setInstanceOperationMaintenanceUntilMs(untilMs);
+    _configAccessor.setInstanceConfig(clusterName, instanceName, instanceConfig);
+  }
+
+  private static List<String> sorted(Collection<String> names) {
+    List<String> result = new ArrayList<>(names);
+    Collections.sort(result);
+    return result;
+  }
+
+  /**
+   * Reads a JSON array field as a sorted list. Sorting both sides keeps the comparison
+   * order-insensitive while still producing a readable diff on failure (TestNG compares
+   * collections element-by-element in iteration order).
+   */
+  private List<String> getSortedStringList(JsonNode jsonNode, String key) {
+    return sorted(getStringSet(jsonNode, key));
   }
 
   private Set<String> getStringSet(JsonNode jsonNode, String key) {


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

Follow-up to review feedback on #175: https://github.com/linkedin/helix/pull/175/changes#r3235901682

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**What.** Adds a read-only endpoint that reports the number of instances Helix itself counts against the cluster-wide offline budget driving auto Maintenance Mode:

```
GET /clusters/{clusterId}/instances?command=getInstancesUnableToAcceptOnlineReplicas
```

**Why.** Requested in review on #175:

> Can we have an endpoint which essentially gives me a number of actual offline instances which are counted by Helix? At present, I don't think there is any such thing present. Clients have to do this calculation on their own, which can change based on internal logic but client won't know.

This is not just a convenience. Clients that respect `MAX_OFFLINE_INSTANCES_ALLOWED` currently reimplement the controller's membership rules against a pinned copy of Helix source. A concrete example is helixacm-service, whose `HelixRestClient.getAllInstancesUnableToTakeOnlineReplicasOrThrow` carries a comment pinning a Helix commit SHA and a line number in `BestPossibleStateCalcStage`. That copy applies the pre-#175 rules and has no notion of the instance-operation maintenance marker, so instances that Helix exempts are still counted by the client. The client's remaining quota comes out smaller than Helix's, and it throttles exactly the planned operations #175 was written to unblock. The client cannot detect this drift; nothing fails loudly.

Cost also matters: that client makes `getLiveInstances` + `getAllInstances` + N per-instance config reads on every pipeline iteration (it carries its own `TODO: change this to batch get from ZK`). This endpoint replaces all of it with one call.

**How.**

1. `InstanceUtil` gains the offline-budget computation as the single definition of the rule:
   * `getInstancesUnableToAcceptOnlineReplicas(instanceConfigMap, liveInstanceNames, nowMs)` — routable, not enabled-and-live, no valid instance-operation maintenance marker.
   * `getInstancesUnderInstanceOperationMaintenance(instanceConfigMap, nowMs)` — the exempted set.
   * `getEnabledLiveInstances(instanceConfigMap, liveInstanceNames)` — extracted so the ENABLE+live rule is stated once.

2. `BaseControllerDataProvider#getInstancesUnableToAcceptOnlineReplicas(long)` now delegates to `InstanceUtil`. Behavior is unchanged; the point is that MM entry (`BestPossibleStateCalcStage`), MM exit (`MaintenanceRecoveryStage`), and the new endpoint can no longer drift from one another, which is the failure mode the review comment describes.

3. helix-rest exposes it as a new `Command` on the existing `GET /clusters/{c}/instances` router, alongside `getAllInstances` and `validateWeight`.

**Response** (HTTP 200):

```json
{
  "id": "cluster0",
  "instances_unable_to_accept_online_replicas": ["h3", "h4"],
  "instances_unable_to_accept_online_replicas_count": 2,
  "instances_under_instance_operation_maintenance": ["h1"],
  "max_offline_instances_allowed": 4,
  "num_offline_instances_for_auto_exit": 2,
  "exceeds_max_offline_instances_allowed": false
}
```

The instance lists are returned sorted so the payload is stable across calls for the same cluster state. The exempted set and both thresholds are included so a caller can explain a throttling decision without a second round of requests. `exceeds_max_offline_instances_allowed` is always false when `max_offline_instances_allowed` is negative, matching the controller, which never auto-enters MM for this reason when the threshold is unset.

### Tests

- [x] The following tests are written for this issue:

* `helix-rest/src/test/java/org/apache/helix/rest/server/TestInstancesAccessor.java` — `testGetInstancesUnableToAcceptOnlineReplicas`, on a dedicated cluster so the counts are not perturbed by other tests. Covers the unmarked baseline (all instances counted, limit exceeded), a valid marker exempting an instance, an expired marker still counting, `SWAP_IN` excluded, the reported under-maintenance set, and an unset `MAX_OFFLINE_INSTANCES_ALLOWED` never reporting a breach.

* `helix-core/src/test/java/org/apache/helix/controller/dataproviders/TestInstancesUnableToAcceptOnlineReplicas.java` — updated to stub live instances rather than the derived enabled-live set, so the ENABLE filter is now exercised by these tests instead of being mocked out. All existing cases retained.

- The following is the result of the "mvn test" command on the appropriate module:

```
mvn -pl helix-rest -am test -Dtest=TestInstancesAccessor#testGetInstancesUnableToAcceptOnlineReplicas
  helix-rest: Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

mvn -pl helix-core test -Dtest='TestInstancesUnableToAcceptOnlineReplicas,TestInstanceConfig,
  TestClusterConfig,TestInstanceUtilValidation'
  helix-core: Tests run: 104, Failures: 0, Errors: 0, Skipped: 0

mvn -pl helix-core test -Dtest='TestInstanceOperationMaintenanceBudget,
  TestClusterInMaintenanceModeWhenReachingOfflineInstancesLimit'
  helix-core: Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

### Changes that Break Backward Compatibility (Optional)

None. The endpoint is additive (a new `Command` enum value on an existing route) and read-only. The `BaseControllerDataProvider` change is a pure extraction: the method keeps its signature and returns the same fresh modifiable set, and the maintenance-mode integration tests confirm entry and exit behavior is unchanged.

### Documentation (Optional)

Endpoint contract and the rationale for reporting the thresholds alongside the count are documented in the javadoc on `InstancesAccessor#getInstancesUnableToAcceptOnlineReplicas`. The membership rules are documented once, on `InstanceUtil#getInstancesUnableToAcceptOnlineReplicas`.

### Commits

- [x] My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] My diff has been formatted using helix-style.xml
(helix-style-intellij.xml if IntelliJ IDE is used)
